### PR TITLE
feat: add DAI symbol shortcut for Ethereum trade commands

### DIFF
--- a/.changeset/add-dai-symbol.md
+++ b/.changeset/add-dai-symbol.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Add DAI symbol shortcut for Ethereum (resolves to 0x6b175474e89094c44da98b954eedeac495271d0f)

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -94,6 +94,7 @@ describe('resolveTokenAddress', () => {
     expect(resolveTokenAddress('USDC', 'base')).toBe('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913');
     expect(resolveTokenAddress('BNB', 'bsc')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
     expect(resolveTokenAddress('ETH', 'ethereum')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
+    expect(resolveTokenAddress('DAI', 'ethereum')).toBe('0x6b175474e89094c44da98b954eedeac495271d0f');
   });
 
   it('should be case-insensitive for symbols', () => {

--- a/src/trading.js
+++ b/src/trading.js
@@ -47,6 +47,7 @@ const TOKEN_SYMBOLS = {
     WETH: WRAPPED_NATIVE_TOKENS.ethereum.address,
     USDC: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
     USDT: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+    DAI:  '0x6b175474e89094c44da98b954eedeac495271d0f',
   },
   base: {
     ETH:  EVM_NATIVE,


### PR DESCRIPTION
Adds DAI to the existing TOKEN_SYMBOLS map for Ethereum. Symbol resolution was already implemented in PR #98 — this just fills the gap for DAI.

**QA source:** nansen-cli v1.8.0 bug report — Bug #3 / Issue #88
All 628 tests pass.