### PR TITLE
chore: add changeset for CLI bug fixes (patch bump to 1.3.1)

### DIFF
--- a/.changeset/cli-bugfixes-batch-1.md
+++ b/.changeset/cli-bugfixes-batch-1.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix batch of CLI bugs: profiler 404s, schema field name mismatches, invalid fields sent to API, removed unsupported chains (zksync, unichain), and updated smart money filter to use include_smart_money_labels


### PR DESCRIPTION
## Summary
- Adds changeset for the bug fixes merged in PR #6
- Will trigger a patch version bump (`1.3.0` → `1.3.1`) and npm publish via the changesets action

## Context
PR #6 was merged without a changeset, so the version wasn't bumped and the package wasn't published to npm. This PR adds the missing changeset to trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)