### PR TITLE
Migrate from legacy /execute to /execution/prepare + /execution/standard

### DIFF
--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -3,7 +3,7 @@
  *
  * Covers: chain resolution, quote storage, RLP encoding, compact-u16 parsing,
  * Solana signing, EVM signing (address recovery, decimal/hex handling, EIP-155),
- * ERC-20 approval building, API error handling, and CLI command validation.
+ * EIP-1559 signing, prepare/submit API, and CLI command validation.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -22,7 +22,9 @@ import {
   signLegacyTransaction,
   signSolanaTransaction,
   signEvmTransaction,
-  buildApprovalTransaction,
+  signEip1559EvmTransaction,
+  prepareTransaction,
+  submitExecution,
   stripLeadingZeros,
   buildTradingCommands,
 } from '../trading.js';
@@ -482,25 +484,176 @@ describe('signEvmTransaction (API response format)', () => {
   });
 });
 
-// ============= ERC-20 Approval Transaction =============
+// ============= EIP-1559 (Type 2) Transaction Signing =============
 
-describe('buildApprovalTransaction', () => {
-  it('should build a valid approval tx', () => {
+describe('signEip1559EvmTransaction', () => {
+  it('should produce valid signed tx hex with 0x02 type prefix', () => {
     const wallet = generateEvmWallet();
-    const signedHex = buildApprovalTransaction(
-      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', // USDC on Base
-      '0x57df6092665eb6058de53939612413ff4b09114e', // spender
-      wallet.privateKey,
-      'base',
-      0,
-    );
-    expect(signedHex).toMatch(/^0x[0-9a-f]+$/);
+    const txData = {
+      nonce: 0,
+      maxFeePerGas: '30000000000',
+      maxPriorityFeePerGas: '1000000000',
+      gas: '21000',
+      to: '0x' + 'ab'.repeat(20),
+      value: '0',
+      data: '0x',
+      chainId: 8453,
+    };
+    const signedHex = signEip1559EvmTransaction(txData, wallet.privateKey);
+    expect(signedHex).toMatch(/^0x02[0-9a-f]+$/);
   });
 
-  it('should reject unsupported chains', () => {
+  it('should produce deterministic signatures (RFC 6979)', () => {
     const wallet = generateEvmWallet();
-    expect(() => buildApprovalTransaction('0xabc', '0xdef', wallet.privateKey, 'polygon', 0))
-      .toThrow('Unsupported chain');
+    const txData = {
+      nonce: 0,
+      maxFeePerGas: '30000000000',
+      maxPriorityFeePerGas: '1000000000',
+      gas: '21000',
+      to: '0x' + 'ab'.repeat(20),
+      value: '0',
+      data: '0x',
+      chainId: 1,
+    };
+    const sig1 = signEip1559EvmTransaction(txData, wallet.privateKey);
+    const sig2 = signEip1559EvmTransaction(txData, wallet.privateKey);
+    expect(sig1).toBe(sig2);
+  });
+
+  it('should produce different signed tx for different nonces', () => {
+    const wallet = generateEvmWallet();
+    const base = {
+      maxFeePerGas: '30000000000',
+      maxPriorityFeePerGas: '1000000000',
+      gas: '21000',
+      to: '0x' + 'ab'.repeat(20),
+      value: '0',
+      data: '0x',
+      chainId: 8453,
+    };
+    const sig0 = signEip1559EvmTransaction({ ...base, nonce: 0 }, wallet.privateKey);
+    const sig1 = signEip1559EvmTransaction({ ...base, nonce: 1 }, wallet.privateKey);
+    expect(sig0).not.toBe(sig1);
+  });
+
+  it('should handle hex string inputs', () => {
+    const wallet = generateEvmWallet();
+    const txData = {
+      nonce: '0x5',
+      maxFeePerGas: '0x6fc23ac00',
+      maxPriorityFeePerGas: '0x3b9aca00',
+      gas: '0x5208',
+      to: '0x' + 'cd'.repeat(20),
+      value: '0xDE0B6B3A7640000',
+      data: '0x',
+      chainId: 8453,
+    };
+    const signedHex = signEip1559EvmTransaction(txData, wallet.privateKey);
+    expect(signedHex).toMatch(/^0x02[0-9a-f]+$/);
+  });
+});
+
+// ============= Prepare / Submit API =============
+
+describe('prepareTransaction', () => {
+  it('should call /execution/prepare with correct params', async () => {
+    const origFetch = global.fetch;
+    const mockResponse = { needsApproval: false, swapTxData: { nonce: 0, to: '0xabc' } };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify(mockResponse),
+    });
+
+    const result = await prepareTransaction({
+      mode: 'standard',
+      chain: 'evm',
+      chainId: '8453',
+      walletAddress: '0x1234',
+      quote: { aggregator: 'test' },
+    });
+
+    expect(result).toEqual(mockResponse);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/execution/prepare'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+
+    global.fetch = origFetch;
+  });
+
+  it('should throw on non-OK response', async () => {
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({ code: 'INVALID_PARAMS', message: 'Bad quote' }),
+    });
+
+    await expect(prepareTransaction({ mode: 'standard', chain: 'evm', chainId: '1', walletAddress: '0x1', quote: {} }))
+      .rejects.toThrow('Bad quote');
+
+    global.fetch = origFetch;
+  });
+
+  it('should throw on non-JSON response', async () => {
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: async () => '<html>Bad Gateway</html>',
+    });
+
+    await expect(prepareTransaction({ mode: 'standard', chain: 'evm', chainId: '1', walletAddress: '0x1', quote: {} }))
+      .rejects.toThrow('non-JSON');
+
+    global.fetch = origFetch;
+  });
+});
+
+describe('submitExecution', () => {
+  it('should call /execution/standard with correct params', async () => {
+    const origFetch = global.fetch;
+    const mockResponse = { txHash: '0xabc123', success: true };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify(mockResponse),
+    });
+
+    const result = await submitExecution({
+      chain: 'evm',
+      chainId: '8453',
+      signedTransaction: '0xsigned',
+      aggregator: 'test',
+    });
+
+    expect(result).toEqual(mockResponse);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/execution/standard'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+
+    global.fetch = origFetch;
+  });
+
+  it('should retry on 502/503 non-JSON responses', async () => {
+    const origFetch = global.fetch;
+    let callCount = 0;
+    global.fetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount <= 2) {
+        return { ok: false, status: 502, text: async () => '<html>Bad Gateway</html>' };
+      }
+      return { ok: true, text: async () => JSON.stringify({ txHash: '0xok', success: true }) };
+    });
+
+    const result = await submitExecution(
+      { chain: 'evm', chainId: '1', signedTransaction: '0x' },
+      { retries: 2, retryDelayMs: 10 },
+    );
+    expect(result.success).toBe(true);
+    expect(callCount).toBe(3);
+
+    global.fetch = origFetch;
   });
 });
 
