### PR TITLE
Fix Solana execute crash with OKX quotes

### DIFF
--- a/src/trading.js
+++ b/src/trading.js
@@ -9,6 +9,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { exportWallet, getDefaultAddress, showWallet, keccak256, listWallets } from './wallet.js';
+import { base58Decode } from './transfer.js';
 
 // ============= Constants =============
 
@@ -1075,9 +1076,14 @@ EXAMPLES:
             let requestId;
 
             if (chainType === 'solana') {
-              // Solana: quote.transaction is base64 serialized VersionedTransaction
+              // Solana: transaction is either a base64 string (Jupiter) or an object
+              // with a base58-encoded `data` field (OKX). Normalize to base64.
+              let txBase64 = currentQuote.transaction;
+              if (typeof txBase64 === 'object' && txBase64.data) {
+                txBase64 = base58Decode(txBase64.data).toString('base64');
+              }
               errorOutput('  Signing Solana transaction...');
-              signedTransaction = signSolanaTransaction(currentQuote.transaction, exported.solana.privateKey);
+              signedTransaction = signSolanaTransaction(txBase64, exported.solana.privateKey);
               requestId = currentQuote.metadata?.requestId;
 
             } else {


### PR DESCRIPTION
## Summary
- `nansen execute --quote <id>` crashes on Solana when the quote comes from OKX
- OKX returns `transaction` as an object (`{ data, from, gas, ... }`) with the serialized tx in `data` as base58, while Jupiter returns a plain base64 string
- The trading API passes through aggregator responses as-is (no normalization), so the CLI must handle both formats
- Fix: detect object format, base58-decode `data`, convert to base64 before signing

## Test plan
- [x] Reproduced crash with real OKX Solana quote
- [x] Verified fix: signing succeeds, broadcast reaches chain (fails with expected "insufficient funds" for test wallet)
- [x] All 562 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)