### PR TITLE
feat: verify allowance after approval, skip simulation on RPC lag

### DIFF
--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -27,6 +27,7 @@ import {
   ecRecover,
   stripLeadingZeros,
   buildTradingCommands,
+  checkAllowance,
 } from '../trading.js';
 import {
   keccak256,
@@ -695,5 +696,89 @@ describe('API error handling', () => {
     })).rejects.toThrow(); // Should throw, not hang
 
     global.fetch = origFetch;
+  });
+});
+
+// ============= Allowance Check Tests =============
+
+describe('checkAllowance', () => {
+  const origFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = origFetch;
+  });
+
+  it('should return allowance as BigInt', async () => {
+    const maxUint = '0x' + 'f'.repeat(64);
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ result: maxUint }),
+    });
+
+    const allowance = await checkAllowance(
+      'base',
+      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      '0x1111111111111111111111111111111111111111',
+      '0x2222222222222222222222222222222222222222',
+    );
+
+    expect(typeof allowance).toBe('bigint');
+    expect(allowance > 0n).toBe(true);
+  });
+
+  it('should return 0n for zero allowance', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ result: '0x0000000000000000000000000000000000000000000000000000000000000000' }),
+    });
+
+    const allowance = await checkAllowance(
+      'base',
+      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      '0x1111111111111111111111111111111111111111',
+      '0x2222222222222222222222222222222222222222',
+    );
+
+    expect(allowance).toBe(0n);
+  });
+
+  it('should call eth_call with correct allowance selector', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ result: '0x0' }),
+    });
+
+    await checkAllowance(
+      'base',
+      '0xTokenAddr000000000000000000000000000000',
+      '0xOwnerAddr000000000000000000000000000000',
+      '0xSpenderAd000000000000000000000000000000',
+    );
+
+    const callBody = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(callBody.method).toBe('eth_call');
+    // Should use allowance selector 0xdd62ed3e
+    expect(callBody.params[0].data).toMatch(/^0xdd62ed3e/);
+    // Should contain owner and spender addresses (lowercased, padded to 64 hex chars)
+    expect(callBody.params[0].data.length).toBe(2 + 8 + 64 + 64); // 0x + selector + owner + spender
+  });
+
+  it('should throw on RPC error', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ error: { message: 'execution reverted' } }),
+    });
+
+    await expect(checkAllowance(
+      'base',
+      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      '0x1111111111111111111111111111111111111111',
+      '0x2222222222222222222222222222222222222222',
+    )).rejects.toThrow('execution reverted');
+  });
+
+  it('should throw for unsupported chain', async () => {
+    await expect(checkAllowance(
+      'fantom',
+      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      '0x1111111111111111111111111111111111111111',
+      '0x2222222222222222222222222222222222222222',
+    )).rejects.toThrow('No RPC URL');
   });
 });

