### PR TITLE
feat: dynamic token symbol resolution via search API fallback

### DIFF
--- a/.changeset/dynamic-symbol-resolution.md
+++ b/.changeset/dynamic-symbol-resolution.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Dynamically resolve unknown token symbols via Nansen search API when not found in the static map

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -87,36 +87,87 @@ describe('resolveChain', () => {
 });
 
 describe('resolveTokenAddress', () => {
-  it('should resolve common symbols to addresses', () => {
-    expect(resolveTokenAddress('SOL', 'solana')).toBe('So11111111111111111111111111111111111111112');
-    expect(resolveTokenAddress('USDC', 'solana')).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
-    expect(resolveTokenAddress('ETH', 'base')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
-    expect(resolveTokenAddress('USDC', 'base')).toBe('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913');
-    expect(resolveTokenAddress('BNB', 'bsc')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
-    expect(resolveTokenAddress('ETH', 'ethereum')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
+  it('should resolve common symbols to addresses', async () => {
+    expect(await resolveTokenAddress('SOL', 'solana')).toBe('So11111111111111111111111111111111111111112');
+    expect(await resolveTokenAddress('USDC', 'solana')).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+    expect(await resolveTokenAddress('ETH', 'base')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
+    expect(await resolveTokenAddress('USDC', 'base')).toBe('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913');
+    expect(await resolveTokenAddress('BNB', 'bsc')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
+    expect(await resolveTokenAddress('ETH', 'ethereum')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
   });
 
-  it('should be case-insensitive for symbols', () => {
-    expect(resolveTokenAddress('sol', 'solana')).toBe('So11111111111111111111111111111111111111112');
-    expect(resolveTokenAddress('usdc', 'ethereum')).toBe('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
-    expect(resolveTokenAddress('Eth', 'base')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
+  it('should be case-insensitive for symbols', async () => {
+    expect(await resolveTokenAddress('sol', 'solana')).toBe('So11111111111111111111111111111111111111112');
+    expect(await resolveTokenAddress('usdc', 'ethereum')).toBe('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
+    expect(await resolveTokenAddress('Eth', 'base')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
   });
 
-  it('should pass through raw addresses unchanged', () => {
+  it('should pass through raw addresses unchanged', async () => {
     const addr = '0x1234567890abcdef1234567890abcdef12345678';
-    expect(resolveTokenAddress(addr, 'ethereum')).toBe(addr);
-    expect(resolveTokenAddress('So11111111111111111111111111111111111111112', 'solana'))
+    expect(await resolveTokenAddress(addr, 'ethereum')).toBe(addr);
+    expect(await resolveTokenAddress('So11111111111111111111111111111111111111112', 'solana'))
       .toBe('So11111111111111111111111111111111111111112');
   });
 
-  it('should pass through unknown symbols unchanged', () => {
-    expect(resolveTokenAddress('SHIB', 'solana')).toBe('SHIB');
+  it('should pass through unknown symbols when no apiInstance provided', async () => {
+    expect(await resolveTokenAddress('SHIB', 'solana')).toBe('SHIB');
   });
 
-  it('should handle null/undefined gracefully', () => {
-    expect(resolveTokenAddress(null, 'solana')).toBe(null);
-    expect(resolveTokenAddress('SOL', null)).toBe('SOL');
-    expect(resolveTokenAddress(undefined, undefined)).toBe(undefined);
+  it('should handle null/undefined gracefully', async () => {
+    expect(await resolveTokenAddress(null, 'solana')).toBe(null);
+    expect(await resolveTokenAddress('SOL', null)).toBe('SOL');
+    expect(await resolveTokenAddress(undefined, undefined)).toBe(undefined);
+  });
+
+  it('should resolve unknown symbol via search API when apiInstance is provided', async () => {
+    const mockApi = {
+      generalSearch: vi.fn().mockResolvedValue({
+        data: [
+          { token_address: '0x6982508145454ce325ddbe47a25d4ec3d2311933', name: 'Pepe', chain: 'ethereum' },
+        ],
+      }),
+    };
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => {});
+    const result = await resolveTokenAddress('PEPE', 'ethereum', mockApi);
+    expect(result).toBe('0x6982508145454ce325ddbe47a25d4ec3d2311933');
+    expect(mockApi.generalSearch).toHaveBeenCalledWith({
+      query: 'PEPE',
+      resultType: 'token',
+      chain: 'ethereum',
+      limit: 5,
+    });
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('[resolve] "PEPE"'));
+    stderrSpy.mockRestore();
+  });
+
+  it('should not call search API for static map symbols even with apiInstance', async () => {
+    const mockApi = { generalSearch: vi.fn() };
+    const result = await resolveTokenAddress('SOL', 'solana', mockApi);
+    expect(result).toBe('So11111111111111111111111111111111111111112');
+    expect(mockApi.generalSearch).not.toHaveBeenCalled();
+  });
+
+  it('should not call search API for inputs that look like addresses', async () => {
+    const mockApi = { generalSearch: vi.fn() };
+    const evmAddr = '0x1234567890abcdef1234567890abcdef12345678';
+    expect(await resolveTokenAddress(evmAddr, 'ethereum', mockApi)).toBe(evmAddr);
+    expect(mockApi.generalSearch).not.toHaveBeenCalled();
+  });
+
+  it('should fall through silently when search API fails', async () => {
+    const mockApi = {
+      generalSearch: vi.fn().mockRejectedValue(new Error('Network error')),
+    };
+    const result = await resolveTokenAddress('PEPE', 'ethereum', mockApi);
+    expect(result).toBe('PEPE');
+  });
+
+  it('should fall through when search returns no results', async () => {
+    const mockApi = {
+      generalSearch: vi.fn().mockResolvedValue({ data: [] }),
+    };
+    const result = await resolveTokenAddress('UNKNOWN_TOKEN', 'ethereum', mockApi);
+    expect(result).toBe('UNKNOWN_TOKEN');
   });
 });
 

--- a/src/trading.js
+++ b/src/trading.js
@@ -64,17 +64,73 @@ const TOKEN_SYMBOLS = {
   },
 };
 
+// Address patterns used to detect whether input is already an address
+const ADDRESS_LIKE_EVM = /^0x[a-fA-F0-9]{40}$/;
+const ADDRESS_LIKE_SOLANA = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+const EVM_TRADE_CHAINS = new Set(['ethereum', 'base', 'bsc']);
+
+function looksLikeAddress(input, chainName) {
+  const chain = chainName?.toLowerCase();
+  if (chain === 'solana') return ADDRESS_LIKE_SOLANA.test(input);
+  if (EVM_TRADE_CHAINS.has(chain)) return ADDRESS_LIKE_EVM.test(input);
+  return ADDRESS_LIKE_EVM.test(input) || ADDRESS_LIKE_SOLANA.test(input);
+}
+
 /**
  * Resolve a token symbol (e.g. "SOL", "USDC") to its canonical address
  * for the given chain. Returns the input unchanged if no match is found
  * (assumes it's already a raw address).
+ *
+ * When an apiInstance is provided, unknown symbols that don't look like
+ * addresses are resolved dynamically via the Nansen search API.
  */
-export function resolveTokenAddress(symbolOrAddress, chainName) {
+export async function resolveTokenAddress(symbolOrAddress, chainName, apiInstance) {
   if (!symbolOrAddress || !chainName) return symbolOrAddress;
-  const chainTokens = TOKEN_SYMBOLS[chainName.toLowerCase()];
-  if (!chainTokens) return symbolOrAddress;
-  const resolved = chainTokens[symbolOrAddress.toUpperCase()];
-  return resolved || symbolOrAddress;
+  const chain = chainName.toLowerCase();
+
+  // Fast path: static map lookup (never triggers API call)
+  const chainTokens = TOKEN_SYMBOLS[chain];
+  if (chainTokens) {
+    const resolved = chainTokens[symbolOrAddress.toUpperCase()];
+    if (resolved) return resolved;
+  }
+
+  // If it already looks like an address, pass through
+  if (looksLikeAddress(symbolOrAddress, chain)) return symbolOrAddress;
+
+  // Dynamic lookup via Nansen search API (if available)
+  if (apiInstance) {
+    try {
+      const result = await apiInstance.generalSearch({
+        query: symbolOrAddress,
+        resultType: 'token',
+        chain,
+        limit: 5,
+      });
+      const tokens = result?.data || result?.results || [];
+      const match = tokens.find(t =>
+        t.chain?.toLowerCase() === chain ||
+        t.blockchain?.toLowerCase() === chain
+      ) || tokens[0];
+      if (match) {
+        const addr = match.token_address || match.address || match.contractAddress;
+        if (addr) {
+          const name = match.name || match.token_name || symbolOrAddress;
+          const shortAddr = addr.length > 16
+            ? `${addr.slice(0, 6)}...${addr.slice(-4)}`
+            : addr;
+          process.stderr.write(`[resolve] "${symbolOrAddress}" → ${shortAddr} (${name} on ${chain})\n`);
+          return addr;
+        }
+      }
+    } catch {
+      // Search failed (network error, no auth, etc.) — fall through silently
+    }
+  }
+
+  // No match found — pass through as-is and let the API give the error
+  return symbolOrAddress;
 }
 
 // Default public RPC endpoints (used for nonce fetching)
@@ -769,8 +825,8 @@ export function buildTradingCommands(deps = {}) {
       const chain = options.chain || args[0];
       const fromRaw = options.from || options['from-token'] || args[1];
       const toRaw = options.to || options['to-token'] || args[2];
-      const from = resolveTokenAddress(fromRaw, chain);
-      const to = resolveTokenAddress(toRaw, chain);
+      const from = await resolveTokenAddress(fromRaw, chain, apiInstance);
+      const to = await resolveTokenAddress(toRaw, chain, apiInstance);
       const amount = options.amount || args[3];
       const walletName = options.wallet;
       const slippage = options.slippage;


### PR DESCRIPTION
## What

When `--from` or `--to` is a symbol not in the static map (e.g. `PEPE`, `DOGE`), the CLI now calls the Nansen search API to resolve it to a token address before sending the trade request.

### How it works
1. **Static map** (SOL, ETH, USDC, etc.) → instant, no API call
2. **Looks like an address** (0x..., base58) → pass through
3. **Unknown symbol** → call `generalSearch()` filtered by chain, pick top result
4. **Stderr feedback** → `[resolve] "PEPE" → 0x6982...1933 (Pepe on ethereum)`
5. **Silent fallback** → if search fails (network/auth), pass through as-is

### Files changed
- `src/trading.js` — `resolveTokenAddress()` now async with API fallback + `looksLikeAddress()` helper
- `src/__tests__/trading.test.js` — 5 new test cases for dynamic resolution
- `.changeset/dynamic-symbol-resolution.md`

All 633 tests pass.