### PR TITLE
Add token indicators endpoint

### DIFF
--- a/.changeset/add-token-indicators.md
+++ b/.changeset/add-token-indicators.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add token indicators command for Nansen Score risk/reward indicators

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -142,6 +142,17 @@ const MOCK_RESPONSES = {
       { token: 'ETH', side: 'short', pnl_usd: 5000 }
     ]
   },
+  tokenIndicators: {
+    token_address: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+    chain: 'ethereum',
+    token_info: { market_cap_usd: 1500000000, market_cap_group: 'largecap', is_stablecoin: false },
+    risk_indicators: [
+      { indicator_type: 'liquidity-risk', score: 'low', signal: 0.2, signal_percentile: 30.5, last_trigger_on: '2025-01-15' }
+    ],
+    reward_indicators: [
+      { indicator_type: 'price-momentum', score: 'bullish', signal: 0.75, signal_percentile: 85.5, last_trigger_on: '2025-01-10' }
+    ]
+  },
   // New Token God Mode endpoints
   tokenFlowIntelligence: {
     flows: [
@@ -761,6 +772,26 @@ describe('NansenAPI', () => {
   // =================== Token God Mode Endpoints ===================
 
   describe('Token God Mode', () => {
+    describe('tokenIndicators', () => {
+      it('should fetch indicators with correct endpoint and body', async () => {
+        setupMock(MOCK_RESPONSES.tokenIndicators);
+
+        const result = await api.tokenIndicators({
+          tokenAddress: TEST_DATA.ethereum.token,
+          chain: 'ethereum'
+        });
+
+        const body = expectFetchCalledWith('/api/v1/tgm/indicators');
+        if (body) {
+          expect(body.token_address).toBe(TEST_DATA.ethereum.token);
+          expect(body.chain).toBe('ethereum');
+        }
+
+        expect(result.risk_indicators).toBeInstanceOf(Array);
+        expect(result.reward_indicators).toBeInstanceOf(Array);
+      });
+    });
+
     describe('tokenScreener', () => {
       it('should screen tokens with correct endpoint and body', async () => {
         setupMock(MOCK_RESPONSES.tokenScreener);

--- a/src/__tests__/coverage.test.js
+++ b/src/__tests__/coverage.test.js
@@ -32,6 +32,7 @@ const DOCUMENTED_ENDPOINTS = {
     { name: 'perp-trades', method: 'addressPerpTrades', endpoint: '/api/v1/profiler/perp-trades' },
   ],
   tokenGodMode: [
+    { name: 'indicators', method: 'tokenIndicators', endpoint: '/api/v1/tgm/indicators' },
     { name: 'screener', method: 'tokenScreener', endpoint: '/api/v1/token-screener' },
     { name: 'holders', method: 'tokenHolders', endpoint: '/api/v1/tgm/holders' },
     { name: 'flows', method: 'tokenFlows', endpoint: '/api/v1/tgm/flows' },

--- a/src/api.js
+++ b/src/api.js
@@ -975,6 +975,18 @@ export class NansenAPI {
     });
   }
 
+  async tokenIndicators(params = {}) {
+    const { tokenAddress, chain = 'ethereum' } = params;
+    if (tokenAddress) {
+      const validation = validateTokenAddress(tokenAddress, chain);
+      if (!validation.valid) throw new NansenError(validation.error, validation.code);
+    }
+    return this.request('/api/v1/tgm/indicators', {
+      token_address: tokenAddress,
+      chain
+    });
+  }
+
   async tokenInformation(params = {}) {
     const { tokenAddress, chain = 'solana', timeframe = '1d' } = params;
     if (tokenAddress) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -165,6 +165,14 @@ export const SCHEMA = {
     'token': {
       description: 'Token God Mode - deep analytics for any token',
       subcommands: {
+        'indicators': {
+          description: 'Risk and reward indicators for a token (Nansen Score)',
+          options: {
+            token: { type: 'string', required: true, description: 'Token address' },
+            chain: { type: 'string', default: 'ethereum' }
+          },
+          returns: ['token_info[market_cap_usd, market_cap_group, is_stablecoin]', 'risk_indicators[indicator_type, score, signal, signal_percentile, last_trigger_on]', 'reward_indicators[indicator_type, score, signal, signal_percentile, last_trigger_on]']
+        },
         'info': {
           description: 'Get detailed information for a specific token',
           options: {
@@ -836,9 +844,9 @@ COMMANDS:
   profiler       Wallet profiling (balance, labels, transactions, pnl, pnl-summary, search,
                    historical-balances, related-wallets, counterparties, perp-positions, perp-trades,
                    batch, trace, compare)
-  token          Token God Mode (info, screener, holders, flows, dex-trades, pnl, who-bought-sold,
-                   flow-intelligence, transfers, jup-dca, perp-trades, perp-positions,
-                   perp-pnl-leaderboard)
+  token          Token God Mode (info, indicators, screener, holders, flows, dex-trades, pnl,
+                   who-bought-sold, flow-intelligence, transfers, jup-dca, perp-trades,
+                   perp-positions, perp-pnl-leaderboard)
   portfolio      Portfolio analytics (defi)
   perp           Perpetual futures analytics (screener, leaderboard)
   points         Nansen Points analytics (leaderboard)
@@ -1191,6 +1199,7 @@ export function buildCommands(deps = {}) {
       }
 
       const handlers = {
+        'indicators': () => apiInstance.tokenIndicators({ tokenAddress, chain }),
         'info': () => apiInstance.tokenInformation({ tokenAddress, chain, timeframe: options.timeframe }),
         'screener': async () => {
           const search = options.search;


### PR DESCRIPTION
## Summary
- Add `token indicators` subcommand for Nansen Score risk/reward indicators (`/api/v1/tgm/indicators`)
- Takes `--token-address` and `--chain` params, returns risk and reward indicators with scores, signals, and percentiles

## Test plan
- [x] Live API test returns valid data (`token indicators --token-address 0x7fc6... --chain ethereum`)
- [x] All 410 tests pass (mock + coverage)
- [x] Changeset added for minor version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)