### PR TITLE
fix: trade help returns blank output

### DIFF
--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -2349,18 +2349,33 @@ describe('trade command routing', () => {
   it('should list subcommands when called with no args', async () => {
     const logs = [];
     const commands = buildCommands({ log: (msg) => logs.push(msg) });
-    await commands.trade([], null, {}, {});
+    const result = await commands.trade([], null, {}, {});
     const output = logs.join('\n');
     expect(output).toContain('quote');
     expect(output).toContain('execute');
+    expect(result.commands).toContain('quote');
+    expect(result.commands).toContain('execute');
+    expect(result.description).toBe('DEX trading commands');
+  });
+
+  it('should show help with help subcommand', async () => {
+    const logs = [];
+    const commands = buildCommands({ log: (msg) => logs.push(msg) });
+    const result = await commands.trade(['help'], null, {}, {});
+    const output = logs.join('\n');
+    expect(output).toContain('SUBCOMMANDS');
+    expect(output).toContain('USAGE');
+    expect(output).toContain('EXAMPLES');
+    expect(result.commands).toContain('quote');
+    expect(result.commands).toContain('execute');
   });
 
   it('should error on unknown subcommand', async () => {
-    const logs = [];
-    const commands = buildCommands({ log: (msg) => logs.push(msg) });
-    await commands.trade(['unknown'], null, {}, {});
-    const output = logs.join('\n');
-    expect(output).toContain('Unknown trade subcommand');
+    const commands = buildCommands({ log: () => {} });
+    const result = await commands.trade(['unknown'], null, {}, {});
+    expect(result.error).toContain('Unknown trade subcommand');
+    expect(result.available).toContain('quote');
+    expect(result.available).toContain('execute');
   });
 });
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -1325,13 +1325,13 @@ EXAMPLES:
 SYMBOLS:
   Common tokens resolve automatically: SOL, ETH, BNB, USDC, USDT, WETH, WBNB
   Raw addresses are also accepted.`);
-      return;
+      return {
+        commands: ['quote', 'execute'],
+        description: 'DEX trading commands',
+      };
     }
     if (!tradingCmds[sub]) {
-      log(`Unknown trade subcommand: ${sub}`);
-      log(`Available: quote, execute`);
-      log(`Run 'nansen trade help' for usage.`);
-      return;
+      return { error: `Unknown trade subcommand: ${sub}`, available: ['quote', 'execute'] };
     }
     return tradingCmds[sub](args.slice(1), apiInstance, flags, options);
   };


### PR DESCRIPTION
## Fix

`nansen trade help` returned empty output (exit code 0). The trade help handler was logging via `log()` but returning `undefined`, unlike wallet help which returns structured data.

### Changes
- Trade help now returns `{ commands: ['quote', 'execute'], description: 'DEX trading commands' }` matching the wallet pattern
- Unknown subcommand handler returns `{ error, available }` instead of just logging

**QA source:** nansen-cli v1.8.0 bug report — Bug #2 / Issue #90
All 629 tests pass.