### PR TITLE
fix: update perp screener sort/field names to match v1.9 API

### DIFF
--- a/skills/nansen-perp/SKILL.md
+++ b/skills/nansen-perp/SKILL.md
@@ -12,11 +12,11 @@ No `--chain` flag needed — Hyperliquid only.
 
 ```bash
 # Top perp markets by volume
-nansen research perp screener --sort volume_usd:desc --limit 20
+nansen research perp screener --sort volume:desc --limit 20
 
 # Agent pattern — JSON output
-nansen research perp screener --sort open_interest_usd:desc --limit 10 --output json \
-  --fields symbol,volume_usd,open_interest_usd,funding_rate
+nansen research perp screener --sort open_interest:desc --limit 10 --output json \
+  --fields token_symbol,volume,open_interest,funding
 ```
 
 ## Leaderboard
@@ -30,7 +30,7 @@ nansen research perp leaderboard --days 7 --limit 20
 
 | Flag | Purpose |
 |------|---------|
-| `--sort field:dir` | Sort (e.g. `volume_usd:desc`) |
+| `--sort field:dir` | Sort (e.g. `volume:desc`) |
 | `--limit` | Number of results |
 | `--days` | Lookback period |
 | `--output json` | JSON output |


### PR DESCRIPTION
## Summary

- Fixes outdated field names in the `nansen-perp` skill that broke `--sort` and `--fields` for the perp screener
- `volume_usd` → `volume`, `open_interest_usd` → `open_interest`, `funding_rate` → `funding`, `symbol` → `token_symbol`
- Verified all commands work against the live API on nansen-cli v1.9.3

## Test plan

- [x] `nansen research perp screener --sort volume:desc --limit 5 --table` returns data
- [x] `nansen research perp screener --sort open_interest:desc --limit 5 --output json --fields token_symbol,volume,open_interest,funding` returns correct JSON


Made with [Cursor](https://cursor.com)