### PR TITLE
Add --wallet and WalletConnect info to trade help text

### DIFF
--- a/.changeset/trade-help-walletconnect.md
+++ b/.changeset/trade-help-walletconnect.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Add --wallet and WalletConnect documentation to `nansen trade help` output

--- a/src/cli.js
+++ b/src/cli.js
@@ -1316,13 +1316,18 @@ SUBCOMMANDS:
   execute     Sign and broadcast a quoted swap
 
 USAGE:
-  nansen trade quote --chain <chain> --from <token> --to <token> --amount <units>
-  nansen trade execute --quote <quoteId>
+  nansen trade quote --chain <chain> --from <token> --to <token> --amount <units> [--wallet <name>]
+  nansen trade execute --quote <quoteId> [--wallet <name>]
 
 EXAMPLES:
   nansen trade quote --chain solana --from SOL --to USDC --amount 1000000000
   nansen trade quote --chain base --from ETH --to USDC --amount 1000000000000000000
+  nansen trade quote --chain base --from ETH --to USDC --amount 1000000000000000000 --wallet walletconnect
   nansen trade execute --quote 1708900000000-abc123
+
+WALLET:
+  --wallet <name>   Use a named wallet, or "walletconnect" / "wc" for WalletConnect (EVM only).
+                    Defaults to the default local wallet if omitted.
 
 SYMBOLS:
   Common tokens resolve automatically: SOL, ETH, BNB, USDC, USDT, WETH, WBNB


### PR DESCRIPTION
## Summary
- `nansen trade help` didn't mention the `--wallet` flag or WalletConnect support
- Adds a WALLET section explaining `--wallet` and `walletconnect`/`wc` usage
- Shows `[--wallet <name>]` in usage lines for both `quote` and `execute`
- Adds a WalletConnect example

## Test plan
- [x] `npm test` passes (674 tests)
- [x] `nansen trade help` now shows wallet/WalletConnect info

🤖 Generated with [Claude Code](https://claude.com/claude-code)