### PR TITLE
Output error JSON to stdout instead of stderr

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1572,7 +1572,7 @@ export async function runCLI(rawArgs, deps = {}) {
   } catch (error) {
     const errorData = formatError(error);
     const formatted = formatOutput(errorData, { pretty, table, csv });
-    errorOutput(formatted.text);
+    output(formatted.text);
     notify();
     exit(1);
     return { type: 'error', data: errorData };


### PR DESCRIPTION
## Summary

- Error JSON was sent to stderr via `errorOutput()`, so `nansen ... | jq` silently dropped error responses
- Changed to use `output()` so all structured JSON goes to stdout, matching `curl` convention (response body to stdout, exit code signals success/failure)

## Test plan

- [x] `npm test` — all 407 tests pass
- [ ] `nansen smart-money netflow --chain solana | jq .error` — should print the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)