--- a/src/trading.js
+++ b/src/trading.js
@@ -307,6 +307,39 @@ export async function getEvmNonce(chain, address) {
 }
 
 /**
+ * Check ERC-20 allowance for a given owner/spender pair.
+ *
+ * @param {string} chain - Chain name
+ * @param {string} tokenAddress - ERC-20 token contract
+ * @param {string} ownerAddress - Token owner
+ * @param {string} spenderAddress - Approved spender (e.g. DEX router)
+ * @returns {Promise<bigint>} Current allowance in raw token units
+ */
+export async function checkAllowance(chain, tokenAddress, ownerAddress, spenderAddress) {
+  const rpcUrl = EVM_RPC_URLS[chain];
+  if (!rpcUrl) throw new Error(`No RPC URL configured for chain: ${chain}`);
+
+  // allowance(address owner, address spender) selector = 0xdd62ed3e
+  const data = '0xdd62ed3e'
+    + ownerAddress.slice(2).toLowerCase().padStart(64, '0')
+    + spenderAddress.slice(2).toLowerCase().padStart(64, '0');
+
+  const res = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_call',
+      params: [{ to: tokenAddress, data }, 'latest'],
+    }),
+  });
+  const body = await res.json();
+  if (body.error) throw new Error(`RPC error: ${body.error.message}`);
+  return BigInt(body.result || '0x0');
+}
+
+/**
  * Wait for an EVM transaction to be confirmed on-chain.
  * Polls eth_getTransactionReceipt until receipt is available or timeout.
  *
@@ -890,7 +923,7 @@ EXAMPLES:
     'execute': async (args, apiInstance, flags, options) => {
       const quoteId = options.quote || options['quote-id'] || args[0];
       const walletName = options.wallet;
-      const noSimulate = flags['no-simulate'] || flags.noSimulate;
+      let noSimulate = flags['no-simulate'] || flags.noSimulate;
 
       if (!quoteId) {
         errorOutput(`
@@ -1002,6 +1035,30 @@ EXAMPLES:
               errorOutput(`  Approval may not have confirmed: ${receiptErr.message}`);
               exit(1);
               return;
+            }
+
+            // Verify allowance is actually set on-chain before proceeding
+            // RPC nodes can lag behind — poll until allowance is non-zero or timeout
+            errorOutput(`  Verifying allowance...`);
+            let allowanceVerified = false;
+            for (let attempt = 0; attempt < 5; attempt++) {
+              try {
+                const allowance = await checkAllowance(chain, bestQuote.inputMint, walletAddress, bestQuote.approvalAddress);
+                if (allowance > 0n) {
+                  errorOutput(`  Allowance confirmed: ${allowance.toString()}`);
+                  allowanceVerified = true;
+                  break;
+                }
+              } catch { /* ignore, retry */ }
+              await new Promise(r => setTimeout(r, 2000));
+            }
+
+            if (!allowanceVerified && !noSimulate) {
+              // Allowance not yet visible to RPC — skip simulation for the swap
+              // to avoid false failure. The approval tx IS confirmed on-chain,
+              // the RPC is just lagging.
+              errorOutput(`  Allowance not yet visible to RPC. Skipping simulation for swap to avoid false failure.`);
+              noSimulate = true;
             }
             errorOutput('');
           }


### PR DESCRIPTION
## Problem

Simulation fails on Base when a token hasn't been approved with the DEX yet (reported by Tim). The approval tx confirms on-chain, but the RPC node used for simulation hasn't propagated the state yet, causing the swap simulation to revert with 'insufficient allowance'.

## Solution

After the approval tx is confirmed, the CLI now:

1. **Polls the allowance** up to 5 times (2s intervals) via `eth_call` to verify the RPC node reflects the approval
2. **If allowance is confirmed** → proceeds with simulation as normal  
3. **If allowance is NOT visible** (RPC lag) → automatically skips simulation for the swap tx to avoid false failure

This is safer than blindly skipping simulation (Tim's suggestion), because:
- Simulation still runs when the allowance is visible (catches real errors)
- Only skips when we *know* the approval is confirmed but the RPC is lagging
- The approval tx receipt is already verified on-chain before this check

## Changes

- `src/trading.js`: Added `checkAllowance()` function + allowance verification loop in execute flow
- `src/__tests__/trading.test.js`: 5 new tests for `checkAllowance`

## How to Test

### Unit tests
```bash
npm test
```

### Manual testing on Base
1. Create a wallet: `nansen wallet create test`
2. Fund it with some ETH + an ERC-20 token (e.g. USDC) on Base
3. Get a quote: `nansen quote --chain base --from 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 --to 0x4200000000000000000000000000000000000006 --amount 1000000`
4. Execute with simulation: `nansen execute --quote <id>`
5. Observe: approval tx → allowance verification → swap tx (simulation should pass or be auto-skipped)

### Testing the RPC lag scenario
To force the lag scenario:
1. Use a slow RPC endpoint (set `NANSEN_RPC_BASE` to a free/rate-limited RPC)
2. Execute a swap that requires approval
3. The CLI should detect the allowance isn't visible and skip simulation with a warning message

### Testing without approval needed
- Swap native ETH → should skip the approval flow entirely
- Swap a token that's already approved → allowance check passes immediately