### PR TITLE
fix: better error message for Solana 502 broadcast failures

### DIFF
--- a/src/trading.js
+++ b/src/trading.js
@@ -907,7 +907,8 @@ EXAMPLES:
         const chainConfig = resolveChain(chain);
         const chainType = chainConfig.type;
 
-        const bestQuote = quoteData.response.quotes?.[0];
+        const quoteIndex = parseInt(options['quote-index'] ?? '0', 10);
+        const bestQuote = quoteData.response.quotes?.[quoteIndex] || quoteData.response.quotes?.[0];
         if (!bestQuote) {
           log('❌ No quote data found');
           exit(1);


### PR DESCRIPTION
Two fixes found during live trading tests on Solana and Base EVM:

## 1. Better error message for Solana 502 broadcast failures

When a Solana transaction broadcast returns HTTP 502, the CLI now hints that it likely means the transaction failed simulation due to insufficient SOL for fees.

**Before:**
```
❌ Execute API returned non-JSON response (status 502). This may be a Cloudflare challenge or server error.
```

**After:**
```
❌ Execute API returned non-JSON response (status 502). This often means the transaction failed simulation — check that you have enough SOL for fees (~0.005 SOL minimum).
```

## 2. Implement `--quote-index` on execute command

Execute was hardcoded to `quotes[0]`, making it impossible to select alternative aggregators. On Base, OKX router reverts on most ERC-20 swaps while LiFi works fine — but there was no way to pick LiFi.

Now reads `--quote-index N` to select which quote to execute (defaults to 0, falls back if out of range).

## Base EVM test findings (for context)

OKX router on Base is unreliable — only ETH→token works for some pairs. All ERC-20 sell-side swaps (token→ETH, token→token) revert or 502. LiFi router works for the same pairs. With `--quote-index 1` we confirmed ETH→BRETT succeeds via LiFi where OKX fails.

Stacked on #31.