### PR TITLE
fix: resilient execute with auto-fallback and pre-flight simulation

### DIFF
--- a/src/trading.js
+++ b/src/trading.js
@@ -1168,7 +1168,7 @@ EXAMPLES:
                 from: walletAddress, to: txData.to, data: txData.data, value: valueHex,
               });
               if (estimatedGas) {
-                const quoteGas = parseInt(txData.gas || txData.gasLimit || '0');
+                const quoteGas = parseInt(currentQuote.gas || txData.gas || txData.gasLimit || '0');
                 const bufferedEstimate = Math.ceil(estimatedGas * 1.2);
                 const finalGas = Math.max(quoteGas, bufferedEstimate);
                 if (finalGas > quoteGas) {


### PR DESCRIPTION
## Problem

The `execute` command was fragile in three ways:

### 1. Hardcoded `quotes[0]` — no way to select alternative aggregators

Execute always picked the first quote returned by the trading API, ignoring all alternatives. When the first aggregator's route was broken (common with OKX on Base), every swap failed with no recourse.

### 2. No pre-flight simulation — gas burned on reverts

On EVM, the CLI would sign and broadcast transactions without simulating first. When a route was broken, the transaction would revert on-chain, consuming gas fees for nothing. During testing, we burned ~$0.15 across 5+ reverted transactions on Base.

### 3. Generic 502 error messages

When the trading API returned HTTP 502, the error message was always "This may be a Cloudflare challenge or server error" — unhelpful for debugging.

## Solution

### Auto-fallback through quotes

Execute now loops through all available quotes. If one fails (simulation, approval, broadcast, or on-chain revert), it automatically tries the next:

```
Executing trade on Base...
  Trying quote 1/2 (okx)...
  ⚠ Approval required → 0x57df...
  ✓ Approval confirmed
  ⚠ Simulation failed for okx: execution reverted
  Trying next quote...

  Trying quote 2/2 (lifi)...
  ✓ Transaction successful!
```

### Pre-flight simulation via `eth_call` (after approval)

Before signing and broadcasting an EVM transaction, the CLI runs `eth_call` against the local RPC to simulate execution. If the call reverts, the quote is skipped — saving swap gas ($0.10-0.50 per reverted tx).

**Key design decision:** Simulation runs AFTER the ERC-20 approval step, not before. This matches the industry standard pattern used by LiFi SDK, 1inch, and other major aggregators. The reason: `eth_call` checks on-chain state, so if the token hasn't been approved yet, the swap simulation would always fail due to missing allowance — causing first-time ERC-20 swaps to skip all quotes without ever attempting them.

The trade-off is that approval gas (~$0.01) may be spent for a route that fails simulation, but this is negligible compared to the swap gas saved.

**Research sources:**
- [LiFi SDK `EthereumStepExecutor.ts`](https://github.com/lifinance/sdk/blob/main/packages/sdk-provider-ethereum/src/EthereumStepExecutor.ts): `checkAllowance` → approve → `estimateGas` → `sendTransaction`
- 1inch: Uses Permit2/EIP-2612 to bundle approval into swap calldata (avoids separate approve entirely)
- No major aggregator SDK does pre-flight simulation before approval

### `--quote-index` flag

Users can pin a specific quote with `--quote-index N` (0-based). When set, only that quote is tried (no fallback):

```bash
nansen execute --quote <id> --quote-index 1  # use LiFi instead of OKX
```

### Chain-specific 502 error messages

```
# Solana
❌ ...status 502. This often means the transaction failed simulation — check that you have enough SOL for fees (~0.005 SOL minimum).

# EVM
❌ ...status 502. This often means the transaction failed simulation — check that you have enough ETH for gas fees.
```

## Test Results

### Live trading tests on Base

| Trade | Before | After |
|-------|--------|-------|
| VIRTUAL→ETH | ❌ OKX revert, gas burned | ✅ OKX: approve → sim caught. LiFi: approve → sim caught. **Zero swap gas burned** |
| ETH→AERO | ❌ OKX revert, gas burned | ✅ LiFi succeeds (auto-selected or fallback) |
| ETH→BRETT | ❌ OKX revert, gas burned | ✅ LiFi succeeds |
| USDC→ETH | ❌ OKX 502 | ✅ LiFi succeeds |
| ETH→USDC | ✅ | ✅ |
| ETH→VIRTUAL | ✅ | ✅ |

### Live trading tests on Solana

All Solana trades (SOL↔USDC, SOL↔BONK, SOL↔PENGU, SOL↔JUP, SOL↔NX8, SOL↔CTO) worked correctly. The 502 error hint was validated by attempting to swap nearly all SOL away.

### Unit tests

**50/50 trading tests pass.** Full suite: 484 passed, 1 pre-existing flaky failure (unrelated `cli.test.js` network test).

## Changes

**`src/trading.js`:**

1. **`executeTransaction()`** — Chain-aware 502 error hints for Solana and EVM
2. **New `simulateEvmCall()`** — Pre-flight `eth_call` simulation helper. Gracefully returns `{ success: true }` on network errors or missing RPC (doesn't block execution)
3. **Execute command refactor:**
   - Loops through all quotes with auto-fallback on failure
   - `--quote-index N` for manual quote selection (no fallback when pinned)
   - Early exit when no quotes have transaction data (avoids hanging on password prompt)
   - Simulation runs after approval, before signing (industry standard flow)