### PR TITLE
Allow requests without API key for x402 payment flow

### DIFF
--- a/.changeset/allow-keyless-x402.md
+++ b/.changeset/allow-keyless-x402.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Allow requests without an API key. Unauthenticated requests now reach the API and return x402 payment options instead of failing immediately.

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -68,10 +68,12 @@ describe('CLI Smoke Tests', () => {
     const { stdout, stderr, exitCode } = runCLI('smart-money netflow', {
       env: { NANSEN_API_KEY: 'invalid-key' }
     });
-    
+
     // Should fail with auth error but still output valid JSON (error goes to stderr)
+    // Parse first JSON line only (stderr may contain update notifications)
     const output = stdout || stderr;
-    const result = JSON.parse(output);
+    const firstLine = output.split('\n').find(l => l.startsWith('{'));
+    const result = JSON.parse(firstLine);
     expect(result.success).toBe(false);
     expect(result.error).toBeDefined();
     expect(result.code).toBeDefined();
@@ -110,8 +112,10 @@ describe('CLI Smoke Tests', () => {
     });
     
     // Will fail auth but proves env var is being read (error goes to stderr)
+    // Parse first JSON line only (stderr may contain update notifications)
     const output = stdout || stderr;
-    const result = JSON.parse(output);
+    const firstLine = output.split('\n').find(l => l.startsWith('{'));
+    const result = JSON.parse(firstLine);
     expect(result.success).toBe(false);
     expect(['UNAUTHORIZED', 'PAYMENT_REQUIRED']).toContain(result.code);
   });

--- a/src/api.js
+++ b/src/api.js
@@ -385,13 +385,7 @@ function parseRetryAfter(headerValue) {
 
 export class NansenAPI {
   constructor(apiKey = config.apiKey, baseUrl = config.baseUrl, options = {}) {
-    if (!apiKey) {
-      throw new NansenError(
-        'API key required. Run `nansen login` or set NANSEN_API_KEY environment variable.',
-        ErrorCode.UNAUTHORIZED
-      );
-    }
-    this.apiKey = apiKey;
+    this.apiKey = apiKey || null;
     this.baseUrl = baseUrl;
     this.retryOptions = { ...DEFAULT_RETRY_OPTIONS, ...options.retry };
     this.cacheOptions = { 
@@ -434,7 +428,7 @@ export class NansenAPI {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'apikey': this.apiKey,
+            ...(this.apiKey ? { 'apikey': this.apiKey } : {}),
             ...options.headers
           },
           body: JSON.stringify(NansenAPI.cleanBody(body))


### PR DESCRIPTION
## Summary
- Remove the API key requirement from the constructor so unauthenticated requests reach the API and receive x402 payment options
- Fix CLI smoke tests to handle multi-line stderr output

## Test plan
- [x] All 407 tests pass
- [x] Verified manually: `nansen smart-money netflow --chain solana` without API key now returns `PAYMENT_REQUIRED` with payment options

🤖 Generated with [Claude Code](https://claude.com/claude-code)