### PR TITLE
fix: replace stale test badge with CI status badge, fix CONTRIBUTING.md handler path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ npm run test:live
 ## Adding New Endpoints
 
 1. Add the API method in `src/api.js`
-2. Add the CLI handler in `src/index.js`
+2. Add the CLI handler in `src/cli.js`
 3. Add tests in `src/__tests__/api.test.js` and `src/__tests__/cli.test.js`
 4. Update `src/__tests__/coverage.test.js` with the new endpoint
 5. Update `README.md` with documentation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/nansen-cli.svg)](https://www.npmjs.com/package/nansen-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Tests](https://img.shields.io/badge/tests-577%20passing-brightgreen.svg)]()
+[![CI](https://github.com/nansen-ai/nansen-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/nansen-ai/nansen-cli/actions/workflows/ci.yml)
 
 > **Built by agents, for agents.** We prioritize the best possible AI agent experience.
 


### PR DESCRIPTION
Two small repo hygiene fixes:

- **README.md**: Replace hardcoded "577 passing" test badge with a GitHub Actions CI workflow status badge that auto-updates
- **CONTRIBUTING.md**: Fix CLI handler reference from `src/index.js` to `src/cli.js` (core CLI logic was extracted to cli.js)