### PR TITLE
Add --x402-payment-signature flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nansen-cli",
-  "version": "1.4.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nansen-cli",
-      "version": "1.4.0",
+      "version": "1.5.1",
       "license": "MIT",
       "bin": {
         "nansen": "src/index.js"

--- a/src/api.js
+++ b/src/api.js
@@ -388,10 +388,11 @@ export class NansenAPI {
     this.apiKey = apiKey || null;
     this.baseUrl = baseUrl;
     this.retryOptions = { ...DEFAULT_RETRY_OPTIONS, ...options.retry };
-    this.cacheOptions = { 
+    this.cacheOptions = {
       enabled: options.cache?.enabled ?? false,
       ttl: options.cache?.ttl ?? DEFAULT_CACHE_TTL
     };
+    this.defaultHeaders = options.defaultHeaders || {};
   }
 
   static cleanBody(body) {
@@ -429,6 +430,7 @@ export class NansenAPI {
           headers: {
             'Content-Type': 'application/json',
             ...(this.apiKey ? { 'apikey': this.apiKey } : {}),
+            ...this.defaultHeaders,
             ...options.headers
           },
           body: JSON.stringify(NansenAPI.cleanBody(body))
@@ -482,7 +484,7 @@ export class NansenAPI {
         } else if (code === ErrorCode.CREDITS_EXHAUSTED) {
           message = message.replace(/\.+$/, '') + '. No retry will help. Check your Nansen dashboard for credit balance.';
         } else if (code === ErrorCode.PAYMENT_REQUIRED) {
-          message = 'Payment required (x402). This endpoint requires on-chain payment.';
+          message = 'Payment required (x402). Sign the paymentRequirements below per https://docs.x402.org and pass the result with --x402-payment-signature <value>.';
           const paymentHeader = response.headers.get('payment-required');
           if (paymentHeader) {
             try {

--- a/src/cli.js
+++ b/src/cli.js
@@ -299,7 +299,8 @@ export const SCHEMA = {
     fields: { type: 'string', description: 'Comma-separated list of fields to include in output' },
     'no-retry': { type: 'boolean', description: 'Disable automatic retry on rate limits/errors' },
     retries: { type: 'number', default: 3, description: 'Max retry attempts' },
-    format: { type: 'string', enum: ['json', 'csv'], description: 'Output format (default: json)' }
+    format: { type: 'string', enum: ['json', 'csv'], description: 'Output format (default: json)' },
+    'x402-payment-signature': { type: 'string', description: 'Pre-signed x402 payment signature header' }
   },
   chains: ['ethereum', 'solana', 'base', 'bnb', 'arbitrum', 'polygon', 'optimism', 'avalanche', 'linea', 'scroll', 'mantle', 'ronin', 'sei', 'plasma', 'sonic', 'monad', 'hyperevm', 'iotaevm'],
   smartMoneyLabels: ['Fund', 'Smart Trader', '30D Smart Trader', '90D Smart Trader', '180D Smart Trader', 'Smart HL Perps Trader']
@@ -847,6 +848,7 @@ GLOBAL OPTIONS:
   --symbol       Token symbol (for perp endpoints)
   --no-retry     Disable automatic retry on rate limits/errors
   --retries <n>  Max retry attempts (default: 3)
+  --x402-payment-signature <sig>  Pre-signed x402 payment signature header
   --cache        Enable response caching (default: off)
   --no-cache     Disable cache for this request
   --cache-ttl <s> Cache TTL in seconds (default: 300)
@@ -1538,7 +1540,11 @@ export async function runCLI(rawArgs, deps = {}) {
       ttl: options['cache-ttl'] !== undefined ? options['cache-ttl'] : 300
     };
     
-    const api = new NansenAPIClass(undefined, undefined, { retry: retryOptions, cache: cacheOptions });
+    const defaultHeaders = {};
+    if (options['x402-payment-signature']) {
+      defaultHeaders['Payment-Signature'] = options['x402-payment-signature'];
+    }
+    const api = new NansenAPIClass(undefined, undefined, { retry: retryOptions, cache: cacheOptions, defaultHeaders });
     let result = await commands[command](subArgs, api, flags, options);
     
     // Apply field filtering if --fields is specified


### PR DESCRIPTION
## Summary
- Add `--x402-payment-signature` CLI flag for passing pre-signed x402 payment signatures
- Signature is sent as `Payment-Signature` header on API requests via a `defaultHeaders` mechanism
- Update x402 error message to link to https://docs.x402.org

## Test plan
- [ ] `npm test` passes
- [ ] Verify flag appears in `nansen schema` and `nansen --help`
- [ ] Test with an actual x402 payment flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)