### PR TITLE
Add X-Client-Type and X-Client-Version tracking headers

### DIFF
--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -231,6 +231,8 @@ describe('NansenAPI', () => {
     // Verify method and headers
     expect(options.method).toBe('POST');
     expect(options.headers['Content-Type']).toBe('application/json');
+    expect(options.headers['X-Client-Type']).toBe('nansen-cli');
+    expect(options.headers['X-Client-Version']).toMatch(/^\d+\.\d+\.\d+/);
     expect(options.headers['apikey']).toBe('test-api-key');
     
     // Verify body contains expected fields

--- a/src/api.js
+++ b/src/api.js
@@ -9,6 +9,10 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const { version: packageVersion } = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
+);
+
 // ============= Error Codes =============
 
 /**
@@ -428,6 +432,8 @@ export class NansenAPI {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            'X-Client-Type': 'nansen-cli',
+            'X-Client-Version': packageVersion,
             ...(this.apiKey ? { 'apikey': this.apiKey } : {}),
             ...options.headers
           },


### PR DESCRIPTION
## Summary

- Adds `X-Client-Type: nansen-cli` and `X-Client-Version: <version>` headers to every API request in `src/api.js`
- Version is read dynamically from `package.json` so it stays in sync automatically
- Mirrors the existing MCP tracking pattern (`X-MCP-Server`, `X-MCP-Version`) for consistency
- Updated `api.test.js` to assert the new headers are present on all requests

## Backend follow-up (out of scope for this PR)

- `bi_tracking.py` — capture `X-Client-Type` / `X-Client-Version` server-side
- Add `client_type` and `client_version` fields to `api_request_succeeded` BI events

Closes BI-341

🤖 Generated with [Claude Code](https://claude.com/claude-code)