@@ -632,6 +785,22 @@ describe('buildTradingCommands', () => {
       }],
     }, 'ethereum');
 
+    // Mock prepare + submit APIs so execution proceeds past validation
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockImplementation(async (url) => {
+      if (url.includes('/execution/prepare')) {
+        return { ok: true, text: async () => JSON.stringify({
+          needsApproval: false,
+          swapTxData: { nonce: 0, maxFeePerGas: '1000000000', maxPriorityFeePerGas: '100000000', gas: '200000', to: '0xabc', value: '0', data: '0x1234', chainId: 1 },
+        })};
+      }
+      if (url.includes('/execution/standard')) {
+        return { ok: true, text: async () => JSON.stringify({ txHash: '0xabc', success: true }) };
+      }
+      // waitForReceipt RPC call
+      return { ok: true, json: async () => ({ result: { status: '0x1', blockNumber: '0x1' } }) };
+    });
+
     const logs = [];
     const cmds = buildTradingCommands({
       errorOutput: (msg) => logs.push(msg),
@@ -643,6 +812,7 @@ describe('buildTradingCommands', () => {
     expect(logs.some(l => l.includes('non-zero tx.value'))).toBe(false);
     expect(logs.some(l => l.includes('value mismatch'))).toBe(false);
 
+    global.fetch = origFetch;
     delete process.env.NANSEN_WALLET_PASSWORD;
   });
 
@@ -662,6 +832,22 @@ describe('buildTradingCommands', () => {
       }],
     }, 'ethereum');
 
