### PR TITLE
fix: restrict @claude trigger to org members and collaborators

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -20,11 +20,15 @@ concurrency:
 
 jobs:
   claude-review:
-    # Run on PR events, or on @claude mentions in comments
+    # Run on PR events, or on @claude mentions in comments (org members only)
     if: |
       (github.event_name == 'pull_request') ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude'))
+      (
+        (
+          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude'))
+        ) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary
- Prevents external users from triggering Claude Code reviews on this public repo, which would burn Anthropic API credits
- Only OWNER, MEMBER, and COLLABORATOR author associations can now trigger @claude via comments
- PR-opened auto-reviews are unaffected

## Test plan
- [ ] Verify workflow syntax is valid (GitHub Actions will validate on push)
- [ ] Confirm auto-reviews still trigger on PR open/sync events
- [ ] Confirm @claude comments from org members still trigger reviews
- [ ] Confirm @claude comments from external users are ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)