### PR TITLE
Fix trade quote usage examples

### DIFF
--- a/.changeset/fix-trade-quote-examples.md
+++ b/.changeset/fix-trade-quote-examples.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix usage examples for `nansen trade quote` to show correct command name instead of deprecated `nansen quote`

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -555,7 +555,7 @@ describe('buildTradingCommands', () => {
 
     await cmds.quote([], null, {}, {});
     expect(exitCalled).toBe(true);
-    expect(logs.some(l => l.includes('Usage: nansen quote'))).toBe(true);
+    expect(logs.some(l => l.includes('Usage: nansen trade quote'))).toBe(true);
   });
 
   it('should show help when quote-id missing for execute', async () => {

--- a/src/trading.js
+++ b/src/trading.js
@@ -781,7 +781,7 @@ export function buildTradingCommands(deps = {}) {
 
       if (!chain || !from || !to || !amount) {
         errorOutput(`
-Usage: nansen quote --chain <chain> --from <token> --to <token> --amount <baseUnits>
+Usage: nansen trade quote --chain <chain> --from <token> --to <token> --amount <baseUnits>
 
 OPTIONS:
   --chain <chain>           Chain: solana, ethereum, base, bsc
@@ -795,9 +795,9 @@ OPTIONS:
   --swap-mode <mode>        exactIn (default) or exactOut
 
 EXAMPLES:
-  nansen quote --chain solana --from SOL --to USDC --amount 1000000000
-  nansen quote --chain base --from ETH --to USDC --amount 1000000000000000000
-  nansen quote --chain solana --from So11111111111111111111111111111111111111112 --to EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v --amount 1000000000
+  nansen trade quote --chain solana --from SOL --to USDC --amount 1000000000
+  nansen trade quote --chain base --from ETH --to USDC --amount 1000000000000000000
+  nansen trade quote --chain solana --from So11111111111111111111111111111111111111112 --to EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v --amount 1000000000
 `);
         exit(1);
         return;


### PR DESCRIPTION
## Summary
- Fix `nansen trade quote` help text to show correct command name instead of deprecated `nansen quote`
- Updates usage line and all three examples
- Updates corresponding test assertion

## Test plan
- [x] `npm test` passes (674 tests)
- [x] `nansen trade quote` shows correct examples
- [x] `nansen quote` deprecation warning still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)