+    // Mock prepare + submit APIs so execution proceeds past validation
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockImplementation(async (url) => {
+      if (url.includes('/execution/prepare')) {
+        return { ok: true, text: async () => JSON.stringify({
+          needsApproval: false,
+          swapTxData: { nonce: 0, maxFeePerGas: '1000000000', maxPriorityFeePerGas: '100000000', gas: '200000', to: '0xabc', value: '1000000000000000000', data: '0x1234', chainId: 1 },
+        })};
+      }
+      if (url.includes('/execution/standard')) {
+        return { ok: true, text: async () => JSON.stringify({ txHash: '0xabc', success: true }) };
+      }
+      // waitForReceipt RPC call
+      return { ok: true, json: async () => ({ result: { status: '0x1', blockNumber: '0x1' } }) };
+    });
+
     const logs = [];
     const cmds = buildTradingCommands({
       errorOutput: (msg) => logs.push(msg),
@@ -673,6 +859,7 @@ describe('buildTradingCommands', () => {
     expect(logs.some(l => l.includes('non-zero tx.value'))).toBe(false);
     expect(logs.some(l => l.includes('value mismatch'))).toBe(false);
 
+    global.fetch = origFetch;
     delete process.env.NANSEN_WALLET_PASSWORD;
   });
 
@@ -776,7 +963,7 @@ describe('API error handling', () => {
     global.fetch = origFetch;
   });
 
-  it('should surface UPSTREAM_BROADCAST_ERROR from execute API', async () => {
+  it('should surface UPSTREAM_BROADCAST_ERROR from submit API', async () => {
     const origFetch = global.fetch;
     const errorBody = JSON.stringify({
       code: 'UPSTREAM_BROADCAST_ERROR',
@@ -788,10 +975,10 @@ describe('API error handling', () => {
       text: async () => errorBody,
     });
 
-    const { executeTransaction } = await import('../trading.js');
-    await expect(executeTransaction({
+    await expect(submitExecution({
       signedTransaction: 'test',
       chain: 'solana',
+      chainId: '501',
     })).rejects.toThrow('simulation failed');
 
     global.fetch = origFetch;

--- a/src/trading.js
+++ b/src/trading.js
@@ -9,7 +9,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { exportWallet, getDefaultAddress, showWallet, listWallets } from './wallet.js';
-import { base58Decode } from './transfer.js';
+
 import { keccak256, signSecp256k1, rlpEncode } from './crypto.js';
 
 // ============= Constants =============
@@ -80,16 +80,68 @@ export async function getQuote(params) {
 }
 
 /**
- * Broadcast a signed transaction via the Nansen Trading API.
+ * Call POST /execution/prepare to build transactions server-side.
+ * The server handles nonce, gas estimation, approval building, and simulation.
  *
  * @param {object} params
- * @param {string} params.signedTransaction - Base64 (Solana) or 0x hex (EVM)
- * @param {string} [params.chain] - Target chain name
- * @param {string} [params.requestId] - Optional Jupiter request ID (Solana only)
- * @param {boolean} [params.simulate] - Run pre-broadcast simulation
- * @returns {Promise<object>} Execution result
+ * @param {string} params.mode - Execution mode ('standard')
+ * @param {string} params.chain - Chain type ('evm' or 'solana')
+ * @param {string} params.chainId - Chain ID as string
+ * @param {string} params.walletAddress - Wallet address
+ * @param {object} params.quote - Quote object from the saved quote file
+ * @param {boolean} [params.skipSimulation] - Skip pre-broadcast simulation
+ * @returns {Promise<object>} Prepare result with swapTxData, approvalTxData, needsApproval, etc.
  */
-export async function executeTransaction(params, { retries = 2, retryDelayMs = 1500 } = {}) {
+export async function prepareTransaction(params) {
+  const headers = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  };
+  if (process.env.NANSEN_API_KEY) {
+    headers['Authorization'] = `Bearer ${process.env.NANSEN_API_KEY}`;
+  }
+
+  const res = await fetch(`${TRADING_API_URL}/execution/prepare`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(params),
+  });
+
+  const text = await res.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw Object.assign(
+      new Error(`Prepare API returned non-JSON response (status ${res.status}). This may be a Cloudflare challenge or server error.`),
+      { code: 'PREPARE_FAILED', status: res.status, details: text.slice(0, 200) }
+    );
+  }
+
+  if (!res.ok) {
+    const code = body.code || 'PREPARE_ERROR';
+    const msg = body.message || `Prepare request failed with status ${res.status}`;
+    throw Object.assign(new Error(msg), { code, status: res.status, details: body.details });
+  }
+
+  return body;
+}
+
+/**
+ * Call POST /execution/standard to broadcast signed transactions.
+ * The server handles approval broadcast + wait + swap broadcast.
+ *
+ * @param {object} params
+ * @param {string} params.chain - Chain type ('evm' or 'solana')
+ * @param {string} params.chainId - Chain ID as string
+ * @param {string} params.signedTransaction - Signed swap tx (base64 for Solana, 0x hex for EVM)
+ * @param {string} [params.signedApprovalTransaction] - Signed approval tx (EVM only)
+ * @param {string} [params.aggregator] - Aggregator name
+ * @param {string} [params.requestId] - Request ID (Solana/Jupiter)
+ * @param {string} [params.walletAddress] - Wallet address
+ * @returns {Promise<object>} { txHash, success, error? }
+ */
+export async function submitExecution(params, { retries = 2, retryDelayMs = 1500 } = {}) {
   const headers = {
     'Content-Type': 'application/json',
     'Accept': 'application/json',
@@ -104,7 +156,7 @@ export async function executeTransaction(params, { retries = 2, retryDelayMs = 1
       await new Promise(r => setTimeout(r, retryDelayMs));
     }
 
-    const res = await fetch(`${TRADING_API_URL}/execute`, {
+    const res = await fetch(`${TRADING_API_URL}/execution/standard`, {
       method: 'POST',
       headers,
       body: JSON.stringify(params),
@@ -115,11 +167,10 @@ export async function executeTransaction(params, { retries = 2, retryDelayMs = 1
     try {
       body = JSON.parse(text);
     } catch {
-      const chainType = params.chain && CHAIN_MAP[params.chain]?.type;
       const feeHint = res.status === 502
-        ? chainType === 'solana'
+        ? params.chain === 'solana'
           ? ' This often means the transaction failed simulation — check that you have enough SOL for fees (~0.005 SOL minimum).'
-          : chainType === 'evm'
+          : params.chain === 'evm'
             ? ' This often means the transaction failed simulation — check that you have enough ETH for gas fees.'
             : ''
         : '';
@@ -291,30 +342,6 @@ export function signEvmTransaction(txData, privateKeyHex, chain, nonce) {
   return signLegacyTransaction(tx, privateKeyHex);
 }
 
-/**
- * Fetch the pending nonce for an EVM address.
- * @param {string} chain - Chain name
- * @param {string} address - 0x address
- * @returns {Promise<number>} Nonce
- */
-export async function getEvmNonce(chain, address) {
-  const rpcUrl = EVM_RPC_URLS[chain];
-  if (!rpcUrl) throw new Error(`No RPC URL configured for chain: ${chain}`);
-
-  const res = await fetch(rpcUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'eth_getTransactionCount',
-      params: [address, 'pending'],
-    }),
-  });
-  const body = await res.json();
-  if (body.error) throw new Error(`RPC error: ${body.error.message}`);
-  return parseInt(body.result, 16);
-}
 
 /**
  * Wait for an EVM transaction to be confirmed on-chain.
@@ -356,130 +383,53 @@ export async function waitForReceipt(chain, txHash, timeoutMs = 30000, pollMs = 
   throw new Error(`Transaction receipt not found after ${timeoutMs}ms. Tx: ${txHash}`);
 }
 
-/**
- * Simulate an EVM transaction via eth_call before broadcasting.
- * Returns { success: true } or { success: false, reason: string }.
- */
-export async function simulateEvmCall(chain, { from, to, data, value, gas }) {
-  const rpcUrl = EVM_RPC_URLS[chain];
-  if (!rpcUrl) return { success: true }; // Can't simulate, skip
 
-  try {
-    const callObj = { from, to, data, value: value || '0x0' };
-    if (gas) callObj.gas = gas; // Pass gas limit to catch under-gassed quotes
-    const res = await fetch(rpcUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'eth_call',
-        params: [callObj, 'latest'],
-      }),
-    });
-    const body = await res.json();
-    if (body.error) {
-      const reason = body.error.message || 'unknown';
-      return { success: false, reason };
-    }
-    return { success: true };
-  } catch {
-    return { success: true }; // Network error — don't block, let broadcast decide
-  }
-}
+// ============= EIP-1559 (Type 2) EVM Transaction Signing =============
 
 /**
- * Estimate gas for an EVM transaction. Returns the gas estimate or null on failure.
- * Used to fix under-gassed quotes from aggregators.
- */
-export async function estimateEvmGas(chain, { from, to, data, value }) {
-  const rpcUrl = EVM_RPC_URLS[chain];
-  if (!rpcUrl) return null;
-
-  try {
-    const res = await fetch(rpcUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'eth_estimateGas',
-        params: [{ from, to, data, value: value || '0x0' }],
-      }),
-    });
-    const body = await res.json();
-    if (body.error) return null;
-    return parseInt(body.result, 16);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Check ERC-20 allowance for a given owner/spender pair.
- * Returns the allowance as a BigInt, or 0n on failure.
- */
-export async function checkErc20Allowance(chain, tokenAddress, ownerAddress, spenderAddress) {
-  const rpcUrl = EVM_RPC_URLS[chain];
-  if (!rpcUrl) return 0n;
-
-  try {
-    // allowance(address,address) selector = 0xdd62ed3e
-    const data = '0xdd62ed3e'
-      + ownerAddress.slice(2).toLowerCase().padStart(64, '0')
-      + spenderAddress.slice(2).toLowerCase().padStart(64, '0');
-    const res = await fetch(rpcUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'eth_call',
-        params: [{ to: tokenAddress, data }, 'latest'],
-      }),
-    });
-    const body = await res.json();
-    if (body.error || !body.result) return 0n;
-    return BigInt(body.result);
-  } catch {
-    return 0n;
-  }
-}
-
-/**
- * Send an ERC-20 approval transaction.
- * Required before swapping non-native EVM tokens.
+ * Sign an EIP-1559 (type 2) EVM transaction.
+ * Used for transactions returned by /execution/prepare which include
+ * maxFeePerGas/maxPriorityFeePerGas instead of gasPrice.
  *
- * @param {string} tokenAddress - ERC-20 token contract
- * @param {string} spenderAddress - Approval target (from quote.approvalAddress)
- * @param {string} privateKeyHex - Wallet private key
- * @param {string} chain - Chain name
- * @param {number} nonce - Account nonce
- * @returns {string} 0x-prefixed signed approval tx hex
+ * @param {object} txData - { nonce, maxFeePerGas, maxPriorityFeePerGas, gas, to, value, data, chainId }
+ * @param {string} privateKeyHex - 32-byte private key as hex
+ * @returns {string} 0x-prefixed signed transaction hex
  */
-// ⚠️ SECURITY: ERC-20 approval signing - requires thorough review
-export function buildApprovalTransaction(tokenAddress, spenderAddress, privateKeyHex, chain, nonce, gasPrice) {
-  const chainConfig = CHAIN_MAP[chain];
-  if (!chainConfig) throw new Error(`Unsupported chain: ${chain}`);
+export function signEip1559EvmTransaction(txData, privateKeyHex) {
+  const chainId = BigInt(txData.chainId);
+  const nonce = BigInt(txData.nonce || 0);
+  const maxPriorityFeePerGas = BigInt(txData.maxPriorityFeePerGas || 0);
+  const maxFeePerGas = BigInt(txData.maxFeePerGas || 0);
+  const gasLimit = BigInt(txData.gas || txData.gasLimit || 210000);
+  const value = BigInt(txData.value || 0);
 
-  // ERC-20 approve(address spender, uint256 amount) selector = 0x095ea7b3
-  // Approve max uint256
-  const MAX_UINT256_HEX = 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
-  const data = '0x095ea7b3'
-    + spenderAddress.slice(2).toLowerCase().padStart(64, '0')
-    + MAX_UINT256_HEX;
+  const bigIntToHex = (n) => n === 0n ? '0x' : '0x' + n.toString(16);
 
-  const tx = {
-    nonce,
-    gasPrice: toHex(gasPrice || '1000000'),
-    gasLimit: '0x186a0', // 100000
-    to: tokenAddress,
-    value: '0x0',
-    data,
-    chainId: chainConfig.chainId,
-  };
+  const txFields = [
+    bigIntToHex(chainId),
+    bigIntToHex(nonce),
+    bigIntToHex(maxPriorityFeePerGas),
+    bigIntToHex(maxFeePerGas),
+    bigIntToHex(gasLimit),
+    txData.to,
+    bigIntToHex(value),
+    txData.data || '0x',
+    [], // accessList
+  ];
 
-  return signLegacyTransaction(tx, privateKeyHex);
+  const unsigned = rlpEncode(txFields);
+  const txHash = keccak256(Buffer.concat([Buffer.from([0x02]), unsigned]));
+  const sig = signSecp256k1(txHash, Buffer.from(privateKeyHex, 'hex'));
+
+  const signed = rlpEncode([
+    ...txFields,
+    bigIntToHex(BigInt(sig.v)),
+    '0x' + sig.r.toString('hex'),
+    '0x' + sig.s.toString('hex'),
+  ]);
+
+  const rawTx = Buffer.concat([Buffer.from([0x02]), signed]);
+  return '0x' + rawTx.toString('hex');
 }
 
 // ============= Legacy (Type 0) EVM Transaction Signing =============
@@ -856,33 +806,12 @@ EXAMPLES:
           errorOutput('');
 
           try {
-            let signedTransaction;
-            let requestId;
-
-            if (chainType === 'solana') {
-              // Solana: transaction is either a base64 string (Jupiter) or an object
-              // with a base58-encoded `data` field (OKX). Normalize to base64.
-              let txBase64 = currentQuote.transaction;
-              if (typeof txBase64 === 'object' && txBase64.data) {
-                txBase64 = base58Decode(txBase64.data).toString('base64');
-              }
-              errorOutput('  Signing Solana transaction...');
-              signedTransaction = signSolanaTransaction(txBase64, exported.solana.privateKey);
-              requestId = currentQuote.metadata?.requestId;
-
-            } else {
-              // EVM: quote.transaction is { to, data, value, gas, gasPrice }
-              const walletAddress = exported.evm.address;
-
-              // Handle approval if needed — skip for native ETH
-              // Check existing allowance first to avoid unnecessary approve txs
-              // (industry standard: LiFi SDK checkAllowance, 1inch Permit2)
+            // Client-side tx.value validation (EVM only).
+            // ERC-20 swaps transfer tokens via calldata, so value must be 0.
+            // Native ETH swaps must have value matching the quoted inAmount.
+            // A compromised API could attach a large value to drain ETH silently.
+            if (chainType === 'evm') {
               const isNative = isNativeToken(currentQuote.inputMint);
-
-              // Validate transaction.value matches the swap type.
-              // ERC-20 swaps transfer tokens via calldata, so value must be 0.
-              // Native ETH swaps must have value matching the quoted inAmount.
-              // A compromised API could attach a large value to drain ETH silently.
               const txValue = BigInt(currentQuote.transaction.value || '0');
               if (isNative) {
                 const expectedValue = BigInt(currentQuote.inAmount || currentQuote.inputAmount || '0');
@@ -900,128 +829,68 @@ EXAMPLES:
                   continue;
                 }
               }
-
-              if (currentQuote.approvalAddress && !isNative) {
-                // Check if sufficient allowance already exists
-                const inputAmount = BigInt(currentQuote.inputAmount || currentQuote.inAmount || currentQuote.transaction?.value || '0');
-                const existingAllowance = await checkErc20Allowance(
-                  chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress
-                );
-
-                if (existingAllowance >= inputAmount && existingAllowance > 0n) {
-                  errorOutput(`  ✓ Sufficient allowance exists for ${quoteName}, skipping approval`);
-                } else {
-                  errorOutput(`  ⚠ Approval required → ${currentQuote.approvalAddress}`);
-                  errorOutput(`  Sending approval tx...`);
-                  const approvalNonce = await getEvmNonce(chain, walletAddress);
-
-                  const approvalGasPrice = currentQuote.transaction?.gasPrice || currentQuote.transaction?.maxFeePerGas || '1000000';
-                  const approvalTxHex = buildApprovalTransaction(
-                    currentQuote.inputMint,
-                    currentQuote.approvalAddress,
-                    exported.evm.privateKey,
-                    chain,
-                    approvalNonce,
-                    approvalGasPrice,
-                  );
-
-                  const approvalResult = await executeTransaction({
-                    signedTransaction: approvalTxHex,
-                    chain,
-                    simulate: !noSimulate,
-                  });
-
-                  if (approvalResult.status !== 'Success') {
-                    errorOutput(`  ❌ Approval failed for ${quoteName}: ${approvalResult.error || 'unknown error'}`);
-                    if (qi + 1 < endIndex) errorOutput(`  Trying next quote...`);
-                    lastQuoteError = `${quoteName} approval failed`;
-                    continue;
-                  }
-
-                  errorOutput(`  Waiting for approval confirmation...`);
-                  try {
-                    const receipt = await waitForReceipt(chain, approvalResult.txHash);
-                    errorOutput(`  ✓ Approval confirmed in block ${parseInt(receipt.blockNumber, 16)}: ${approvalResult.txHash}`);
-                  } catch (receiptErr) {
-                    errorOutput(`  ❌ Approval may not have confirmed: ${receiptErr.message}`);
-                    if (qi + 1 < endIndex) errorOutput(`  Trying next quote...`);
-                    lastQuoteError = `${quoteName} approval unconfirmed`;
-                    continue;
-                  }
-                  // Wait for RPC state propagation after approval
-                  await new Promise(r => setTimeout(r, 2000));
-                  errorOutput('');
-                }
-              }
-
-              // Pre-flight simulation (EVM only) — catch logic reverts before spending gas
-              // Runs AFTER approval so eth_call sees the current allowance state
-              // Simulates WITHOUT gas limit to check swap logic; gas re-estimation is separate
-              if (!noSimulate) {
-                const txData = currentQuote.transaction;
-                const sim = await simulateEvmCall(chain, {
-                  from: walletAddress,
-                  to: txData.to,
-                  data: txData.data,
-                  value: txData.value ? '0x' + BigInt(txData.value).toString(16) : '0x0',
-                });
-                if (!sim.success) {
-                  errorOutput(`  ⚠ Simulation failed for ${quoteName}: ${sim.reason}`);
-                  if (qi + 1 < endIndex) errorOutput(`  Trying next quote...`);
-                  lastQuoteError = `${quoteName} simulation failed: ${sim.reason}`;
-                  continue;
-                }
-              }
-
-              // Use the Trading API's gas estimation (quote.gas) directly.
-              // The API already applies a 1.5x buffer over eth_estimateGas.
-              // Skip client-side re-estimation — it adds latency and the API value is reliable.
-              const txData = currentQuote.transaction;
-              const apiGas = parseInt(currentQuote.gas || "0");
-              const txGas = parseInt(txData.gas || txData.gasLimit || "0");
-              const finalGas = apiGas > 0 ? apiGas : txGas;
-              if (finalGas !== txGas) {
-                errorOutput(`  ℹ Using API gas ${finalGas} (tx.gas was ${txGas})`);
-              }
-              if (txData.gasLimit) txData.gasLimit = String(finalGas);
-              else txData.gas = String(finalGas);
-
-              errorOutput('  Fetching nonce...');
-              await new Promise(r => setTimeout(r, 1000));
-              const nonce = await getEvmNonce(chain, walletAddress);
-              errorOutput(`  Nonce: ${nonce}`);
-
-              errorOutput('  Signing EVM transaction...');
-              signedTransaction = signEvmTransaction(
-                currentQuote.transaction,
-                exported.evm.privateKey,
-                chain,
-                nonce
-              );
             }
 
+            // Step 1: Prepare — server handles nonce, gas, approval building, simulation
+            const walletAddress = chainType === 'solana' ? exported.solana.address : exported.evm.address;
+            errorOutput('  Preparing transaction...');
+            const prepareResult = await prepareTransaction({
+              mode: 'standard',
+              chain: chainConfig.type,
+              chainId: String(chainConfig.chainId),
+              walletAddress,
+              quote: currentQuote,
+              skipSimulation: noSimulate || false,
+            });
+
+            // Step 2: Sign locally
+            let signedTransaction;
+            let signedApprovalTransaction;
+
+            if (chainType === 'solana') {
+              errorOutput('  Signing Solana transaction...');
+              signedTransaction = signSolanaTransaction(prepareResult.transaction, exported.solana.privateKey);
+            } else {
+              // EVM: sign approval if needed, then sign swap
+              if (prepareResult.needsApproval && prepareResult.approvalTxData) {
+                errorOutput('  Signing approval transaction...');
+                signedApprovalTransaction = prepareResult.approvalTxData.maxFeePerGas
+                  ? signEip1559EvmTransaction(prepareResult.approvalTxData, exported.evm.privateKey)
+                  : signEvmTransaction(prepareResult.approvalTxData, exported.evm.privateKey, chain, prepareResult.approvalTxData.nonce);
+              }
+              errorOutput('  Signing swap transaction...');
+              signedTransaction = prepareResult.swapTxData.maxFeePerGas
+                ? signEip1559EvmTransaction(prepareResult.swapTxData, exported.evm.privateKey)
+                : signEvmTransaction(prepareResult.swapTxData, exported.evm.privateKey, chain, prepareResult.swapTxData.nonce);
+            }
+
+            // Step 3: Submit — server handles approval broadcast + wait + swap broadcast
             errorOutput('  Broadcasting...');
-            const execParams = {
+            const submitParams = {
+              chain: chainConfig.type,
+              chainId: String(chainConfig.chainId),
               signedTransaction,
-              chain,
-              simulate: !noSimulate,
+              aggregator: currentQuote.aggregator,
+              walletAddress,
             };
-            if (requestId) execParams.requestId = requestId;
+            if (signedApprovalTransaction) submitParams.signedApprovalTransaction = signedApprovalTransaction;
+            if (prepareResult.requestId) submitParams.requestId = prepareResult.requestId;
+            if (currentQuote.metadata?.requestId) submitParams.requestId = currentQuote.metadata.requestId;
 
-            const result = await executeTransaction(execParams);
+            const result = await submitExecution(submitParams);
 
-            if (result.status === 'Success') {
-              const txId = result.signature || result.txHash;
+            if (result.success) {
+              const txId = result.txHash;
               const explorerUrl = chainConfig.explorer + txId;
 
               // For EVM: verify the tx actually succeeded on-chain
-              if (chainType === 'evm' && result.txHash) {
+              if (chainType === 'evm' && txId) {
                 errorOutput('  Verifying on-chain status...');
                 try {
-                  await waitForReceipt(chain, result.txHash);
+                  await waitForReceipt(chain, txId);
                 } catch (receiptErr) {
                   errorOutput(`\n  ⚠ Transaction was broadcast but REVERTED on-chain!`);
-                  errorOutput(`    Tx Hash:   ${result.txHash}`);
+                  errorOutput(`    Tx Hash:   ${txId}`);
                   errorOutput(`    Explorer:  ${explorerUrl}`);
                   errorOutput(`    Error:     ${receiptErr.message}`);
                   if (qi + 1 < endIndex) {
@@ -1037,24 +906,15 @@ EXAMPLES:
               }
 
               errorOutput(`\n  ✓ Transaction successful!`);
-              errorOutput(`    Status:      ${result.status}`);
-              errorOutput(`    ${result.signature ? 'Signature' : 'Tx Hash'}:   ${txId}`);
-              errorOutput(`    Chain:       ${chainConfig.name} (${result.chainType})`);
-              errorOutput(`    Broadcaster: ${result.broadcaster}`);
-              errorOutput(`    Explorer:    ${explorerUrl}`);
-
-              if (result.swapEvents?.length) {
-                errorOutput(`    Swaps:`);
-                result.swapEvents.forEach(e => {
-                  errorOutput(`      ${e.inputAmount} ${e.inputMint?.slice(0, 8)}... → ${e.outputAmount} ${e.outputMint?.slice(0, 8)}...`);
-                });
-              }
+              errorOutput(`    Tx Hash:   ${txId}`);
+              errorOutput(`    Chain:     ${chainConfig.name}`);
+              errorOutput(`    Explorer:  ${explorerUrl}`);
               errorOutput('');
               return undefined; // Success — done
             } else {
-              errorOutput(`\n  ✗ Quote ${quoteName} failed: ${result.status}`);
+              errorOutput(`\n  ✗ Quote ${quoteName} failed`);
               if (result.error) errorOutput(`    Error:  ${result.error}`);
-              lastQuoteError = `${quoteName}: ${result.error || result.status}`;
+              lastQuoteError = `${quoteName}: ${result.error || 'unknown'}`;
               if (qi + 1 < endIndex) errorOutput(`  Trying next quote...`);
             }
 


### PR DESCRIPTION
## Summary

- Replace single `/execute` call with two-step server-side flow: `/execution/prepare` + `/execution/standard`
- Server now handles nonce, gas estimation, approval building, simulation, and broadcast sequencing
- Add `signEip1559EvmTransaction()` for type 2 transactions returned by the prepare endpoint
- Remove client-side RPC functions no longer needed: `getEvmNonce`, `simulateEvmCall`, `estimateEvmGas`, `checkErc20Allowance`, `buildApprovalTransaction`
- Client-side tx.value validation (security check) is preserved

## Blocked on

- **Cloudflare WAF**: `/execution/prepare` returns 403 on `trading-api.nansen.ai` — the route needs to be allowlisted in Cloudflare (the app code requires no auth, same as `/execute`)

## Follow-up (superapp side)

- Add `'cli'` to `ExecutionSourceSchema` and `GaslessSourceSchema` in `trading/src/schemas/execution.ts` and `trading/src/schemas/execute-gasless.ts`, so CLI swaps are tagged in BI tracking (currently omitted since the schema only allows `'web' | 'mobile' | 'mobile_agent'`)

## Test plan

- [x] `npm test` — all 584 unit tests pass
- [ ] e2e `npm run test:swap` — blocked on Cloudflare WAF allowlisting `/execution/*`
- [ ] Manual test on Solana after Cloudflare unblock
- [ ] Manual test on EVM (Base) after Cloudflare unblock

🤖 Generated with [Claude Code](https://claude.com/claude-code)