### PR TITLE
Fix token info default timeframe

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -976,7 +976,7 @@ export class NansenAPI {
   }
 
   async tokenInformation(params = {}) {
-    const { tokenAddress, chain = 'solana', timeframe = '24h' } = params;
+    const { tokenAddress, chain = 'solana', timeframe = '1d' } = params;
     if (tokenAddress) {
       const validation = validateTokenAddress(tokenAddress, chain);
       if (!validation.valid) throw new NansenError(validation.error, validation.code);

--- a/src/cli.js
+++ b/src/cli.js
@@ -170,7 +170,7 @@ export const SCHEMA = {
           options: {
             token: { type: 'string', required: true, description: 'Token address' },
             chain: { type: 'string', default: 'solana' },
-            timeframe: { type: 'string', default: '24h', enum: ['5m', '10m', '1h', '6h', '24h', '7d', '30d'] }
+            timeframe: { type: 'string', default: '1d', enum: ['5m', '1h', '6h', '12h', '1d', '7d'] }
           },
           returns: ['token_address', 'token_symbol', 'token_name', 'chain', 'price_usd', 'volume_usd', 'market_cap', 'holder_count', 'liquidity_usd']
         },
@@ -1191,7 +1191,7 @@ export function buildCommands(deps = {}) {
       }
 
       const handlers = {
-        'info': () => apiInstance.tokenInformation({ tokenAddress, chain, timeframe }),
+        'info': () => apiInstance.tokenInformation({ tokenAddress, chain, timeframe: options.timeframe }),
         'screener': async () => {
           const search = options.search;
           // When searching, fetch more results to filter from (API has no server-side search)


### PR DESCRIPTION
## Summary
- The `token info` endpoint accepts `5m/1h/6h/12h/1d/7d` but the CLI was sending `24h` (only valid for the screener endpoint)
- Changed default timeframe from `24h` to `1d` in `api.js`
- Updated schema enum in `cli.js` to match the API's accepted values
- CLI handler now passes explicit `options.timeframe` only when user provides it, letting the API method default handle the rest

## Test plan
- [x] `token info --token-address 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 --chain ethereum` returns success
- [x] `token info --timeframe 7d` with explicit timeframe works
- [x] `token screener` still works with its own `24h` default
- [x] All 408 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)