### PR TITLE
fix: API key prompt masking shows real chars alongside asterisks

### DIFF
--- a/.changeset/fix-prompt-masking.md
+++ b/.changeset/fix-prompt-masking.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix API key prompt masking: each keystroke was showing the real character followed by `*` (e.g. `f*o*o*`) because the readline interface was active alongside raw mode, causing double output. Moving readline creation into the non-hidden branch eliminates the double-echo and also fixes backspace incorrectly clearing the prompt label.

--- a/src/cli.js
+++ b/src/cli.js
@@ -786,11 +786,6 @@ Skills: npx skills add nansen-ai/nansen-cli (agent-optimised docs per command gr
 
 // Helper to prompt for input (exported for mocking)
 export async function prompt(question, hidden = false) {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
-  });
-  
   return new Promise((resolve) => {
     if (hidden && process.stdout.isTTY) {
       process.stdout.write(question);
@@ -805,7 +800,6 @@ export async function prompt(question, hidden = false) {
           process.stdin.pause();
           process.stdin.removeListener('data', onData);
           process.stdout.write('\n');
-          rl.close();
           resolve(input);
         } else if (char === '\u0003') {
           // Ctrl+C
@@ -824,6 +818,10 @@ export async function prompt(question, hidden = false) {
       
       process.stdin.on('data', onData);
     } else {
+      const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+      });
       rl.question(question, (answer) => {
         rl.close();
         resolve(answer);


### PR DESCRIPTION
## Problem

When entering an API key interactively, each keystroke showed the real character \*and\* an asterisk:
```
Enter your API key: f*o*o*
```
Also, backspace could over-erase into the prompt label itself.

## Root cause

`readline.createInterface` was called before the `hidden/visible` branch, leaving it active during raw mode. This caused each keystroke to be output twice — once by readline's own echo, and once by our `'*'` handler.

## Fix

Move `readline.createInterface` into the non-hidden `else` branch only. The hidden branch uses raw mode directly with no readline involvement — 6 lines changed, nothing else affected.

```
Enter your API key: ***
```

## Test output

```
Test Files  15 passed (15)
      Tests  675 passed | 2 skipped (677)
   Duration  13.32s
```