### PR TITLE
feat: add Hyperliquid perps trading

### DIFF
--- a/.changeset/hyperliquid-perps.md
+++ b/.changeset/hyperliquid-perps.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add Hyperliquid perpetuals trading via new `perps` command

--- a/README.md
+++ b/README.md
@@ -190,6 +190,57 @@ nansen schema --pretty                    # All commands
 nansen schema smart-money --pretty        # One command's options & return fields
 ```
 
+### `perps` - Hyperliquid Perpetuals Trading
+
+Trade Hyperliquid perpetuals directly from the CLI. Read-only commands (price, funding, orderbook, search, status, balance) work without credentials. Write commands require either `HL_SECRET_KEY` (32-byte private key) or the nansen wallet system.
+
+```bash
+# Auth: set private key in env (or use nansen wallet + NANSEN_WALLET_PASSWORD)
+export HL_SECRET_KEY=0xdeadbeef...        # 32-byte EVM private key
+export HL_ACCOUNT_ADDRESS=0x...           # Optional: agent wallet address override
+export HL_TESTNET=1                       # Optional: use testnet
+
+# Market data (no credentials needed)
+nansen perps price --symbol BTC
+nansen perps funding --symbol ETH
+nansen perps orderbook --symbol BTC --depth 5
+nansen perps search --query pepe
+
+# Account info
+nansen perps status
+nansen perps balance
+
+# Open a position (market order)
+nansen perps open --symbol BTC --side long --size 0.001
+
+# Open with leverage and limit price
+nansen perps open --symbol ETH --side short --size 0.1 --leverage 5 --isolated --price 3100
+
+# Close a position (fully or partially)
+nansen perps close --symbol BTC
+nansen perps close --symbol BTC --size 0.0005
+
+# Close everything
+nansen perps close-all
+
+# Reduce position by 50%
+nansen perps reduce --symbol BTC --percent 50
+
+# Set stop-loss / take-profit
+nansen perps set-sl --symbol BTC --price 60000
+nansen perps set-tp --symbol BTC --price 120000
+
+# Cancel orders
+nansen perps cancel --symbol BTC
+nansen perps cancel-all
+```
+
+**Auth options:**
+- `HL_SECRET_KEY` — 32-byte (64 hex char) EVM private key
+- `HL_ACCOUNT_ADDRESS` — Optional agent/sub-account address (key signs on its behalf)
+- `HL_TESTNET=1` — Use Hyperliquid testnet (mainnet is default)
+- Or: set `NANSEN_WALLET_PASSWORD` and use `--wallet <name>` to use the nansen wallet system
+
 ### `portfolio` / `perp` / `points` / `cache`
 
 See `nansen help` or `nansen schema --pretty` for full details.

--- a/src/__tests__/perps.test.js
+++ b/src/__tests__/perps.test.js
@@ -1,0 +1,707 @@
+/**
+ * Tests for perps module — Hyperliquid perpetuals trading.
+ *
+ * Covers: msgpack encoding, signing helpers, read commands (with mocked fetch),
+ * write command validation, and CLI command builder.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  msgpackEncode,
+  floatToWire,
+  floatToWirePrice,
+  computeActionHash,
+  buildPhantomAgentHash,
+  signL1Action,
+  deriveEvmAddress,
+  cmdStatus,
+  cmdBalance,
+  cmdPrice,
+  cmdFunding,
+  cmdOrderbook,
+  cmdSearch,
+  buildPerpsCommands,
+} from '../perps.js';
+import { generateEvmWallet } from '../wallet.js';
+
+// ============= Test Setup =============
+
+let originalHome;
+let tempDir;
+let originalEnv;
+
+beforeEach(() => {
+  originalHome = process.env.HOME;
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nansen-perps-test-'));
+  process.env.HOME = tempDir;
+
+  // Save env vars we'll modify
+  originalEnv = {
+    HL_SECRET_KEY: process.env.HL_SECRET_KEY,
+    HL_ACCOUNT_ADDRESS: process.env.HL_ACCOUNT_ADDRESS,
+    HL_TESTNET: process.env.HL_TESTNET,
+    NANSEN_WALLET_PASSWORD: process.env.NANSEN_WALLET_PASSWORD,
+  };
+  delete process.env.HL_SECRET_KEY;
+  delete process.env.HL_ACCOUNT_ADDRESS;
+  delete process.env.HL_TESTNET;
+  delete process.env.NANSEN_WALLET_PASSWORD;
+});
+
+afterEach(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(tempDir, { recursive: true, force: true });
+
+  // Restore env vars
+  for (const [k, v] of Object.entries(originalEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+// ============= MsgPack Encoding =============
+
+describe('msgpackEncode', () => {
+  it('should encode nil', () => {
+    expect(msgpackEncode(null)).toEqual(Buffer.from([0xc0]));
+    expect(msgpackEncode(undefined)).toEqual(Buffer.from([0xc0]));
+  });
+
+  it('should encode booleans', () => {
+    expect(msgpackEncode(true)).toEqual(Buffer.from([0xc3]));
+    expect(msgpackEncode(false)).toEqual(Buffer.from([0xc2]));
+  });
+
+  it('should encode positive fixint (0-127)', () => {
+    expect(msgpackEncode(0)).toEqual(Buffer.from([0x00]));
+    expect(msgpackEncode(127)).toEqual(Buffer.from([0x7f]));
+    expect(msgpackEncode(1)).toEqual(Buffer.from([0x01]));
+  });
+
+  it('should encode uint8 (128-255)', () => {
+    expect(msgpackEncode(128)[0]).toBe(0xcc);
+    expect(msgpackEncode(255)[0]).toBe(0xcc);
+    expect(msgpackEncode(255)[1]).toBe(255);
+  });
+
+  it('should encode uint16', () => {
+    expect(msgpackEncode(256)[0]).toBe(0xcd);
+  });
+
+  it('should encode uint32', () => {
+    expect(msgpackEncode(65536)[0]).toBe(0xce);
+  });
+
+  it('should encode negative fixint (-32 to -1)', () => {
+    expect(msgpackEncode(-1)).toEqual(Buffer.from([0xff]));
+    expect(msgpackEncode(-32)).toEqual(Buffer.from([0xe0]));
+  });
+
+  it('should encode int8', () => {
+    expect(msgpackEncode(-128)[0]).toBe(0xd0);
+  });
+
+  it('should encode floats as double (64-bit)', () => {
+    const encoded = msgpackEncode(3.14);
+    expect(encoded[0]).toBe(0xcb);
+    expect(encoded.length).toBe(9);
+    expect(encoded.readDoubleBE(1)).toBeCloseTo(3.14);
+  });
+
+  it('should encode short strings (fixstr)', () => {
+    const encoded = msgpackEncode('abc');
+    expect(encoded[0]).toBe(0xa0 | 3);
+    expect(encoded.subarray(1).toString()).toBe('abc');
+  });
+
+  it('should encode empty string', () => {
+    expect(msgpackEncode('')).toEqual(Buffer.from([0xa0]));
+  });
+
+  it('should encode longer strings (str8)', () => {
+    const s = 'a'.repeat(32);
+    const encoded = msgpackEncode(s);
+    expect(encoded[0]).toBe(0xd9);
+    expect(encoded[1]).toBe(32);
+  });
+
+  it('should encode empty array', () => {
+    expect(msgpackEncode([])).toEqual(Buffer.from([0x90]));
+  });
+
+  it('should encode fixarray (1-15 items)', () => {
+    const encoded = msgpackEncode([1, 2, 3]);
+    expect(encoded[0]).toBe(0x90 | 3);
+  });
+
+  it('should encode array16 (16+ items)', () => {
+    const arr = new Array(16).fill(0);
+    expect(msgpackEncode(arr)[0]).toBe(0xdc);
+  });
+
+  it('should encode empty map', () => {
+    expect(msgpackEncode({})).toEqual(Buffer.from([0x80]));
+  });
+
+  it('should encode fixmap', () => {
+    const encoded = msgpackEncode({ a: 1 });
+    expect(encoded[0]).toBe(0x80 | 1);
+  });
+
+  it('should sort map keys deterministically', () => {
+    const enc1 = msgpackEncode({ b: 2, a: 1 });
+    const enc2 = msgpackEncode({ a: 1, b: 2 });
+    expect(enc1).toEqual(enc2);
+  });
+
+  it('should encode a realistic Hyperliquid order action', () => {
+    const action = {
+      type: 'order',
+      orders: [{ a: 0, b: true, p: '95000', s: '0.001', r: false, t: { limit: { tif: 'Ioc' } } }],
+      grouping: 'na',
+    };
+    const encoded = msgpackEncode(action);
+    expect(encoded).toBeInstanceOf(Buffer);
+    expect(encoded.length).toBeGreaterThan(0);
+  });
+
+  it('should throw for unsupported types', () => {
+    // Symbol is not supported
+    expect(() => msgpackEncode(Symbol('test'))).toThrow('unsupported type');
+  });
+});
+
+// ============= Wire Format Helpers =============
+
+describe('floatToWire', () => {
+  it('should format integer floats without decimal', () => {
+    expect(floatToWire(100)).toBe('100');
+    expect(floatToWire(0)).toBe('0');
+  });
+
+  it('should strip trailing zeros', () => {
+    expect(floatToWire(1.5)).toBe('1.5');
+    expect(floatToWire(0.001)).toBe('0.001');
+    expect(floatToWire(1.10000000)).toBe('1.1');
+  });
+
+  it('should handle negative zero', () => {
+    expect(floatToWire(-0)).toBe('0');
+  });
+});
+
+describe('floatToWirePrice', () => {
+  it('should round to 5 significant figures', () => {
+    // 95123.456789 → 5 sig figs → 95123
+    expect(floatToWirePrice(95123.456789)).toBe('95123');
+    // 0.001234567 → 5 sig figs → 0.0012346
+    expect(floatToWirePrice(0.001234567)).toBe('0.0012346');
+    // 1.23456789 → 5 sig figs → 1.2346
+    expect(floatToWirePrice(1.23456789)).toBe('1.2346');
+  });
+
+  it('should handle zero', () => {
+    expect(floatToWirePrice(0)).toBe('0');
+  });
+
+  it('should handle large prices', () => {
+    expect(floatToWirePrice(100000)).toBe('100000');
+    expect(floatToWirePrice(99999.9)).toBe('100000');
+  });
+});
+
+// ============= Action Hash =============
+
+describe('computeActionHash', () => {
+  it('should return a 32-byte buffer', () => {
+    const action = { type: 'order', orders: [], grouping: 'na' };
+    const hash = computeActionHash(action, null, 1234567890);
+    expect(hash).toBeInstanceOf(Buffer);
+    expect(hash.length).toBe(32);
+  });
+
+  it('should produce different hashes for different nonces', () => {
+    const action = { type: 'order', orders: [], grouping: 'na' };
+    const h1 = computeActionHash(action, null, 1000);
+    const h2 = computeActionHash(action, null, 2000);
+    expect(h1.toString('hex')).not.toBe(h2.toString('hex'));
+  });
+
+  it('should include vault address when provided', () => {
+    const action = { type: 'order', orders: [], grouping: 'na' };
+    const vaultAddr = '0x' + '12'.repeat(20);
+    const h1 = computeActionHash(action, null, 1000);
+    const h2 = computeActionHash(action, vaultAddr, 1000);
+    expect(h1.toString('hex')).not.toBe(h2.toString('hex'));
+  });
+
+  it('should be deterministic', () => {
+    const action = { type: 'cancel', cancels: [{ a: 0, o: 12345 }] };
+    const h1 = computeActionHash(action, null, 9999);
+    const h2 = computeActionHash(action, null, 9999);
+    expect(h1.toString('hex')).toBe(h2.toString('hex'));
+  });
+});
+
+// ============= Phantom Agent Hash =============
+
+describe('buildPhantomAgentHash', () => {
+  it('should return a 32-byte buffer', () => {
+    const actionHash = Buffer.alloc(32, 0xab);
+    const hash = buildPhantomAgentHash(actionHash, true);
+    expect(hash).toBeInstanceOf(Buffer);
+    expect(hash.length).toBe(32);
+  });
+
+  it('should differ for mainnet vs testnet', () => {
+    const actionHash = Buffer.alloc(32, 0x42);
+    const mainnetHash = buildPhantomAgentHash(actionHash, true);
+    const testnetHash = buildPhantomAgentHash(actionHash, false);
+    expect(mainnetHash.toString('hex')).not.toBe(testnetHash.toString('hex'));
+  });
+
+  it('should be deterministic', () => {
+    const actionHash = Buffer.alloc(32, 0x77);
+    const h1 = buildPhantomAgentHash(actionHash, true);
+    const h2 = buildPhantomAgentHash(actionHash, true);
+    expect(h1.toString('hex')).toBe(h2.toString('hex'));
+  });
+});
+
+// ============= signL1Action =============
+
+describe('signL1Action', () => {
+  it('should produce a valid signature with r/s/v', () => {
+    const wallet = generateEvmWallet();
+    const action = { type: 'order', orders: [], grouping: 'na' };
+    const sig = signL1Action(action, wallet.privateKey, null, Date.now(), true);
+
+    expect(sig.r).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(sig.s).toMatch(/^0x[0-9a-f]{64}$/);
+    expect([27, 28]).toContain(sig.v);
+  });
+
+  it('should produce deterministic signatures (RFC 6979)', () => {
+    const wallet = generateEvmWallet();
+    const action = { type: 'cancel', cancels: [{ a: 1, o: 42 }] };
+    const nonce = 1234567890;
+    const sig1 = signL1Action(action, wallet.privateKey, null, nonce, true);
+    const sig2 = signL1Action(action, wallet.privateKey, null, nonce, true);
+
+    expect(sig1.r).toBe(sig2.r);
+    expect(sig1.s).toBe(sig2.s);
+    expect(sig1.v).toBe(sig2.v);
+  });
+
+  it('should produce different signatures for mainnet vs testnet', () => {
+    const wallet = generateEvmWallet();
+    const action = { type: 'order', orders: [], grouping: 'na' };
+    const nonce = 999;
+    const mainSig = signL1Action(action, wallet.privateKey, null, nonce, true);
+    const testSig = signL1Action(action, wallet.privateKey, null, nonce, false);
+
+    expect(mainSig.r).not.toBe(testSig.r);
+  });
+
+  it('should accept 0x-prefixed private key', () => {
+    const wallet = generateEvmWallet();
+    const action = { type: 'order', orders: [], grouping: 'na' };
+    const sig = signL1Action(action, '0x' + wallet.privateKey, null, 123, true);
+    expect(sig.r).toMatch(/^0x/);
+  });
+});
+
+// ============= deriveEvmAddress =============
+
+describe('deriveEvmAddress', () => {
+  it('should derive address from private key', () => {
+    const wallet = generateEvmWallet();
+    const derived = deriveEvmAddress(wallet.privateKey);
+    expect(derived.toLowerCase()).toBe(wallet.address.toLowerCase());
+  });
+
+  it('should handle 0x-prefixed keys', () => {
+    const wallet = generateEvmWallet();
+    const derived = deriveEvmAddress('0x' + wallet.privateKey);
+    expect(derived.toLowerCase()).toBe(wallet.address.toLowerCase());
+  });
+
+  it('should return lowercase hex address with 0x prefix', () => {
+    const wallet = generateEvmWallet();
+    const derived = deriveEvmAddress(wallet.privateKey);
+    expect(derived).toMatch(/^0x[0-9a-f]{40}$/);
+  });
+});
+
+// ============= Read Commands (mocked fetch) =============
+
+describe('cmdPrice', () => {
+  it('should return price for a symbol', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ BTC: '95000.5', ETH: '3200.0' }),
+    });
+
+    const result = await cmdPrice({ symbol: 'BTC' });
+    expect(result.symbol).toBe('BTC');
+    expect(result.price).toBe(95000.5);
+  });
+
+  it('should throw when symbol not found', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ BTC: '95000' }),
+    });
+
+    await expect(cmdPrice({ symbol: 'NONEXISTENT' })).rejects.toThrow('No price found');
+  });
+
+  it('should throw when --symbol missing', async () => {
+    await expect(cmdPrice({})).rejects.toThrow('--symbol is required');
+  });
+});
+
+describe('cmdFunding', () => {
+  it('should return funding data for a symbol', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { universe: [{ name: 'BTC', szDecimals: 5 }, { name: 'ETH', szDecimals: 4 }] },
+        [
+          { funding: '0.0001', openInterest: '1234.5', markPx: '95000', dayNtlVlm: '100000000' },
+          { funding: '-0.00005', openInterest: '5000', markPx: '3200', dayNtlVlm: '50000000' },
+        ],
+      ],
+    });
+
+    const result = await cmdFunding({ symbol: 'BTC' });
+    expect(result.symbol).toBe('BTC');
+    expect(result.fundingRate).toBe(0.0001);
+    expect(result.openInterest).toBe(1234.5);
+    expect(result.markPrice).toBe(95000);
+  });
+
+  it('should throw when symbol not found', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ universe: [{ name: 'BTC' }] }, [{}]],
+    });
+
+    await expect(cmdFunding({ symbol: 'PEPE' })).rejects.toThrow('not found');
+  });
+
+  it('should throw when --symbol missing', async () => {
+    await expect(cmdFunding({})).rejects.toThrow('--symbol is required');
+  });
+});
+
+describe('cmdOrderbook', () => {
+  it('should return L2 book with bids and asks', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        levels: [
+          [{ px: '94990', sz: '0.5', n: 3 }, { px: '94980', sz: '1.2', n: 5 }],
+          [{ px: '95010', sz: '0.8', n: 2 }, { px: '95020', sz: '2.0', n: 7 }],
+        ],
+      }),
+    });
+
+    const result = await cmdOrderbook({ symbol: 'BTC', depth: '2' });
+    expect(result.symbol).toBe('BTC');
+    expect(result.bids).toHaveLength(2);
+    expect(result.asks).toHaveLength(2);
+    expect(result.bids[0].price).toBe(94990);
+    expect(result.asks[0].price).toBe(95010);
+  });
+
+  it('should respect depth limit', async () => {
+    const levels = new Array(20).fill(null).map((_, i) => ({ px: String(94000 - i), sz: '1', n: 1 }));
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ levels: [levels, levels] }),
+    });
+
+    const result = await cmdOrderbook({ symbol: 'BTC', depth: '5' });
+    expect(result.bids).toHaveLength(5);
+    expect(result.asks).toHaveLength(5);
+  });
+
+  it('should throw when --symbol missing', async () => {
+    await expect(cmdOrderbook({})).rejects.toThrow('--symbol is required');
+  });
+});
+
+describe('cmdSearch', () => {
+  it('should find matching symbols', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        universe: [
+          { name: 'BTC', szDecimals: 5 },
+          { name: 'PEPE', szDecimals: 0 },
+          { name: 'PEPECOIN', szDecimals: 0 },
+          { name: 'ETH', szDecimals: 4 },
+        ],
+      }),
+    });
+
+    const result = await cmdSearch({ query: 'pepe' });
+    expect(result.results).toHaveLength(2);
+    expect(result.results.map(r => r.symbol)).toEqual(['PEPE', 'PEPECOIN']);
+    expect(result.count).toBe(2);
+  });
+
+  it('should return empty results for no match', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ universe: [{ name: 'BTC' }, { name: 'ETH' }] }),
+    });
+
+    const result = await cmdSearch({ query: 'xyz' });
+    expect(result.results).toHaveLength(0);
+  });
+
+  it('should throw when --query missing', async () => {
+    await expect(cmdSearch({})).rejects.toThrow('--query is required');
+  });
+});
+
+describe('cmdStatus', () => {
+  it('should return positions for a given address', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        marginSummary: { accountValue: '10000.5', totalMarginUsed: '500' },
+        assetPositions: [
+          {
+            position: {
+              coin: 'BTC',
+              szi: '0.1',
+              entryPx: '90000',
+              unrealizedPnl: '500',
+              returnOnEquity: '0.05',
+              leverage: { type: 'cross', value: '10' },
+              liquidationPx: '80000',
+              marginUsed: '100',
+            },
+          },
+          {
+            position: { coin: 'ETH', szi: '0', entryPx: '3000', unrealizedPnl: '0', marginUsed: '0' },
+          },
+        ],
+      }),
+    });
+
+    const result = await cmdStatus({ address: '0x' + '12'.repeat(20) });
+    expect(result.equity).toBe(10000.5);
+    expect(result.positions).toHaveLength(1); // ETH filtered (szi=0)
+    expect(result.positions[0].symbol).toBe('BTC');
+    expect(result.positions[0].side).toBe('long');
+    expect(result.positionCount).toBe(1);
+  });
+
+  it('should use HL_ACCOUNT_ADDRESS env if no --address', async () => {
+    process.env.HL_ACCOUNT_ADDRESS = '0x' + 'ab'.repeat(20);
+    let capturedBody;
+    global.fetch = vi.fn().mockImplementation(async (url, opts) => {
+      capturedBody = JSON.parse(opts.body);
+      return {
+        ok: true,
+        json: async () => ({ marginSummary: {}, assetPositions: [] }),
+      };
+    });
+
+    await cmdStatus({});
+    expect(capturedBody.user).toBe('0x' + 'ab'.repeat(20));
+  });
+
+  it('should throw when no address available', async () => {
+    await expect(cmdStatus({})).rejects.toThrow(/address|wallet/i);
+  });
+});
+
+describe('cmdBalance', () => {
+  it('should return equity and margin summary', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        marginSummary: {
+          accountValue: '5000',
+          totalNtlPos: '1000',
+          totalRawUsd: '4500',
+          totalMarginUsed: '200',
+        },
+        assetPositions: [],
+      }),
+    });
+
+    const result = await cmdBalance({ address: '0x' + '11'.repeat(20) });
+    expect(result.equity).toBe(5000);
+    expect(result.totalMarginUsed).toBe(200);
+  });
+});
+
+// ============= CLI Builder =============
+
+describe('buildPerpsCommands', () => {
+  it('should return a handler for perps command', () => {
+    const cmds = buildPerpsCommands();
+    expect(typeof cmds.perps).toBe('function');
+  });
+
+  it('should return help for unknown subcommand', async () => {
+    const cmds = buildPerpsCommands();
+    const result = await cmds.perps(['unknown-sub'], null, {}, {});
+    expect(result.error).toMatch(/Unknown subcommand/);
+    expect(result.available).toContain('status');
+  });
+
+  it('should return help info for help subcommand', async () => {
+    const cmds = buildPerpsCommands();
+    const result = await cmds.perps(['help'], null, {}, {});
+    expect(Array.isArray(result.commands)).toBe(true);
+    expect(result.commands).toContain('open');
+    expect(result.commands).toContain('close');
+    expect(result.commands).toContain('price');
+  });
+
+  it('should require credentials for write commands', async () => {
+    const cmds = buildPerpsCommands();
+    // No HL_SECRET_KEY or NANSEN_WALLET_PASSWORD set
+    await expect(cmds.perps(['open'], null, {}, { symbol: 'BTC', side: 'long', size: '0.001' }))
+      .rejects.toThrow(/credentials|HL_SECRET_KEY/i);
+  });
+
+  it('should throw for missing --symbol on price', async () => {
+    const cmds = buildPerpsCommands();
+    await expect(cmds.perps(['price'], null, {}, {})).rejects.toThrow('--symbol is required');
+  });
+
+  it('should throw for missing --query on search', async () => {
+    const cmds = buildPerpsCommands();
+    await expect(cmds.perps(['search'], null, {}, {})).rejects.toThrow('--query is required');
+  });
+
+  it('should call price handler with mocked fetch', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ BTC: '95000', ETH: '3200' }),
+    });
+
+    const cmds = buildPerpsCommands();
+    const result = await cmds.perps(['price'], null, {}, { symbol: 'ETH' });
+    expect(result.symbol).toBe('ETH');
+    expect(result.price).toBe(3200);
+  });
+
+  it('should handle API errors gracefully', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error',
+    });
+
+    const cmds = buildPerpsCommands();
+    await expect(cmds.perps(['price'], null, {}, { symbol: 'BTC' }))
+      .rejects.toThrow(/Hyperliquid info API error/);
+  });
+});
+
+// ============= Write Command Validation =============
+
+describe('open command validation', () => {
+  it('should throw for missing --symbol', async () => {
+    process.env.HL_SECRET_KEY = '0x' + 'a'.repeat(64);
+    const cmds = buildPerpsCommands();
+    await expect(cmds.perps(['open'], null, {}, { side: 'long', size: '0.001' }))
+      .rejects.toThrow('--symbol is required');
+  });
+
+  it('should throw for invalid --side', async () => {
+    process.env.HL_SECRET_KEY = '0x' + 'a'.repeat(64);
+    const cmds = buildPerpsCommands();
+    await expect(cmds.perps(['open'], null, {}, { symbol: 'BTC', side: 'up', size: '0.001' }))
+      .rejects.toThrow('--side must be "long" or "short"');
+  });
+
+  it('should throw for missing --size', async () => {
+    process.env.HL_SECRET_KEY = '0x' + 'a'.repeat(64);
+    const cmds = buildPerpsCommands();
+    await expect(cmds.perps(['open'], null, {}, { symbol: 'BTC', side: 'long' }))
+      .rejects.toThrow('--size is required');
+  });
+
+  it('should throw for invalid --size (zero)', async () => {
+    process.env.HL_SECRET_KEY = '0x' + 'a'.repeat(64);
+
+    // Mock meta and mids calls
+    global.fetch = vi.fn().mockImplementation(async (url, opts) => {
+      const body = JSON.parse(opts.body);
+      if (body.type === 'meta') {
+        return { ok: true, json: async () => ({ universe: [{ name: 'BTC', szDecimals: 5 }] }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const cmds = buildPerpsCommands();
+    await expect(cmds.perps(['open'], null, {}, { symbol: 'BTC', side: 'long', size: '0' }))
+      .rejects.toThrow('positive number');
+  });
+});
+
+describe('close command validation', () => {
+  it('should throw for missing --symbol', async () => {
+    process.env.HL_SECRET_KEY = '0x' + 'a'.repeat(64);
+    const cmds = buildPerpsCommands();
+    await expect(cmds.perps(['close'], null, {}, {})).rejects.toThrow('--symbol is required');
+  });
+
+  it('should throw when no position found', async () => {
+    const wallet = generateEvmWallet();
+    process.env.HL_SECRET_KEY = wallet.privateKey;
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ marginSummary: {}, assetPositions: [] }),
+    });
+
+    const cmds = buildPerpsCommands();
+    await expect(cmds.perps(['close'], null, {}, { symbol: 'BTC' }))
+      .rejects.toThrow('No open position');
+  });
+});
+
+describe('cancel command validation', () => {
+  it('should throw for missing --symbol', async () => {
+    process.env.HL_SECRET_KEY = '0x' + 'a'.repeat(64);
+    const cmds = buildPerpsCommands();
+    await expect(cmds.perps(['cancel'], null, {}, {})).rejects.toThrow('--symbol is required');
+  });
+
+  it('should return 0 cancelled when no orders', async () => {
+    const wallet = generateEvmWallet();
+    process.env.HL_SECRET_KEY = wallet.privateKey;
+
+    let callCount = 0;
+    global.fetch = vi.fn().mockImplementation(async (url, opts) => {
+      const body = JSON.parse(opts.body);
+      callCount++;
+      if (body.type === 'meta') {
+        return { ok: true, json: async () => ({ universe: [{ name: 'BTC', szDecimals: 5 }] }) };
+      }
+      if (body.type === 'openOrders') {
+        return { ok: true, json: async () => [] };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const cmds = buildPerpsCommands();
+    const result = await cmds.perps(['cancel'], null, {}, { symbol: 'BTC' });
+    expect(result.cancelled).toBe(0);
+    expect(result.message).toMatch(/No open orders/);
+  });
+});

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,6 +6,7 @@
 import { NansenAPI, NansenError, ErrorCode, saveConfig, deleteConfig, getConfigFile, clearCache, getCacheDir, validateAddress, sleep } from './api.js';
 import { buildWalletCommands } from './wallet.js';
 import { buildTradingCommands } from './trading.js';
+import { buildPerpsCommands } from './perps.js';
 import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
@@ -288,6 +289,25 @@ export const SCHEMA = {
           },
           returns: ['address', 'address_label', 'realized_pnl', 'unrealized_pnl', 'total_pnl', 'trade_count', 'win_rate']
         }
+      }
+    },
+    'perps': {
+      description: 'Hyperliquid perpetuals trading — open/close positions, manage SL/TP, query market data',
+      subcommands: {
+        'status':     { description: 'All open positions and PnL', options: { address: { type: 'string', description: 'Wallet address (optional)' } }, returns: ['address', 'equity', 'totalMarginUsed', 'positions', 'positionCount'] },
+        'balance':    { description: 'USDC equity and margin summary', options: { address: { type: 'string' } }, returns: ['address', 'equity', 'totalNtlPos', 'totalRawUsd', 'totalMarginUsed'] },
+        'open':       { description: 'Open a new position', options: { symbol: { type: 'string', required: true, description: 'Asset symbol (e.g. BTC)' }, side: { type: 'string', required: true, description: 'long or short' }, size: { type: 'number', required: true, description: 'Size in base asset units' }, leverage: { type: 'number', description: 'Leverage multiplier' }, isolated: { type: 'boolean', description: 'Use isolated margin' }, price: { type: 'number', description: 'Limit price (omit for market order)' } }, returns: ['symbol', 'side', 'requestedSize', 'status', 'fills'] },
+        'close':      { description: 'Close a position', options: { symbol: { type: 'string', required: true }, size: { type: 'number', description: 'Partial close size (omit to close fully)' } }, returns: ['symbol', 'side', 'requestedSize', 'status', 'fills'] },
+        'close-all':  { description: 'Close all open positions', options: {}, returns: ['attempted', 'symbols', 'result'] },
+        'reduce':     { description: 'Reduce position by percentage', options: { symbol: { type: 'string', required: true }, percent: { type: 'number', description: 'Reduction percentage (default: 50)' } }, returns: ['symbol', 'side', 'requestedSize', 'status', 'fills'] },
+        'set-sl':     { description: 'Set stop-loss order', options: { symbol: { type: 'string', required: true }, price: { type: 'number', required: true, description: 'Trigger price' } }, returns: ['type', 'symbol', 'triggerPrice', 'result'] },
+        'set-tp':     { description: 'Set take-profit order', options: { symbol: { type: 'string', required: true }, price: { type: 'number', required: true, description: 'Trigger price' } }, returns: ['type', 'symbol', 'triggerPrice', 'result'] },
+        'cancel':     { description: 'Cancel open orders for symbol', options: { symbol: { type: 'string', required: true } }, returns: ['symbol', 'cancelled'] },
+        'cancel-all': { description: 'Cancel all open orders', options: {}, returns: ['cancelled'] },
+        'price':      { description: 'Get current mark price', options: { symbol: { type: 'string', required: true } }, returns: ['symbol', 'price'] },
+        'funding':    { description: 'Get funding rate', options: { symbol: { type: 'string', required: true } }, returns: ['symbol', 'fundingRate', 'openInterest', 'markPrice'] },
+        'orderbook':  { description: 'Get L2 order book', options: { symbol: { type: 'string', required: true }, depth: { type: 'number', default: 10, description: 'Number of levels per side' } }, returns: ['symbol', 'bids', 'asks'] },
+        'search':     { description: 'Search available perp symbols', options: { query: { type: 'string', required: true, description: 'Symbol name search query' } }, returns: ['symbol', 'assetIndex', 'szDecimals'] },
       }
     },
     'search': {
@@ -895,6 +915,7 @@ COMMANDS:
                    perp-positions, perp-pnl-leaderboard)
   portfolio      Portfolio analytics (defi)
   perp           Perpetual futures analytics (screener, leaderboard)
+  perps          Hyperliquid perps trading (open, close, set-sl, set-tp, price, funding, orderbook, search)
   points         Nansen Points analytics (leaderboard)
   changelog      Show what's new (use --since <version> to filter)
   help           Show this help message
@@ -1598,7 +1619,7 @@ export async function runCLI(rawArgs, deps = {}) {
     if (updateNotification) errorOutput(updateNotification);
   };
 
-  const commands = { ...buildCommands(deps), ...buildWalletCommands(deps), ...buildTradingCommands(deps), ...commandOverrides };
+  const commands = { ...buildCommands(deps), ...buildWalletCommands(deps), ...buildTradingCommands(deps), ...buildPerpsCommands(deps), ...commandOverrides };
 
   if (flags.version || flags.v) {
     output(VERSION);

--- a/src/perps.js
+++ b/src/perps.js
@@ -1,0 +1,819 @@
+/**
+ * Nansen CLI - Hyperliquid Perpetuals Trading
+ * Open/close positions, manage SL/TP, query prices and orderbook.
+ * Zero external dependencies — uses Node.js built-in crypto only.
+ */
+
+import crypto from 'crypto';
+import { keccak256, signSecp256k1 } from './crypto.js';
+import { exportWallet, getDefaultAddress, listWallets } from './wallet.js';
+
+// ============= Constants =============
+
+const HL_INFO_URL = process.env.HL_INFO_URL || 'https://api.hyperliquid.xyz/info';
+const HL_EXCHANGE_URL = process.env.HL_EXCHANGE_URL || 'https://api.hyperliquid.xyz/exchange';
+
+// ============= Minimal MsgPack Encoder =============
+// Hyperliquid uses msgpack to serialize actions before hashing.
+// We implement only the subset needed: nil, bool, int, float, string, array, map.
+// Follows the MessagePack spec: https://msgpack.org/index.html
+
+export function msgpackEncode(value) {
+  if (value === null || value === undefined) {
+    return Buffer.from([0xc0]); // nil
+  }
+  if (typeof value === 'boolean') {
+    return Buffer.from([value ? 0xc3 : 0xc2]);
+  }
+  if (typeof value === 'number') {
+    if (Number.isInteger(value)) {
+      return msgpackEncodeInt(value);
+    }
+    // 64-bit float (double)
+    const buf = Buffer.allocUnsafe(9);
+    buf[0] = 0xcb;
+    buf.writeDoubleBE(value, 1);
+    return buf;
+  }
+  if (typeof value === 'bigint') {
+    return msgpackEncodeInt(Number(value));
+  }
+  if (typeof value === 'string') {
+    const bytes = Buffer.from(value, 'utf8');
+    const len = bytes.length;
+    if (len <= 31) {
+      return Buffer.concat([Buffer.from([0xa0 | len]), bytes]);
+    }
+    if (len <= 0xff) {
+      return Buffer.concat([Buffer.from([0xd9, len]), bytes]);
+    }
+    if (len <= 0xffff) {
+      const h = Buffer.allocUnsafe(3);
+      h[0] = 0xda; h.writeUInt16BE(len, 1);
+      return Buffer.concat([h, bytes]);
+    }
+    const h = Buffer.allocUnsafe(5);
+    h[0] = 0xdb; h.writeUInt32BE(len, 1);
+    return Buffer.concat([h, bytes]);
+  }
+  if (Array.isArray(value)) {
+    const items = value.map(msgpackEncode);
+    const len = value.length;
+    let header;
+    if (len <= 15) {
+      header = Buffer.from([0x90 | len]);
+    } else if (len <= 0xffff) {
+      header = Buffer.allocUnsafe(3);
+      header[0] = 0xdc; header.writeUInt16BE(len, 1);
+    } else {
+      header = Buffer.allocUnsafe(5);
+      header[0] = 0xdd; header.writeUInt32BE(len, 1);
+    }
+    return Buffer.concat([header, ...items]);
+  }
+  if (typeof value === 'object') {
+    // Sort keys for deterministic encoding (matches Hyperliquid SDK behavior)
+    const keys = Object.keys(value).sort();
+    const len = keys.length;
+    let header;
+    if (len <= 15) {
+      header = Buffer.from([0x80 | len]);
+    } else if (len <= 0xffff) {
+      header = Buffer.allocUnsafe(3);
+      header[0] = 0xde; header.writeUInt16BE(len, 1);
+    } else {
+      header = Buffer.allocUnsafe(5);
+      header[0] = 0xdf; header.writeUInt32BE(len, 1);
+    }
+    const parts = [header];
+    for (const k of keys) {
+      parts.push(msgpackEncode(k));
+      parts.push(msgpackEncode(value[k]));
+    }
+    return Buffer.concat(parts);
+  }
+  throw new Error(`msgpackEncode: unsupported type ${typeof value}`);
+}
+
+function msgpackEncodeInt(n) {
+  if (n >= 0) {
+    if (n <= 127) return Buffer.from([n]);
+    if (n <= 0xff) return Buffer.from([0xcc, n]);
+    if (n <= 0xffff) { const b = Buffer.allocUnsafe(3); b[0] = 0xcd; b.writeUInt16BE(n, 1); return b; }
+    if (n <= 0xffffffff) { const b = Buffer.allocUnsafe(5); b[0] = 0xce; b.writeUInt32BE(n, 1); return b; }
+    const b = Buffer.allocUnsafe(9); b[0] = 0xcf; b.writeBigUInt64BE(BigInt(n), 1); return b;
+  } else {
+    if (n >= -32) return Buffer.from([n & 0xff]);
+    if (n >= -128) return Buffer.from([0xd0, n & 0xff]);
+    if (n >= -32768) { const b = Buffer.allocUnsafe(3); b[0] = 0xd1; b.writeInt16BE(n, 1); return b; }
+    if (n >= -2147483648) { const b = Buffer.allocUnsafe(5); b[0] = 0xd2; b.writeInt32BE(n, 1); return b; }
+    const b = Buffer.allocUnsafe(9); b[0] = 0xd3; b.writeBigInt64BE(BigInt(n), 1); return b;
+  }
+}
+
+// ============= Hyperliquid Signing =============
+
+/**
+ * Convert a float to Hyperliquid's wire format (normalized decimal string).
+ * e.g. 1.5 → "1.5", 0.001 → "0.001", 100.0 → "100"
+ */
+export function floatToWire(x) {
+  let s = x.toFixed(8);
+  // Strip trailing zeros after decimal
+  s = s.replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '');
+  if (s === '-0') s = '0';
+  return s;
+}
+
+/**
+ * Round a price to Hyperliquid's 5 significant figures wire format.
+ */
+export function floatToWirePrice(x) {
+  if (x === 0) return '0';
+  const sigFigs = 5;
+  const mag = Math.floor(Math.log10(Math.abs(x)));
+  const factor = Math.pow(10, sigFigs - 1 - mag);
+  const rounded = Math.round(x * factor) / factor;
+  return floatToWire(rounded);
+}
+
+/**
+ * Compute the Hyperliquid action hash.
+ * hash = keccak256(msgpack(action) || nonce_8bytes_bigendian || vault_flag [|| vault_20bytes])
+ */
+export function computeActionHash(action, vaultAddress, nonce) {
+  const packed = msgpackEncode(action);
+  const nonceBuf = Buffer.allocUnsafe(8);
+  nonceBuf.writeBigUInt64BE(BigInt(nonce));
+
+  let vaultBuf;
+  if (vaultAddress == null) {
+    vaultBuf = Buffer.from([0x00]);
+  } else {
+    const addrBytes = Buffer.from(vaultAddress.replace(/^0x/, ''), 'hex');
+    vaultBuf = Buffer.concat([Buffer.from([0x01]), addrBytes]);
+  }
+
+  return keccak256(Buffer.concat([packed, nonceBuf, vaultBuf]));
+}
+
+/**
+ * Build the EIP-712 domain separator for Hyperliquid (chainId=1337, zero verifyingContract).
+ */
+function buildDomainSeparator() {
+  const typeHash = keccak256(Buffer.from(
+    'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'
+  ));
+  const nameHash = keccak256(Buffer.from('Exchange'));
+  const versionHash = keccak256(Buffer.from('1'));
+  const chainId = Buffer.alloc(32);
+  // chainId = 1337 — write as big-endian uint256
+  const chainIdBuf = Buffer.allocUnsafe(8);
+  chainIdBuf.writeBigUInt64BE(1337n);
+  chainId.set(chainIdBuf, 24);
+  const verifyingContract = Buffer.alloc(32); // zero address
+
+  return keccak256(Buffer.concat([typeHash, nameHash, versionHash, chainId, verifyingContract]));
+}
+
+const DOMAIN_SEPARATOR = buildDomainSeparator();
+
+/**
+ * Build the EIP-712 typed data hash for a phantom agent.
+ * Agent(string source, bytes32 connectionId)
+ * The "connectionId" is the action hash.
+ */
+export function buildPhantomAgentHash(actionHash, isMainnet) {
+  const source = isMainnet ? 'a' : 'b';
+  const agentTypeHash = keccak256(Buffer.from('Agent(string source,bytes32 connectionId)'));
+  const sourceHash = keccak256(Buffer.from(source, 'utf8'));
+  // actionHash is already 32 bytes (bytes32)
+  const structHash = keccak256(Buffer.concat([agentTypeHash, sourceHash, actionHash]));
+
+  return keccak256(Buffer.concat([
+    Buffer.from([0x19, 0x01]), // EIP-712 prefix
+    DOMAIN_SEPARATOR,
+    structHash,
+  ]));
+}
+
+/**
+ * Sign a Hyperliquid L1 action.
+ * Returns { r: "0x...", s: "0x...", v: N } where v is 27 or 28.
+ */
+export function signL1Action(action, privateKeyHex, vaultAddress, nonce, isMainnet) {
+  const actionHash = computeActionHash(action, vaultAddress, nonce);
+  const phantomHash = buildPhantomAgentHash(actionHash, isMainnet);
+  const privateKey = Buffer.from(privateKeyHex.replace(/^0x/, ''), 'hex');
+  const { r, s, v } = signSecp256k1(phantomHash, privateKey);
+  return {
+    r: '0x' + r.toString('hex'),
+    s: '0x' + s.toString('hex'),
+    v: 27 + v, // Ethereum v convention (27 or 28)
+  };
+}
+
+/**
+ * Derive EVM address from a private key hex string.
+ */
+export function deriveEvmAddress(privateKeyHex) {
+  const key = Buffer.from(privateKeyHex.replace(/^0x/, ''), 'hex');
+  const ecdh = crypto.createECDH('secp256k1');
+  ecdh.setPrivateKey(key);
+  const pubKey = ecdh.getPublicKey(null, 'uncompressed');
+  const hash = keccak256(pubKey.subarray(1));
+  return '0x' + hash.subarray(12).toString('hex');
+}
+
+// ============= HTTP Helpers =============
+
+async function hlInfo(body) {
+  const res = await fetch(HL_INFO_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Hyperliquid info API error (${res.status}): ${text.slice(0, 300)}`);
+  }
+  return res.json();
+}
+
+async function hlExchange(action, privateKeyHex, vaultAddress, isMainnet) {
+  const nonce = Date.now();
+  const signature = signL1Action(action, privateKeyHex, vaultAddress, nonce, isMainnet);
+  const body = { action, nonce, signature };
+  if (vaultAddress) body.vaultAddress = vaultAddress;
+
+  const res = await fetch(HL_EXCHANGE_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Hyperliquid exchange API error (${res.status}): ${text.slice(0, 300)}`);
+  }
+  return res.json();
+}
+
+// ============= Market Data Helpers =============
+
+async function getMeta() {
+  return hlInfo({ type: 'meta' });
+}
+
+async function getMetaAndCtxs() {
+  const result = await hlInfo({ type: 'metaAndAssetCtxs' });
+  // Returns [meta, contexts]
+  if (Array.isArray(result)) return result;
+  return [result, []];
+}
+
+/**
+ * Get the asset index for a coin symbol from meta.universe.
+ */
+async function getAssetIndex(symbol, meta) {
+  const m = meta || await getMeta();
+  const universe = m.universe || [];
+  const idx = universe.findIndex(a => a.name === symbol.toUpperCase());
+  if (idx === -1) {
+    throw new Error(`Symbol "${symbol.toUpperCase()}" not found on Hyperliquid. Use 'perps search --query ${symbol}' to find it.`);
+  }
+  return idx;
+}
+
+// ============= Position Parsing =============
+
+function parsePosition(pos) {
+  if (!pos || !pos.position) return null;
+  const p = pos.position;
+  const szi = parseFloat(p.szi || '0');
+  if (szi === 0) return null;
+  return {
+    symbol: p.coin,
+    side: szi > 0 ? 'long' : 'short',
+    size: Math.abs(szi),
+    entryPrice: parseFloat(p.entryPx || '0'),
+    unrealizedPnl: parseFloat(p.unrealizedPnl || '0'),
+    returnOnEquity: parseFloat(p.returnOnEquity || '0'),
+    leverage: p.leverage ? { type: p.leverage.type, value: parseFloat(p.leverage.value || '0') } : null,
+    liquidationPrice: p.liquidationPx ? parseFloat(p.liquidationPx) : null,
+    marginUsed: parseFloat(p.marginUsed || '0'),
+  };
+}
+
+function parseOrderResult(result, symbol, side, size) {
+  if (!result) return { symbol, side, size, status: 'unknown' };
+  const status = (result.status || '').toLowerCase();
+  if (status === 'ok') {
+    const data = result.response?.data || {};
+    const statuses = data.statuses || [];
+    const fills = statuses
+      .filter(s => s.filled)
+      .map(s => ({
+        orderId: s.filled?.oid,
+        totalSz: parseFloat(s.filled?.totalSz || '0'),
+        avgPx: parseFloat(s.filled?.avgPx || '0'),
+      }));
+    const resting = statuses.filter(s => s.resting).map(s => ({ orderId: s.resting?.oid }));
+    return { symbol, side, requestedSize: size, status: 'ok', fills, resting };
+  }
+  return { symbol, side, requestedSize: size, status, error: result.response };
+}
+
+// ============= Credential Helpers =============
+
+/**
+ * Get signing credentials.
+ * Priority: HL_SECRET_KEY env > wallet system.
+ */
+async function getCredentials(walletName) {
+  const isMainnet = !process.env.HL_TESTNET;
+
+  if (process.env.HL_SECRET_KEY) {
+    const key = process.env.HL_SECRET_KEY.replace(/^0x/, '');
+    if (key.length !== 64) throw new Error('HL_SECRET_KEY must be a 32-byte (64 hex char) private key');
+    const accountAddress = process.env.HL_ACCOUNT_ADDRESS || null;
+    return { privateKey: key, accountAddress, isMainnet };
+  }
+
+  const password = process.env.NANSEN_WALLET_PASSWORD;
+  if (!password) {
+    throw new Error(
+      'No credentials found. Set HL_SECRET_KEY env var, ' +
+      'or set NANSEN_WALLET_PASSWORD and optionally --wallet <name>.'
+    );
+  }
+
+  let effectiveName = walletName;
+  if (!effectiveName) {
+    const list = listWallets();
+    effectiveName = list.defaultWallet;
+  }
+  if (!effectiveName) {
+    throw new Error('No wallet found. Create one with: nansen wallet create');
+  }
+
+  const exported = exportWallet(effectiveName, password);
+  const key = exported.evm.privateKey;
+  if (!key) throw new Error('Wallet has no EVM private key');
+  return { privateKey: key, accountAddress: null, isMainnet };
+}
+
+/**
+ * Resolve the user's trading address.
+ * Priority: HL_ACCOUNT_ADDRESS env > derive from private key.
+ */
+async function resolveUserAddress(options, walletName) {
+  // Explicit address flag takes priority
+  if (options.address) return options.address;
+  // HL_ACCOUNT_ADDRESS env for agent wallets
+  if (process.env.HL_ACCOUNT_ADDRESS) return process.env.HL_ACCOUNT_ADDRESS;
+
+  // Derive from HL_SECRET_KEY
+  if (process.env.HL_SECRET_KEY) {
+    const key = process.env.HL_SECRET_KEY.replace(/^0x/, '');
+    return deriveEvmAddress(key);
+  }
+
+  // Fall back to nansen wallet
+  try {
+    const { privateKey } = await getCredentials(walletName);
+    return deriveEvmAddress(privateKey);
+  } catch {
+    // Last resort
+    try { return getDefaultAddress('evm'); } catch { /* ignore */ }
+  }
+  throw new Error('Could not determine wallet address. Set HL_ACCOUNT_ADDRESS, HL_SECRET_KEY, or configure a wallet.');
+}
+
+// ============= Command Implementations =============
+
+export async function cmdStatus(options, walletName) {
+  const address = await resolveUserAddress(options, walletName);
+  const state = await hlInfo({ type: 'clearinghouseState', user: address });
+  const positions = (state.assetPositions || []).map(parsePosition).filter(Boolean);
+
+  return {
+    address,
+    equity: parseFloat(state.marginSummary?.accountValue || '0'),
+    totalMarginUsed: parseFloat(state.marginSummary?.totalMarginUsed || '0'),
+    positions,
+    positionCount: positions.length,
+  };
+}
+
+export async function cmdBalance(options, walletName) {
+  const address = await resolveUserAddress(options, walletName);
+  const state = await hlInfo({ type: 'clearinghouseState', user: address });
+  const summary = state.marginSummary || {};
+
+  return {
+    address,
+    equity: parseFloat(summary.accountValue || '0'),
+    totalNtlPos: parseFloat(summary.totalNtlPos || '0'),
+    totalRawUsd: parseFloat(summary.totalRawUsd || '0'),
+    totalMarginUsed: parseFloat(summary.totalMarginUsed || '0'),
+  };
+}
+
+export async function cmdPrice(options) {
+  const symbol = (options.symbol || '').toUpperCase();
+  if (!symbol) throw new Error('--symbol is required (e.g. --symbol BTC)');
+
+  const mids = await hlInfo({ type: 'allMids' });
+  const price = mids[symbol];
+  if (price == null) {
+    throw new Error(`No price found for "${symbol}". Use 'perps search --query ${symbol}' to verify the symbol.`);
+  }
+  return { symbol, price: parseFloat(price) };
+}
+
+export async function cmdFunding(options) {
+  const symbol = (options.symbol || '').toUpperCase();
+  if (!symbol) throw new Error('--symbol is required (e.g. --symbol BTC)');
+
+  const [meta, ctxs] = await getMetaAndCtxs();
+  const universe = meta.universe || [];
+  const idx = universe.findIndex(a => a.name === symbol);
+  if (idx === -1) throw new Error(`Symbol "${symbol}" not found on Hyperliquid`);
+
+  const ctx = (ctxs || [])[idx] || {};
+  return {
+    symbol,
+    fundingRate: parseFloat(ctx.funding || '0'),
+    openInterest: parseFloat(ctx.openInterest || '0'),
+    markPrice: parseFloat(ctx.markPx || '0'),
+    dayNtlVlm: parseFloat(ctx.dayNtlVlm || '0'),
+    premium: parseFloat(ctx.premium || '0'),
+  };
+}
+
+export async function cmdOrderbook(options) {
+  const symbol = (options.symbol || '').toUpperCase();
+  if (!symbol) throw new Error('--symbol is required (e.g. --symbol BTC)');
+  const depth = Math.min(parseInt(options.depth || '10', 10), 50);
+
+  const book = await hlInfo({ type: 'l2Book', coin: symbol });
+  const levels = book.levels || [[], []];
+  const bids = (levels[0] || []).slice(0, depth).map(l => ({
+    price: parseFloat(l.px), size: parseFloat(l.sz), orders: l.n,
+  }));
+  const asks = (levels[1] || []).slice(0, depth).map(l => ({
+    price: parseFloat(l.px), size: parseFloat(l.sz), orders: l.n,
+  }));
+
+  return { symbol, depth: Math.min(depth, Math.max(bids.length, asks.length)), bids, asks };
+}
+
+export async function cmdSearch(options) {
+  const query = (options.query || '').toLowerCase();
+  if (!query) throw new Error('--query is required (e.g. --query pepe)');
+
+  const meta = await getMeta();
+  const universe = meta.universe || [];
+  const results = universe
+    .filter(a => a.name.toLowerCase().includes(query))
+    .map((a, i) => ({ symbol: a.name, assetIndex: i, szDecimals: a.szDecimals }));
+
+  return { query, results, count: results.length };
+}
+
+export async function cmdOpen(options, walletName) {
+  const symbol = (options.symbol || '').toUpperCase();
+  const side = (options.side || '').toLowerCase();
+  const sizeStr = options.size;
+  const leverage = options.leverage != null ? parseInt(options.leverage, 10) : null;
+  const isolated = !!(options.isolated || options.isIsolated);
+  const limitPrice = options.price ? parseFloat(options.price) : null;
+
+  if (!symbol) throw new Error('--symbol is required (e.g. --symbol BTC)');
+  if (!['long', 'short'].includes(side)) throw new Error('--side must be "long" or "short"');
+  if (!sizeStr) throw new Error('--size is required (base asset units, e.g. 0.001 for 0.001 BTC)');
+
+  const size = parseFloat(sizeStr);
+  if (isNaN(size) || size <= 0) throw new Error('--size must be a positive number');
+
+  const { privateKey, accountAddress, isMainnet } = await getCredentials(walletName);
+  const meta = await getMeta();
+  const assetIndex = await getAssetIndex(symbol, meta);
+
+  // Set leverage if specified
+  if (leverage !== null && leverage > 0) {
+    const leverageAction = {
+      type: 'updateLeverage',
+      asset: assetIndex,
+      isCross: !isolated,
+      leverage,
+    };
+    await hlExchange(leverageAction, privateKey, accountAddress, isMainnet);
+  }
+
+  const isBuy = side === 'long';
+  let px;
+
+  if (limitPrice) {
+    px = floatToWirePrice(limitPrice);
+  } else {
+    // Market order: use current mid with slippage buffer (3%)
+    const mids = await hlInfo({ type: 'allMids' });
+    const mid = parseFloat(mids[symbol] || '0');
+    if (!mid) throw new Error(`No price found for ${symbol}`);
+    const slippage = isBuy ? mid * 1.03 : mid * 0.97;
+    px = floatToWirePrice(slippage);
+  }
+
+  const orderType = limitPrice
+    ? { limit: { tif: 'Gtc' } }   // limit order, resting
+    : { limit: { tif: 'Ioc' } };  // "market": IOC at slippage price
+
+  const order = {
+    a: assetIndex,
+    b: isBuy,
+    p: px,
+    s: floatToWire(size),
+    r: false, // not reduce-only
+    t: orderType,
+  };
+
+  const action = { type: 'order', orders: [order], grouping: 'na' };
+  const result = await hlExchange(action, privateKey, accountAddress, isMainnet);
+  return parseOrderResult(result, symbol, side, size);
+}
+
+export async function cmdClose(options, walletName) {
+  const symbol = (options.symbol || '').toUpperCase();
+  if (!symbol) throw new Error('--symbol is required (e.g. --symbol BTC)');
+
+  const { privateKey, accountAddress, isMainnet } = await getCredentials(walletName);
+  const address = accountAddress || deriveEvmAddress(privateKey);
+
+  const state = await hlInfo({ type: 'clearinghouseState', user: address });
+  const posEntry = (state.assetPositions || []).find(p => p.position?.coin === symbol);
+  if (!posEntry) throw new Error(`No open position found for ${symbol}`);
+
+  const currentSzi = parseFloat(posEntry.position?.szi || '0');
+  if (currentSzi === 0) throw new Error(`Position for ${symbol} has zero size`);
+
+  const closeSize = options.size ? parseFloat(options.size) : Math.abs(currentSzi);
+  const isBuy = currentSzi < 0; // closing a short requires buying
+
+  const meta = await getMeta();
+  const assetIndex = await getAssetIndex(symbol, meta);
+
+  const mids = await hlInfo({ type: 'allMids' });
+  const mid = parseFloat(mids[symbol] || '0');
+  if (!mid) throw new Error(`No price found for ${symbol}`);
+  const px = isBuy ? floatToWirePrice(mid * 1.03) : floatToWirePrice(mid * 0.97);
+
+  const order = {
+    a: assetIndex,
+    b: isBuy,
+    p: px,
+    s: floatToWire(closeSize),
+    r: true, // reduce-only
+    t: { limit: { tif: 'Ioc' } },
+  };
+
+  const action = { type: 'order', orders: [order], grouping: 'na' };
+  const result = await hlExchange(action, privateKey, accountAddress, isMainnet);
+  const side = isBuy ? 'close-short' : 'close-long';
+  return parseOrderResult(result, symbol, side, closeSize);
+}
+
+export async function cmdCloseAll(options, walletName) {
+  const { privateKey, accountAddress, isMainnet } = await getCredentials(walletName);
+  const address = accountAddress || deriveEvmAddress(privateKey);
+
+  const state = await hlInfo({ type: 'clearinghouseState', user: address });
+  const positions = (state.assetPositions || []).map(parsePosition).filter(Boolean);
+
+  if (positions.length === 0) return { closed: 0, message: 'No open positions to close' };
+
+  const meta = await getMeta();
+  const mids = await hlInfo({ type: 'allMids' });
+
+  const orders = [];
+  for (const pos of positions) {
+    const assetIndex = await getAssetIndex(pos.symbol, meta);
+    const mid = parseFloat(mids[pos.symbol] || '0');
+    if (!mid) continue;
+    const isBuy = pos.side === 'short';
+    const px = isBuy ? floatToWirePrice(mid * 1.03) : floatToWirePrice(mid * 0.97);
+    orders.push({
+      a: assetIndex,
+      b: isBuy,
+      p: px,
+      s: floatToWire(pos.size),
+      r: true,
+      t: { limit: { tif: 'Ioc' } },
+    });
+  }
+
+  if (orders.length === 0) return { closed: 0, message: 'No closable positions found' };
+
+  const action = { type: 'order', orders, grouping: 'na' };
+  const result = await hlExchange(action, privateKey, accountAddress, isMainnet);
+
+  return {
+    attempted: positions.length,
+    symbols: positions.map(p => p.symbol),
+    result: parseOrderResult(result, 'all', 'close-all', 0),
+  };
+}
+
+export async function cmdReduce(options, walletName) {
+  const symbol = (options.symbol || '').toUpperCase();
+  const percent = parseFloat(options.percent || '50');
+  if (!symbol) throw new Error('--symbol is required (e.g. --symbol BTC)');
+  if (isNaN(percent) || percent <= 0 || percent > 100) throw new Error('--percent must be between 1 and 100');
+
+  const { privateKey, accountAddress } = await getCredentials(walletName);
+  const address = accountAddress || deriveEvmAddress(privateKey);
+
+  const state = await hlInfo({ type: 'clearinghouseState', user: address });
+  const posEntry = (state.assetPositions || []).find(p => p.position?.coin === symbol);
+  if (!posEntry) throw new Error(`No open position found for ${symbol}`);
+
+  const currentSzi = parseFloat(posEntry.position?.szi || '0');
+  if (currentSzi === 0) throw new Error(`Position for ${symbol} has zero size`);
+
+  const reduceSize = Math.abs(currentSzi) * (percent / 100);
+  return cmdClose({ symbol: options.symbol, size: String(reduceSize) }, walletName);
+}
+
+export async function cmdSetSL(options, walletName) {
+  return cmdSetTpSl(options, walletName, 'sl');
+}
+
+export async function cmdSetTP(options, walletName) {
+  return cmdSetTpSl(options, walletName, 'tp');
+}
+
+async function cmdSetTpSl(options, walletName, type) {
+  const symbol = (options.symbol || '').toUpperCase();
+  const triggerPrice = parseFloat(options.price || '0');
+  if (!symbol) throw new Error('--symbol is required');
+  if (!triggerPrice || isNaN(triggerPrice)) throw new Error('--price is required (e.g. --price 60000)');
+
+  const { privateKey, accountAddress, isMainnet } = await getCredentials(walletName);
+  const address = accountAddress || deriveEvmAddress(privateKey);
+
+  const state = await hlInfo({ type: 'clearinghouseState', user: address });
+  const posEntry = (state.assetPositions || []).find(p => p.position?.coin === symbol);
+  if (!posEntry) throw new Error(`No open position found for ${symbol}`);
+
+  const currentSzi = parseFloat(posEntry.position?.szi || '0');
+  if (currentSzi === 0) throw new Error(`Position for ${symbol} has zero size`);
+
+  const meta = await getMeta();
+  const assetIndex = await getAssetIndex(symbol, meta);
+  const isBuy = currentSzi < 0; // closing short = buy
+
+  const mids = await hlInfo({ type: 'allMids' });
+  const mid = parseFloat(mids[symbol] || '0');
+
+  // Limit price: for TP use trigger price; for SL use slippage (stop-market)
+  let limitPx;
+  if (type === 'tp') {
+    limitPx = floatToWirePrice(triggerPrice);
+  } else {
+    limitPx = isBuy ? floatToWirePrice(mid * 1.1) : floatToWirePrice(mid * 0.9);
+  }
+
+  const orderType = type === 'tp'
+    ? { trigger: { triggerPx: floatToWirePrice(triggerPrice), isMarket: false, tpsl: 'tp' } }
+    : { trigger: { triggerPx: floatToWirePrice(triggerPrice), isMarket: true, tpsl: 'sl' } };
+
+  const order = {
+    a: assetIndex,
+    b: isBuy,
+    p: limitPx,
+    s: floatToWire(Math.abs(currentSzi)),
+    r: true,
+    t: orderType,
+  };
+
+  const action = { type: 'order', orders: [order], grouping: 'tpsl' };
+  const result = await hlExchange(action, privateKey, accountAddress, isMainnet);
+  return {
+    type,
+    symbol,
+    triggerPrice,
+    result: parseOrderResult(result, symbol, type, Math.abs(currentSzi)),
+  };
+}
+
+export async function cmdCancel(options, walletName) {
+  const symbol = (options.symbol || '').toUpperCase();
+  if (!symbol) throw new Error('--symbol is required (e.g. --symbol BTC)');
+
+  const { privateKey, accountAddress, isMainnet } = await getCredentials(walletName);
+  const address = accountAddress || deriveEvmAddress(privateKey);
+
+  const meta = await getMeta();
+  const assetIndex = await getAssetIndex(symbol, meta);
+
+  const openOrders = await hlInfo({ type: 'openOrders', user: address });
+  const toCancel = (openOrders || [])
+    .filter(o => o.coin === symbol)
+    .map(o => ({ a: assetIndex, o: o.oid }));
+
+  if (toCancel.length === 0) return { symbol, cancelled: 0, message: 'No open orders found for this symbol' };
+
+  const action = { type: 'cancel', cancels: toCancel };
+  const result = await hlExchange(action, privateKey, accountAddress, isMainnet);
+  return { symbol, cancelled: toCancel.length, result };
+}
+
+export async function cmdCancelAll(options, walletName) {
+  const { privateKey, accountAddress, isMainnet } = await getCredentials(walletName);
+  const address = accountAddress || deriveEvmAddress(privateKey);
+
+  const [openOrders, meta] = await Promise.all([
+    hlInfo({ type: 'openOrders', user: address }),
+    getMeta(),
+  ]);
+
+  if (!openOrders || openOrders.length === 0) return { cancelled: 0, message: 'No open orders' };
+
+  const universe = meta.universe || [];
+  const symbolToIdx = Object.fromEntries(universe.map((a, i) => [a.name, i]));
+
+  const toCancel = (openOrders || [])
+    .filter(o => symbolToIdx[o.coin] !== undefined)
+    .map(o => ({ a: symbolToIdx[o.coin], o: o.oid }));
+
+  if (toCancel.length === 0) return { cancelled: 0, message: 'No cancellable orders found' };
+
+  const action = { type: 'cancel', cancels: toCancel };
+  const result = await hlExchange(action, privateKey, accountAddress, isMainnet);
+  return { cancelled: toCancel.length, result };
+}
+
+// ============= CLI Command Builder =============
+
+export function buildPerpsCommands(deps = {}) {
+  const { errorOutput = console.error, exit = process.exit } = deps;
+
+  return {
+    'perps': async (args, apiInstance, flags, options) => {
+      const subcommand = args[0] || 'help';
+      const walletName = options.wallet;
+
+      const handlers = {
+        'status':     () => cmdStatus(options, walletName),
+        'balance':    () => cmdBalance(options, walletName),
+        'price':      () => cmdPrice(options),
+        'funding':    () => cmdFunding(options),
+        'orderbook':  () => cmdOrderbook(options),
+        'search':     () => cmdSearch(options),
+        'open':       () => cmdOpen(options, walletName),
+        'close':      () => cmdClose(options, walletName),
+        'close-all':  () => cmdCloseAll(options, walletName),
+        'reduce':     () => cmdReduce(options, walletName),
+        'set-sl':     () => cmdSetSL(options, walletName),
+        'set-tp':     () => cmdSetTP(options, walletName),
+        'cancel':     () => cmdCancel(options, walletName),
+        'cancel-all': () => cmdCancelAll(options, walletName),
+        'help': () => ({
+          commands: [
+            'status', 'balance', 'price', 'funding', 'orderbook', 'search',
+            'open', 'close', 'close-all', 'reduce', 'set-sl', 'set-tp',
+            'cancel', 'cancel-all',
+          ],
+          description: 'Hyperliquid perpetuals trading',
+          auth: 'Write commands require HL_SECRET_KEY (32-byte private key) or NANSEN_WALLET_PASSWORD + --wallet',
+          network: 'Mainnet by default. Set HL_TESTNET=1 for testnet.',
+          examples: [
+            'nansen perps status',
+            'nansen perps balance',
+            'nansen perps price --symbol BTC',
+            'nansen perps funding --symbol ETH',
+            'nansen perps orderbook --symbol BTC --depth 5',
+            'nansen perps search --query pepe',
+            'nansen perps open --symbol BTC --side long --size 0.001',
+            'nansen perps open --symbol ETH --side short --size 0.1 --leverage 5 --isolated',
+            'nansen perps open --symbol BTC --side long --size 0.001 --price 95000',
+            'nansen perps close --symbol BTC',
+            'nansen perps close --symbol BTC --size 0.0005',
+            'nansen perps close-all',
+            'nansen perps reduce --symbol BTC --percent 50',
+            'nansen perps set-sl --symbol BTC --price 60000',
+            'nansen perps set-tp --symbol BTC --price 120000',
+            'nansen perps cancel --symbol BTC',
+            'nansen perps cancel-all',
+          ],
+        }),
+      };
+
+      if (!handlers[subcommand]) {
+        return { error: `Unknown subcommand: ${subcommand}`, available: Object.keys(handlers) };
+      }
+
+      return handlers[subcommand]();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a new `perps` top-level command enabling Hyperliquid perpetuals trading directly from the CLI
- Implements msgpack encoding and EIP-712 phantom agent signing from scratch (zero external dependencies)
- Supports 14 subcommands: status, balance, open, close, close-all, reduce, set-sl, set-tp, cancel, cancel-all, price, funding, orderbook, search

## New command: `perps`

```bash
# Market data (no auth needed)
nansen perps price --symbol BTC
nansen perps funding --symbol ETH
nansen perps orderbook --symbol BTC --depth 5
nansen perps search --query pepe

# Account (reads your positions/balance)
nansen perps status
nansen perps balance

# Trading (requires HL_SECRET_KEY)
nansen perps open --symbol BTC --side long --size 0.001
nansen perps open --symbol ETH --side short --size 0.1 --leverage 5 --isolated
nansen perps close --symbol BTC
nansen perps close-all
nansen perps reduce --symbol BTC --percent 50
nansen perps set-sl --symbol BTC --price 60000
nansen perps set-tp --symbol BTC --price 120000
nansen perps cancel --symbol BTC
nansen perps cancel-all
```

## Implementation details

- **`src/perps.js`**: Self-contained module with:
  - Minimal msgpack encoder (nil, bool, int, float, string, array, sorted-key map)
  - Hyperliquid action hash: `keccak256(msgpack(action) || nonce_8b || vault_flag)`
  - EIP-712 phantom agent signing (domain: Exchange/1337/0x0)
  - All 14 command implementations
- **`src/__tests__/perps.test.js`**: 72 tests covering msgpack encoding, wire format helpers, signing, and all commands
- **`src/cli.js`**: Schema entry + command wiring
- **`README.md`**: New perps section with examples

## Auth

- `HL_SECRET_KEY` — 32-byte EVM private key (primary)
- `HL_ACCOUNT_ADDRESS` — Optional agent/sub-account address
- `HL_TESTNET=1` — Use testnet (mainnet is default)
- Or: `NANSEN_WALLET_PASSWORD` + `--wallet <name>` for nansen wallet system

## Test plan

- [x] `npm test` passes (15 test files, 658 tests, 0 failures)
- [x] 72 new tests in `perps.test.js`
- [x] msgpack encoding tested against spec values
- [x] EIP-712 signing determinism verified
- [x] All read commands tested with mocked fetch
- [x] Write command validation (missing args, invalid args) tested
- [x] No external dependencies added

🤖 Generated with [Claude Code](https://claude.com/claude-code)