### PR TITLE
Add changeset for CLI namespace restructure

### DIFF
--- a/.changeset/cli-restructure-namespaces.md
+++ b/.changeset/cli-restructure-namespaces.md
@@ -1,0 +1,10 @@
+---
+"nansen-cli": minor
+---
+
+Restructure CLI into research/trade/wallet namespaces
+
+- Commands reorganized: `smart-money`, `profiler`, `token`, `portfolio` now live under `nansen research`
+- New `nansen trade` namespace for `quote` and `execute`
+- New `nansen wallet` namespace for wallet management
+- Old top-level commands still work with deprecation warnings


### PR DESCRIPTION
## Summary
- Adds missing changeset file for the CLI namespace restructure merged in #74
- Marked as `minor` since old commands still work (with deprecation warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)