### PR TITLE
Add general search command

### DIFF
--- a/.changeset/add-general-search.md
+++ b/.changeset/add-general-search.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add general search command for tokens and entities

--- a/README.md
+++ b/README.md
@@ -123,6 +123,21 @@ Deep analytics for any token.
 |------------|-------------|
 | `defi` | DeFi holdings across protocols |
 
+### `search` - Search
+
+Search for tokens and entities across Nansen.
+
+```bash
+nansen search "uniswap" --pretty
+nansen search "uniswap" --type token --chain ethereum
+```
+
+| Option | Description |
+|--------|-------------|
+| `--type` | Filter by result type: `token`, `entity`, or `any` (default) |
+| `--chain` | Filter by chain |
+| `--limit` | Max results, 1-50 (default: 25) |
+
 ### `schema` - Schema Discovery
 
 Output JSON schema for agent introspection. No API key required.
@@ -258,7 +273,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
 | Profiler | 11 | 100% |
 | Token God Mode | 12 | 100% |
 | Portfolio | 1 | 100% |
-| **Total** | **30** | **100%** |
+| Search | 1 | 100% |
+| **Total** | **31** | **100%** |
 
 ## License
 

--- a/src/__tests__/coverage.test.js
+++ b/src/__tests__/coverage.test.js
@@ -53,6 +53,9 @@ const DOCUMENTED_ENDPOINTS = {
   portfolio: [
     { name: 'defi-holdings', method: 'portfolioDefiHoldings', endpoint: '/api/v1/portfolio/defi-holdings' },
   ],
+  search: [
+    { name: 'general-search', method: 'generalSearch', endpoint: '/api/v1/search/general' },
+  ],
 };
 
 // Endpoints that are documented but return 404 (confirmed non-existent)
@@ -105,6 +108,14 @@ describe('API Endpoint Coverage', () => {
     }
   });
 
+  describe('Search Endpoints', () => {
+    for (const ep of DOCUMENTED_ENDPOINTS.search) {
+      it(`should have ${ep.name} method`, () => {
+        expect(typeof api[ep.method]).toBe('function');
+      });
+    }
+  });
+
   describe('Coverage Summary', () => {
     it('should report implemented endpoints', () => {
       const implemented = [
@@ -113,6 +124,7 @@ describe('API Endpoint Coverage', () => {
         ...DOCUMENTED_ENDPOINTS.tokenGodMode,
         ...DOCUMENTED_ENDPOINTS.composite,
         ...DOCUMENTED_ENDPOINTS.portfolio,
+        ...DOCUMENTED_ENDPOINTS.search,
       ];
       
       console.log(`\n📊 API Coverage Summary:`);

--- a/src/api.js
+++ b/src/api.js
@@ -675,6 +675,20 @@ export class NansenAPI {
     });
   }
 
+  async generalSearch(params = {}) {
+    const { query, resultType = 'any', chain, limit = 25 } = params;
+    if (!query) {
+      throw new NansenError('Search query is required', ErrorCode.MISSING_PARAM);
+    }
+    const body = {
+      search_query: query,
+      result_type: resultType,
+      limit
+    };
+    if (chain) body.chain = chain;
+    return this.request('/api/v1/search/general', body);
+  }
+
   async addressHistoricalBalances(params = {}) {
     const { address, chain = 'ethereum', filters = {}, orderBy, pagination, days = 30 } = params;
     if (address) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -279,6 +279,16 @@ export const SCHEMA = {
         }
       }
     },
+    'search': {
+      description: 'Search for tokens and entities across Nansen',
+      options: {
+        query: { type: 'string', required: true, description: 'Search query (token name, symbol, address, or entity)' },
+        type: { type: 'string', default: 'any', enum: ['token', 'entity', 'any'], description: 'Result type filter' },
+        chain: { type: 'string', description: 'Filter by chain (e.g., ethereum, solana)' },
+        limit: { type: 'number', default: 25, description: 'Max results (1-50)' }
+      },
+      returns: ['tokens[name, symbol, chain, address, price, volume_24h, market_cap, rank]', 'entities[name, tags, rank]', 'total_results']
+    },
     'points': {
       description: 'Nansen Points analytics',
       subcommands: {
@@ -1292,6 +1302,15 @@ export function buildCommands(deps = {}) {
       }
 
       return handlers[subcommand]();
+    },
+
+    'search': async (args, apiInstance, flags, options) => {
+      return apiInstance.generalSearch({
+        query: args[0] || options.query,
+        resultType: options.type,
+        chain: options.chain,
+        limit: options.limit
+      });
     },
 
     'points': async (args, apiInstance, flags, options) => {


### PR DESCRIPTION
## Summary
- Top-level `nansen search` command for unified token and entity search via `/api/v1/search/general`
- Options: `--type` (token/entity/any), `--chain`, `--limit`
- Query as positional arg or `--query` flag
- Includes coverage test and changeset

Supersedes #16 (rebased to avoid unrelated fork commits).
Based on work by @0xlaveen.

## Test plan
- [x] `npm test` passes (408 tests)