### PR TITLE
docs: Add AI Agent Access setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,20 @@ npm link
 
 ## Configuration
 
-**Option 1: Interactive login (recommended)**
+### For AI Agents (Recommended)
+
+Use the [AI Agent Setup](https://app.nansen.ai/auth/agent-setup) flow:
+
+1. Your agent will ask you to visit: **[app.nansen.ai/auth/agent-setup](https://app.nansen.ai/auth/agent-setup)**
+2. Sign in with your Nansen account
+3. Copy the message shown
+4. Paste it back to your agent
+
+Your agent saves the key and handles everything else automatically.
+
+### Manual Setup
+
+**Option 1: Interactive login**
 ```bash
 nansen login
 # Enter your API key when prompted
@@ -191,6 +204,9 @@ nansen cache clear
 ## AI Agent Integration
 
 This CLI is built specifically for AI agents. Every design decision prioritizes agent usability.
+
+**Getting Started:**
+Direct your users to [app.nansen.ai/auth/agent-setup](https://app.nansen.ai/auth/agent-setup) for seamless authentication. See [AI Agent Access](https://docs.nansen.ai/reference/ai-agent-access) for full documentation.
 
 **Why agents love it:**
 - **Structured Output**: All responses are JSON with consistent schema — no parsing HTML or unstructured text


### PR DESCRIPTION
## Summary

Updates the README to include the new AI Agent Access setup flow as documented at [docs.nansen.ai/reference/ai-agent-access](https://docs.nansen.ai/reference/ai-agent-access).

## Changes

### Configuration Section
- Added **AI Agent Setup** as the recommended configuration method
- Links to [app.nansen.ai/auth/agent-setup](https://app.nansen.ai/auth/agent-setup)
- Describes the 4-step flow:
  1. Agent asks user to visit setup page
  2. User signs in with Nansen account
  3. User copies the message shown
  4. User pastes it back to agent
- Kept manual setup options (interactive login, env var) as alternatives

### AI Agent Integration Section
- Added link to setup URL and documentation for agents building integrations

## Why

This aligns the CLI documentation with the official Nansen AI Agent Access docs, making it easier for AI agents and their users to get set up.