### PR TITLE
Fix entity search, flow-intelligence pagination, and schema gaps

### DIFF
--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -572,12 +572,12 @@ describe('NansenAPI', () => {
     describe('entitySearch', () => {
       it('should search for entities with correct endpoint', async () => {
         setupMock(MOCK_RESPONSES.entitySearch);
-        
+
         const result = await api.entitySearch({ query: 'Vitalik' });
-        
-        const body = expectFetchCalledWith('/api/beta/profiler/entity-name-search');
-        expect(body.parameters.query).toBe('Vitalik');
-        
+
+        const body = expectFetchCalledWith('/api/v1/search/entity-name');
+        expect(body.search_query).toBe('Vitalik');
+
         expect(result.results).toBeInstanceOf(Array);
         expect(result.results[0]).toHaveProperty('name', 'Vitalik Buterin');
         expect(result.results[0].addresses).toContain('0xd8da6bf26964af9d7eed9e03e53415d37aa96045');
@@ -1411,13 +1411,13 @@ describe('NansenAPI', () => {
 
     it('should handle special characters in entity search query', async () => {
       if (LIVE_TEST) return;
-      
+
       setupMock(MOCK_RESPONSES.entitySearch);
-      
+
       await api.entitySearch({ query: 'Test & Co. <script>' });
-      
-      const body = expectFetchCalledWith('/api/beta/profiler/entity-name-search');
-      expect(body.parameters.query).toBe('Test & Co. <script>');
+
+      const body = expectFetchCalledWith('/api/v1/search/entity-name');
+      expect(body.search_query).toBe('Test & Co. <script>');
     });
 
     it('should handle days=0', async () => {

--- a/src/api.js
+++ b/src/api.js
@@ -631,10 +631,9 @@ export class NansenAPI {
   }
 
   async entitySearch(params = {}) {
-    const { query, pagination } = params;
-    return this.request('/api/beta/profiler/entity-name-search', {
-      parameters: { query },
-      pagination
+    const { query } = params;
+    return this.request('/api/v1/search/entity-name', {
+      search_query: query
     });
   }
 
@@ -840,7 +839,7 @@ export class NansenAPI {
   }
 
   async tokenFlowIntelligence(params = {}) {
-    const { tokenAddress, chain = 'solana', filters = {}, orderBy, pagination, days = 30 } = params;
+    const { tokenAddress, chain = 'solana', filters = {}, orderBy, days = 30 } = params;
     if (tokenAddress) {
       const validation = validateTokenAddress(tokenAddress, chain);
       if (!validation.valid) throw new NansenError(validation.error, validation.code);
@@ -852,8 +851,7 @@ export class NansenAPI {
       chain,
       date: { from, to },
       filters,
-      order_by: orderBy,
-      pagination
+      order_by: orderBy
     });
   }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -151,7 +151,7 @@ export const SCHEMA = {
         },
         'flows': {
           description: 'Token flow metrics',
-          options: { token: { type: 'string', required: true }, chain: { type: 'string', default: 'solana' }, limit: { type: 'number' } },
+          options: { token: { type: 'string', required: true }, chain: { type: 'string', default: 'solana' }, days: { type: 'number', default: 30 }, limit: { type: 'number' } },
           returns: ['label', 'inflow', 'outflow', 'net_flow', 'wallet_count']
         },
         'dex-trades': {
@@ -166,12 +166,12 @@ export const SCHEMA = {
         },
         'who-bought-sold': {
           description: 'Recent buyers and sellers',
-          options: { token: { type: 'string', required: true }, chain: { type: 'string', default: 'solana' }, limit: { type: 'number' } },
+          options: { token: { type: 'string', required: true }, chain: { type: 'string', default: 'solana' }, days: { type: 'number', default: 30 }, limit: { type: 'number' } },
           returns: ['wallet_address', 'side', 'amount', 'value_usd', 'timestamp', 'labels']
         },
         'flow-intelligence': {
           description: 'Detailed flow intelligence by label',
-          options: { token: { type: 'string', required: true }, chain: { type: 'string', default: 'solana' }, limit: { type: 'number' } },
+          options: { token: { type: 'string', required: true }, chain: { type: 'string', default: 'solana' }, days: { type: 'number', default: 30 } },
           returns: ['label', 'inflow_usd', 'outflow_usd', 'net_flow_usd', 'unique_wallets']
         },
         'transfers': {
@@ -751,7 +751,7 @@ export function buildCommands(deps = {}) {
         'labels': () => apiInstance.addressLabels({ address, chain, pagination }),
         'transactions': () => apiInstance.addressTransactions({ address, chain, filters, orderBy, pagination, days }),
         'pnl': () => apiInstance.addressPnl({ address, chain }),
-        'search': () => apiInstance.entitySearch({ query: options.query, pagination }),
+        'search': () => apiInstance.entitySearch({ query: options.query }),
         'historical-balances': () => apiInstance.addressHistoricalBalances({ address, chain, filters, orderBy, pagination, days }),
         'related-wallets': () => apiInstance.addressRelatedWallets({ address, chain, filters, orderBy, pagination }),
         'counterparties': () => apiInstance.addressCounterparties({ address, chain, filters, orderBy, pagination, days }),
@@ -797,7 +797,7 @@ export function buildCommands(deps = {}) {
         'dex-trades': () => apiInstance.tokenDexTrades({ tokenAddress, chain, onlySmartMoney, filters, orderBy, pagination, days }),
         'pnl': () => apiInstance.tokenPnlLeaderboard({ tokenAddress, chain, filters, orderBy, pagination, days }),
         'who-bought-sold': () => apiInstance.tokenWhoBoughtSold({ tokenAddress, chain, filters, orderBy, pagination, days }),
-        'flow-intelligence': () => apiInstance.tokenFlowIntelligence({ tokenAddress, chain, filters, orderBy, pagination, days }),
+        'flow-intelligence': () => apiInstance.tokenFlowIntelligence({ tokenAddress, chain, filters, orderBy, days }),
         'transfers': () => apiInstance.tokenTransfers({ tokenAddress, chain, filters, orderBy, pagination, days }),
         'jup-dca': () => apiInstance.tokenJupDca({ tokenAddress, filters, orderBy, pagination }),
         'perp-trades': () => apiInstance.tokenPerpTrades({ tokenSymbol, filters, orderBy, pagination, days }),


### PR DESCRIPTION
## Summary

- **Entity search endpoint migrated**: `/api/beta/profiler/entity-name-search` returns 404. Migrated to `/api/v1/search/entity-name` with `search_query` parameter per [current API docs](https://docs.nansen.ai/api/profiler/entity-name-search)
- **Flow intelligence pagination removed**: The `/api/v1/tgm/flow-intelligence` endpoint rejects `pagination` as an unknown field. Removed from request body
- **Schema updated**: Added missing `days` option to `flows`, `who-bought-sold`, and `flow-intelligence` subcommand schemas (the API methods already supported `days` after #2, but the schema didn't advertise it)

## Reproduction

```bash
# Entity search — returns 404
nansen profiler search --query "Vitalik"

# Flow intelligence with --limit — API rejects pagination
nansen token flow-intelligence --token So111... --chain solana --limit 10
```

## Test plan

- [x] All 86 API tests pass (`npx vitest run src/__tests__/api.test.js`)
- [x] All 48 unit tests pass
- [x] All 33 coverage tests pass
- [x] Updated entity search test assertions for new endpoint/body format
- [ ] Live API verification with `NANSEN_LIVE_TEST=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)