### PR TITLE
Add price impact warning for trade quotes

### DIFF
--- a/.changeset/price-impact-warning.md
+++ b/.changeset/price-impact-warning.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Show warning when trade quote price impact exceeds 5%, and show pin command to avoid fallback to worse quotes

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -28,6 +28,7 @@ import {
   getWrappedNativeFromWarning,
   validateBaseUnitAmount,
   resolveTokenAddress,
+  formatQuote,
 } from '../trading.js';
 import { keccak256, rlpEncode } from '../crypto.js';
 import { base58Decode } from '../transfer.js';
@@ -1179,5 +1180,31 @@ describe('API error handling', () => {
     })).rejects.toThrow(); // Should throw, not hang
 
     global.fetch = origFetch;
+  });
+});
+
+describe('formatQuote price impact warning', () => {
+  it('should show warning when priceImpactPct exceeds 5%', () => {
+    const output = formatQuote({ aggregator: 'jupiter', inputMint: 'So11111111111111111111111111111111111111112', outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', inAmount: '1000', outAmount: '500', priceImpactPct: '22.59' });
+    expect(output).toContain('⚠ Price impact is 22.59%!');
+    expect(output).not.toContain('Price Impact: 22.59%');
+  });
+
+  it('should show warning when priceImpactPct is negative and exceeds -5%', () => {
+    const output = formatQuote({ aggregator: 'okx', inputMint: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed', outputMint: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', inAmount: '100000000000000000000000000', outAmount: '31932262114904620119', priceImpactPct: '-10.03' });
+    expect(output).toContain('⚠ Price impact is 10.03%!');
+    expect(output).not.toContain('-10.03');
+  });
+
+  it('should show normal line when priceImpactPct is low', () => {
+    const output = formatQuote({ aggregator: 'jupiter', inputMint: 'So11111111111111111111111111111111111111112', outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', inAmount: '1000', outAmount: '500', priceImpactPct: '0.05' });
+    expect(output).toContain('Price Impact: 0.05%');
+    expect(output).not.toContain('WARNING');
+  });
+
+  it('should not show price impact line when priceImpactPct is absent', () => {
+    const output = formatQuote({ aggregator: 'jupiter', inputMint: 'So11111111111111111111111111111111111111112', outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', inAmount: '1000', outAmount: '500' });
+    expect(output).not.toContain('Price Impact');
+    expect(output).not.toContain('WARNING');
   });
 });

--- a/src/trading.js
+++ b/src/trading.js
@@ -742,7 +742,7 @@ export function validateBaseUnitAmount(amount) {
   return null;
 }
 
-function formatQuote(quote, index) {
+export function formatQuote(quote, index) {
   const lines = [];
   const label = index !== undefined ? `  Quote #${index + 1}` : '  Best Quote';
   lines.push(`${label} (${quote.aggregator || 'unknown'})`);
@@ -750,10 +750,21 @@ function formatQuote(quote, index) {
   lines.push(`    Output:       ${quote.outAmount} → ${quote.outputMint?.slice(0, 12)}...`);
   if (quote.inUsdValue)  lines.push(`    In USD:       $${quote.inUsdValue}`);
   if (quote.outUsdValue) lines.push(`    Out USD:      $${quote.outUsdValue}`);
-  if (quote.priceImpactPct) lines.push(`    Price Impact: ${quote.priceImpactPct}%`);
+  if (quote.priceImpactPct) {
+    const impactAbs = Math.abs(parseFloat(quote.priceImpactPct));
+    if (impactAbs <= 5) {
+      lines.push(`    Price Impact: ${impactAbs}%`);
+    }
+  }
   if (quote.tradingFeeInUsd) lines.push(`    Trading Fee:  $${quote.tradingFeeInUsd}`);
   if (quote.networkFeeInUsd) lines.push(`    Network Fee:  $${quote.networkFeeInUsd}`);
   if (quote.approvalAddress && !isNativeToken(quote.inputMint)) lines.push(`    ⚠ Requires token approval to: ${quote.approvalAddress}`);
+  if (quote.priceImpactPct) {
+    const impactAbs = Math.abs(parseFloat(quote.priceImpactPct));
+    if (impactAbs > 5) {
+      lines.push(`    ⚠ Price impact is ${impactAbs}%! You may lose significant value.`);
+    }
+  }
   return lines.join('\n');
 }
 
@@ -877,6 +888,9 @@ EXAMPLES:
         const quoteId = saveQuote(response, chain, isWalletConnect ? 'walletconnect' : 'local');
         errorOutput(`\n  Quote ID: ${quoteId}`);
         errorOutput(`  Execute:  nansen trade execute --quote ${quoteId}`);
+        if (response.quotes.length > 1) {
+          errorOutput(`  Pin #1:  nansen trade execute --quote ${quoteId} --quote-index 0`);
+        }
 
         if (response.quotes[0]?.approvalAddress && !isNativeToken(response.quotes[0]?.inputMint)) {
           errorOutput(`\n  Warning: This token swap requires an ERC-20 approval step.`);


### PR DESCRIPTION
Closes #91

## Summary

- Show `⚠` warning when price impact exceeds 5%, grouped with other warnings at the bottom of each quote
- Handle negative `priceImpactPct` values from the API (use absolute value for display)
- Show `--quote-index` pin command when multiple quotes returned, so users can avoid fallback to worse-impact quotes

## Example output

```
  Quote #1 (lifi)
    Input:        100000000000000000000000000 → 0x4ed4E86286...
    Output:       31950281133383098368 → 0xeeeeeeeeee...
    In USD:       $71370
    Out USD:      $64953.643532922506
    Trading Fee:  $178.425
    Network Fee:  $0.0705
    ⚠ Requires token approval to: 0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE
    ⚠ Price impact is 8.76%! You may lose significant value.
  Quote #2 (okx)
    Input:        100000000000000000000000000 → 0x4ed4e86286...
    Output:       31829264456339906105 → 0xeeeeeeeeee...
    In USD:       $69137.84
    Out USD:      $62363.40
    Trading Fee:  $155.91
    Network Fee:  $0.03
    ⚠ Requires token approval to: 0x57df6092665eb6058de53939612413ff4b09114e
    ⚠ Price impact is 9.57%! You may lose significant value.

  Quote ID: 1772192874143-330bd823
  Execute:  nansen trade execute --quote 1772192874143-330bd823
  Pin #1:  nansen trade execute --quote 1772192874143-330bd823 --quote-index 0
```

## Test plan

- [x] `npm test` passes (678 tests)
- [x] Verified live against DEGEN→ETH on Base (high price impact pair from #91)
- [x] Warning shown for negative `priceImpactPct` values (API returns negative)
- [x] Normal `Price Impact:` line shown for low impact
- [x] No price impact line when field is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)