### PR TITLE
fix: auto-substitute wrapped native token with native sentinel

### DIFF
--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -26,6 +26,9 @@ import {
   stripLeadingZeros,
   buildTradingCommands,
   getWrappedNativeWarning,
+  getErc20Balance,
+  getNativeBalance,
+  resolveWrappedNativeToken,
 } from '../trading.js';
 import { keccak256, rlpEncode } from '../crypto.js';
 import { base58Decode } from '../transfer.js';
@@ -798,23 +801,216 @@ describe('getWrappedNativeWarning', () => {
   });
 });
 
-describe('quote handler wrapped native token warnings', () => {
-  it('should emit warning when --from is a wrapped native token', async () => {
-    createWallet('default', 'testpass');
+// ============= Balance Helpers =============
 
+describe('getErc20Balance', () => {
+  it('should return balance from mocked RPC response', async () => {
+    const origFetch = global.fetch;
+    // 1000000000000000000 = 0xde0b6b3a7640000
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ jsonrpc: '2.0', id: 1, result: '0x0000000000000000000000000000000000000000000000000de0b6b3a7640000' }),
+    });
+
+    const balance = await getErc20Balance('base', '0x4200000000000000000000000000000000000006', '0x' + 'ab'.repeat(20));
+    expect(balance).toBe(1000000000000000000n);
+
+    global.fetch = origFetch;
+  });
+
+  it('should return 0n on RPC error', async () => {
     const origFetch = global.fetch;
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      text: async () => JSON.stringify({
-        success: true,
-        quotes: [{
-          aggregator: 'test',
-          inputMint: '0x4200000000000000000000000000000000000006',
-          outputMint: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-          inAmount: '10000000000000000',
-          outAmount: '25000000',
-        }],
-      }),
+      json: async () => ({ jsonrpc: '2.0', id: 1, error: { code: -32000, message: 'execution reverted' } }),
+    });
+
+    const balance = await getErc20Balance('base', '0x4200000000000000000000000000000000000006', '0x' + 'ab'.repeat(20));
+    expect(balance).toBe(0n);
+
+    global.fetch = origFetch;
+  });
+
+  it('should return 0n on network failure', async () => {
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockRejectedValue(new Error('network error'));
+
+    const balance = await getErc20Balance('base', '0x4200000000000000000000000000000000000006', '0x' + 'ab'.repeat(20));
+    expect(balance).toBe(0n);
+
+    global.fetch = origFetch;
+  });
+});
+
+describe('getNativeBalance', () => {
+  it('should return balance from mocked RPC response', async () => {
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ jsonrpc: '2.0', id: 1, result: '0xde0b6b3a7640000' }),
+    });
+
+    const balance = await getNativeBalance('base', '0x' + 'ab'.repeat(20));
+    expect(balance).toBe(1000000000000000000n);
+
+    global.fetch = origFetch;
+  });
+
+  it('should return 0n on RPC error', async () => {
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ jsonrpc: '2.0', id: 1, error: { code: -32000, message: 'error' } }),
+    });
+
+    const balance = await getNativeBalance('base', '0x' + 'ab'.repeat(20));
+    expect(balance).toBe(0n);
+
+    global.fetch = origFetch;
+  });
+
+  it('should return 0n on network failure', async () => {
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockRejectedValue(new Error('network error'));
+
+    const balance = await getNativeBalance('base', '0x' + 'ab'.repeat(20));
+    expect(balance).toBe(0n);
+
+    global.fetch = origFetch;
+  });
+});
+
+// ============= Wrapped Native Token Auto-Substitution =============
+
+describe('resolveWrappedNativeToken', () => {
+  it('should not substitute non-wrapped tokens', async () => {
+    const result = await resolveWrappedNativeToken('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', 'base', '0x' + 'ab'.repeat(20), '1000');
+    expect(result.substituted).toBe(false);
+    expect(result.address).toBe('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+  });
+
+  it('should not substitute when WETH balance is sufficient', async () => {
+    const origFetch = global.fetch;
+    // First call: getErc20Balance returns sufficient balance
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ jsonrpc: '2.0', id: 1, result: '0x0000000000000000000000000000000000000000000000000de0b6b3a7640000' }), // 1 ETH
+    });
+
+    const result = await resolveWrappedNativeToken(
+      '0x4200000000000000000000000000000000000006', 'base', '0x' + 'ab'.repeat(20), '10000000000000000' // 0.01 ETH
+    );
+    expect(result.substituted).toBe(false);
+    expect(result.address).toBe('0x4200000000000000000000000000000000000006');
+
+    global.fetch = origFetch;
+  });
+
+  it('should substitute when WETH balance is zero but native ETH is sufficient', async () => {
+    const origFetch = global.fetch;
+    let callCount = 0;
+    global.fetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // getErc20Balance: zero WETH
+        return { ok: true, json: async () => ({ jsonrpc: '2.0', id: 1, result: '0x0' }) };
+      }
+      // getNativeBalance: 1 ETH
+      return { ok: true, json: async () => ({ jsonrpc: '2.0', id: 1, result: '0xde0b6b3a7640000' }) };
+    });
+
+    const result = await resolveWrappedNativeToken(
+      '0x4200000000000000000000000000000000000006', 'base', '0x' + 'ab'.repeat(20), '10000000000000000'
+    );
+    expect(result.substituted).toBe(true);
+    expect(result.address).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
+    expect(result.symbol).toBe('WETH');
+    expect(result.nativeSymbol).toBe('ETH');
+
+    global.fetch = origFetch;
+  });
+
+  it('should not substitute when both WETH and native ETH are insufficient', async () => {
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ jsonrpc: '2.0', id: 1, result: '0x0' }),
+    });
+
+    const result = await resolveWrappedNativeToken(
+      '0x4200000000000000000000000000000000000006', 'base', '0x' + 'ab'.repeat(20), '10000000000000000'
+    );
+    expect(result.substituted).toBe(false);
+    expect(result.address).toBe('0x4200000000000000000000000000000000000006');
+
+    global.fetch = origFetch;
+  });
+
+  it('should be case-insensitive for token address matching', async () => {
+    const origFetch = global.fetch;
+    let callCount = 0;
+    global.fetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) return { ok: true, json: async () => ({ jsonrpc: '2.0', id: 1, result: '0x0' }) };
+      return { ok: true, json: async () => ({ jsonrpc: '2.0', id: 1, result: '0xde0b6b3a7640000' }) };
+    });
+
+    const result = await resolveWrappedNativeToken(
+      '0x4200000000000000000000000000000000000006'.toUpperCase().replace('0X', '0x'), 'base', '0x' + 'ab'.repeat(20), '10000000000000000'
+    );
+    expect(result.substituted).toBe(true);
+
+    global.fetch = origFetch;
+  });
+
+  it('should not substitute for solana chain', async () => {
+    const result = await resolveWrappedNativeToken(
+      'So11111111111111111111111111111111111111112', 'solana', 'SomeAddress', '1000'
+    );
+    expect(result.substituted).toBe(false);
+  });
+
+  it('should not substitute for null/undefined inputs', async () => {
+    expect((await resolveWrappedNativeToken(null, 'base', '0xabc', '1000')).substituted).toBe(false);
+    expect((await resolveWrappedNativeToken(undefined, 'base', '0xabc', '1000')).substituted).toBe(false);
+    expect((await resolveWrappedNativeToken('0x4200000000000000000000000000000000000006', null, '0xabc', '1000')).substituted).toBe(false);
+  });
+});
+
+describe('quote handler wrapped native token auto-substitution', () => {
+  it('should auto-substitute --from WETH when wallet has no WETH but has native ETH', async () => {
+    createWallet('default', 'testpass');
+
+    const origFetch = global.fetch;
+    let callCount = 0;
+    global.fetch = vi.fn().mockImplementation(async (url, opts) => {
+      const body = opts?.body ? JSON.parse(opts.body) : null;
+
+      // RPC calls for balance checking
+      if (body?.jsonrpc === '2.0') {
+        callCount++;
+        if (callCount === 1) {
+          // getErc20Balance: zero WETH
+          return { ok: true, json: async () => ({ jsonrpc: '2.0', id: 1, result: '0x0' }) };
+        }
+        // getNativeBalance: 1 ETH
+        return { ok: true, json: async () => ({ jsonrpc: '2.0', id: 1, result: '0xde0b6b3a7640000' }) };
+      }
+
+      // Trading API quote call
+      return {
+        ok: true,
+        text: async () => JSON.stringify({
+          success: true,
+          quotes: [{
+            aggregator: 'test',
+            inputMint: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+            outputMint: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+            inAmount: '10000000000000000',
+            outAmount: '25000000',
+          }],
+        }),
+      };
     });
 
     const logs = [];
@@ -830,11 +1026,76 @@ describe('quote handler wrapped native token warnings', () => {
       amount: '10000000000000000',
     });
 
-    expect(logs.some(l => l.includes('WETH') && l.includes('wrapped ETH'))).toBe(true);
+    expect(logs.some(l => l.includes('Auto-substituted') && l.includes('WETH') && l.includes('ETH'))).toBe(true);
+
+    // Verify the API was called with native sentinel, not WETH address
+    const apiCall = global.fetch.mock.calls.find(c => {
+      const url = typeof c[0] === 'string' ? c[0] : '';
+      return url.includes('fromTokenAddress');
+    });
+    expect(apiCall).toBeTruthy();
+    const apiUrl = new URL(apiCall[0]);
+    expect(apiUrl.searchParams.get('fromTokenAddress')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
+
     global.fetch = origFetch;
   });
 
-  it('should not emit warning for native token sentinel', async () => {
+  it('should not substitute when wallet has sufficient WETH balance', async () => {
+    createWallet('default', 'testpass');
+
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockImplementation(async (url, opts) => {
+      const body = opts?.body ? JSON.parse(opts.body) : null;
+
+      // RPC call: getErc20Balance returns sufficient WETH
+      if (body?.jsonrpc === '2.0') {
+        return { ok: true, json: async () => ({ jsonrpc: '2.0', id: 1, result: '0xde0b6b3a7640000' }) };
+      }
+
+      // Trading API quote call
+      return {
+        ok: true,
+        text: async () => JSON.stringify({
+          success: true,
+          quotes: [{
+            aggregator: 'test',
+            inputMint: '0x4200000000000000000000000000000000000006',
+            outputMint: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+            inAmount: '10000000000000000',
+            outAmount: '25000000',
+          }],
+        }),
+      };
+    });
+
+    const logs = [];
+    const cmds = buildTradingCommands({
+      errorOutput: (msg) => logs.push(msg),
+      exit: () => {},
+    });
+
+    await cmds.quote([], null, {}, {
+      chain: 'base',
+      from: '0x4200000000000000000000000000000000000006',
+      to: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      amount: '10000000000000000',
+    });
+
+    expect(logs.some(l => l.includes('Auto-substituted'))).toBe(false);
+
+    // Verify the API was called with original WETH address
+    const apiCall = global.fetch.mock.calls.find(c => {
+      const url = typeof c[0] === 'string' ? c[0] : '';
+      return url.includes('fromTokenAddress');
+    });
+    expect(apiCall).toBeTruthy();
+    const apiUrl = new URL(apiCall[0]);
+    expect(apiUrl.searchParams.get('fromTokenAddress')).toBe('0x4200000000000000000000000000000000000006');
+
+    global.fetch = origFetch;
+  });
+
+  it('should not substitute for native token sentinel (not a wrapped token)', async () => {
     createWallet('default', 'testpass');
 
     const origFetch = global.fetch;
@@ -865,7 +1126,7 @@ describe('quote handler wrapped native token warnings', () => {
       amount: '10000000000000000',
     });
 
-    expect(logs.some(l => l.includes('WETH') && l.includes('wrapped'))).toBe(false);
+    expect(logs.some(l => l.includes('Auto-substituted'))).toBe(false);
     global.fetch = origFetch;
   });
 });

--- a/src/trading.js
+++ b/src/trading.js
@@ -455,6 +455,63 @@ export async function checkErc20Allowance(chain, tokenAddress, ownerAddress, spe
 }
 
 /**
+ * Get ERC-20 token balance for an address.
+ * Uses balanceOf(address) selector 0x70a08231.
+ * Returns 0n on any failure (network, invalid address, etc).
+ */
+export async function getErc20Balance(chain, tokenAddress, ownerAddress) {
+  const rpcUrl = EVM_RPC_URLS[chain];
+  if (!rpcUrl) return 0n;
+
+  try {
+    // balanceOf(address) selector = 0x70a08231
+    const data = '0x70a08231' + ownerAddress.slice(2).toLowerCase().padStart(64, '0');
+    const res = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_call',
+        params: [{ to: tokenAddress, data }, 'latest'],
+      }),
+    });
+    const body = await res.json();
+    if (body.error || !body.result) return 0n;
+    return BigInt(body.result);
+  } catch {
+    return 0n;
+  }
+}
+
+/**
+ * Get native token balance (ETH/BNB) for an address.
+ * Returns 0n on any failure.
+ */
+export async function getNativeBalance(chain, address) {
+  const rpcUrl = EVM_RPC_URLS[chain];
+  if (!rpcUrl) return 0n;
+
+  try {
+    const res = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_getBalance',
+        params: [address, 'latest'],
+      }),
+    });
+    const body = await res.json();
+    if (body.error || !body.result) return 0n;
+    return BigInt(body.result);
+  } catch {
+    return 0n;
+  }
+}
+
+/**
  * Send an ERC-20 approval transaction.
  * Required before swapping non-native EVM tokens.
  *
@@ -672,6 +729,38 @@ export function getWrappedNativeWarning(tokenAddress, chain, direction) {
     `If you hold native ${wrapped.nativeSymbol}, use the native token sentinel address instead: ${NATIVE_TOKEN_SENTINEL}`;
 }
 
+/**
+ * Auto-detect whether to substitute a wrapped native token (WETH/WBNB) with the native sentinel.
+ * Checks on-chain balances: if user lacks wrapped token but has native token, substitutes.
+ *
+ * @param {string} tokenAddress - Token address to check
+ * @param {string} chain - Chain name
+ * @param {string} walletAddress - User's wallet address
+ * @param {string} amount - Amount in base units (as string)
+ * @returns {Promise<{address: string, substituted: boolean, symbol?: string, nativeSymbol?: string}>}
+ */
+export async function resolveWrappedNativeToken(tokenAddress, chain, walletAddress, amount) {
+  if (!tokenAddress || !chain) return { address: tokenAddress, substituted: false };
+  const wrapped = WRAPPED_NATIVE_TOKENS[chain.toLowerCase()];
+  if (!wrapped) return { address: tokenAddress, substituted: false };
+  if (tokenAddress.toLowerCase() !== wrapped.address.toLowerCase()) return { address: tokenAddress, substituted: false };
+
+  const requiredAmount = BigInt(amount);
+
+  // Check if user has enough wrapped token balance
+  const wrappedBalance = await getErc20Balance(chain, wrapped.address, walletAddress);
+  if (wrappedBalance >= requiredAmount) return { address: tokenAddress, substituted: false };
+
+  // Check if user has enough native token balance
+  const nativeBalance = await getNativeBalance(chain, walletAddress);
+  if (nativeBalance >= requiredAmount) {
+    return { address: NATIVE_TOKEN_SENTINEL, substituted: true, symbol: wrapped.symbol, nativeSymbol: wrapped.nativeSymbol };
+  }
+
+  // Neither sufficient — let API handle the error
+  return { address: tokenAddress, substituted: false };
+}
+
 function formatQuote(quote, index) {
   const lines = [];
   const label = index !== undefined ? `  Quote #${index + 1}` : '  Best Quote';
@@ -698,7 +787,7 @@ export function buildTradingCommands(deps = {}) {
   return {
     'quote': async (args, apiInstance, flags, options) => {
       const chain = options.chain || args[0];
-      const from = options.from || options['from-token'] || args[1];
+      let from = options.from || options['from-token'] || args[1];
       const to = options.to || options['to-token'] || args[2];
       const amount = options.amount || args[3];
       const walletName = options.wallet;
@@ -751,8 +840,15 @@ EXAMPLES:
         errorOutput(`\nFetching quote on ${chainConfig.name}...`);
         errorOutput(`  Wallet: ${walletAddress}`);
 
-        const fromWarning = getWrappedNativeWarning(from, chain, 'from');
-        if (fromWarning) errorOutput(`  ${fromWarning}`);
+        // Auto-substitute wrapped native token for --from if wallet has native token instead
+        if (chainConfig.type === 'evm') {
+          const resolved = await resolveWrappedNativeToken(from, chain, walletAddress, amount);
+          if (resolved.substituted) {
+            errorOutput(`  Auto-substituted ${resolved.symbol} → native ${resolved.nativeSymbol} (wallet has native ${resolved.nativeSymbol}, not ${resolved.symbol})`);
+            from = resolved.address;
+          }
+        }
+
         const toWarning = getWrappedNativeWarning(to, chain, 'to');
         if (toWarning) errorOutput(`  ${toWarning}`);
 


### PR DESCRIPTION
## Summary
- Auto-detects wallet balances when `--from` is a wrapped native token (WETH/WBNB) and substitutes with native token sentinel if the wallet holds native ETH/BNB but not the wrapped version
- Adds `getErc20Balance`, `getNativeBalance`, and `resolveWrappedNativeToken` helpers using on-chain RPC calls
- Prevents `TRANSFER_FROM_FAILED` errors at execution time on Base/Ethereum/BSC
- Only applies to `--from` (input token); `--to` still shows a warning only

## Test plan
- [x] Unit tests for `getErc20Balance` (3 tests: success, RPC error, network failure)
- [x] Unit tests for `getNativeBalance` (3 tests: success, RPC error, network failure)
- [x] Unit tests for `resolveWrappedNativeToken` (7 tests: non-wrapped, sufficient WETH, zero WETH + native ETH, both insufficient, case-insensitive, solana, null inputs)
- [x] Integration tests for quote handler (3 tests: auto-substitution, no substitution with WETH balance, no substitution for sentinel)
- [x] All 627 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)