### PR TITLE
fix: screener --search fetches larger page to find matches

### DIFF
--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -464,7 +464,7 @@ describe('buildCommands', () => {
       );
     });
 
-    it('should filter screener results by search option (client-side)', async () => {
+    it('should filter screener results by search option (client-side, flat)', async () => {
       const mockApi = {
         tokenScreener: vi.fn().mockResolvedValue({ data: [
           { token_symbol: 'PEPE', token_name: 'Pepe', price_usd: 0.001 },
@@ -477,6 +477,21 @@ describe('buildCommands', () => {
       expect(result.data).toHaveLength(2);
       expect(result.data[0].token_symbol).toBe('PEPE');
       expect(result.data[1].token_symbol).toBe('PEPEFORK');
+    });
+
+    it('should filter screener results by search option (client-side, nested)', async () => {
+      const mockApi = {
+        tokenScreener: vi.fn().mockResolvedValue({ data: { data: [
+          { token_symbol: 'PEPE', price_usd: 0.001 },
+          { token_symbol: 'USDC', price_usd: 1.0 },
+          { token_symbol: 'PEPEFORK', price_usd: 0.0001 },
+        ], pagination: { page: 1 } } })
+      };
+      const result = await commands['token'](['screener'], mockApi, {}, { chain: 'ethereum', search: 'PEPE' });
+      
+      expect(result.data.data).toHaveLength(2);
+      expect(result.data.data[0].token_symbol).toBe('PEPE');
+      expect(result.data.pagination.page).toBe(1);
     });
 
     it('should call holders with token address', async () => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1131,16 +1131,26 @@ export function buildCommands(deps = {}) {
 
       const handlers = {
         'screener': async () => {
-          const result = await apiInstance.tokenScreener({ chains, timeframe, filters, orderBy, pagination });
-          // Client-side search filter (API doesn't support server-side search)
           const search = options.search;
-          if (search && result?.data) {
+          // When searching, fetch more results to filter from (API has no server-side search)
+          const searchPagination = search 
+            ? { page: 1, per_page: Math.max(500, pagination?.per_page || 0) }
+            : pagination;
+          const result = await apiInstance.tokenScreener({ chains, timeframe, filters, orderBy, pagination: searchPagination });
+          if (search) {
             const q = search.toLowerCase();
-            const filtered = result.data.filter(t => 
+            const requestedLimit = pagination?.per_page || 100;
+            const filterArr = (arr) => arr.filter(t => 
               (t.token_symbol && t.token_symbol.toLowerCase().includes(q)) ||
-              (t.token_name && t.token_name.toLowerCase().includes(q))
-            );
-            return { ...result, data: filtered };
+              (t.token_name && t.token_name.toLowerCase().includes(q)) ||
+              (t.token_address && t.token_address.toLowerCase() === q)
+            ).slice(0, requestedLimit);
+            // Handle nested response shapes: {data: [...]} or {data: {data: [...]}}
+            if (Array.isArray(result?.data)) {
+              return { ...result, data: filterArr(result.data) };
+            } else if (result?.data?.data && Array.isArray(result.data.data)) {
+              return { ...result, data: { ...result.data, data: filterArr(result.data.data) } };
+            }
           }
           return result;
         },


### PR DESCRIPTION
## Problem
`token screener --search PEPE --limit 5` returned empty results because the client-side filter only searched within the small page returned by the API. PEPE wasn't in the top 5 by volume, so it was never seen.

## Fix
When `--search` is used, fetch up to 500 results from the API, filter client-side, then trim to the requested limit. Also handles the nested response shape `{data: {data: [...]}}` from the API.

## Tests
- Added test for nested response shape filtering
- All 407 tests pass ✅

## Verified
```
$ nansen token screener --chain ethereum --search PEPE --limit 5
→ PEPE, PEPECOIN, 🌱 CLAWPEPE (3 matches)
```

Co-authored-by: Claude Code