### PR TITLE
feat: add production-ready nansen watch command for real-time monitoring

### DIFF
--- a/.changeset/add-watch-command.md
+++ b/.changeset/add-watch-command.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add production-ready `nansen watch` command for real-time wallet and token monitoring with NDJSON output

--- a/src/__tests__/watch.test.js
+++ b/src/__tests__/watch.test.js
@@ -1,0 +1,623 @@
+/**
+ * Watch Command Tests
+ * Tests for the nansen watch command: polling, NDJSON output, retries,
+ * state persistence, interval clamping, heartbeats, timeouts, shutdown.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runWatch, clampInterval, loadWatchState, saveWatchState, buildWatchCommand } from '../watch.js';
+import { runCLI } from '../cli.js';
+import fs from 'fs';
+import path from 'path';
+import { getConfigDir } from '../api.js';
+
+const STATE_DIR = path.join(getConfigDir(), 'watch-state');
+const STATE_FILE = path.join(STATE_DIR, 'watch-state.json');
+
+// Helper: collect NDJSON output lines as parsed objects
+function createOutputCollector() {
+  const lines = [];
+  const output = (line) => lines.push(JSON.parse(line));
+  return { lines, output };
+}
+
+// Helper: create a mock API
+function createMockApi(responses = []) {
+  let callCount = 0;
+  return {
+    addressTransactions: vi.fn(async () => {
+      const resp = responses[callCount] || responses[responses.length - 1] || { data: [] };
+      callCount++;
+      if (resp instanceof Error) throw resp;
+      return resp;
+    }),
+    tokenDexTrades: vi.fn(async () => {
+      const resp = responses[callCount] || responses[responses.length - 1] || { data: [] };
+      callCount++;
+      if (resp instanceof Error) throw resp;
+      return resp;
+    })
+  };
+}
+
+describe('clampInterval', () => {
+  it('should return interval unchanged when within bounds', () => {
+    const { interval, warning } = clampInterval(30, null);
+    expect(interval).toBe(30);
+    expect(warning).toBeNull();
+  });
+
+  it('should clamp interval below minimum to 10', () => {
+    const warns = [];
+    const { interval, warning } = clampInterval(5, (msg) => warns.push(msg));
+    expect(interval).toBe(10);
+    expect(warning).toContain('below minimum');
+    expect(warns).toHaveLength(1);
+  });
+
+  it('should clamp interval above maximum to 3600', () => {
+    const warns = [];
+    const { interval, warning } = clampInterval(5000, (msg) => warns.push(msg));
+    expect(interval).toBe(3600);
+    expect(warning).toContain('above maximum');
+  });
+
+  it('should handle exact boundaries', () => {
+    expect(clampInterval(10, null).interval).toBe(10);
+    expect(clampInterval(3600, null).interval).toBe(3600);
+  });
+});
+
+describe('State Persistence', () => {
+  beforeEach(() => {
+    // Clean up state file
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+
+  afterEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+
+  it('should return empty object when no state file exists', () => {
+    const state = loadWatchState();
+    expect(state).toEqual({});
+  });
+
+  it('should save and load state', () => {
+    const state = { 'wallet:ethereum:0x123': { seenKeys: ['tx1', 'tx2'], lastPoll: '2025-01-01T00:00:00Z' } };
+    saveWatchState(state);
+    const loaded = loadWatchState();
+    expect(loaded).toEqual(state);
+  });
+
+  it('should handle corrupted state file gracefully', () => {
+    if (!fs.existsSync(STATE_DIR)) {
+      fs.mkdirSync(STATE_DIR, { recursive: true });
+    }
+    fs.writeFileSync(STATE_FILE, 'not json');
+    const state = loadWatchState();
+    expect(state).toEqual({});
+  });
+});
+
+describe('runWatch - wallet', () => {
+  beforeEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+  afterEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+
+  it('should emit started event and stop with --once', async () => {
+    const { lines, output } = createOutputCollector();
+    const api = createMockApi([{ data: [] }]);
+
+    await runWatch({
+      watchType: 'wallet',
+      address: '0x' + 'a'.repeat(40),
+      chain: 'ethereum',
+      interval: 30,
+      once: true,
+      api,
+      output,
+      errorOutput: () => {},
+    });
+
+    expect(lines.length).toBeGreaterThanOrEqual(2); // started + stopped
+    expect(lines[0].type).toBe('started');
+    expect(lines[0].watchType).toBe('wallet');
+    expect(lines[0].chain).toBe('ethereum');
+    expect(lines[0].interval).toBe(30);
+    expect(lines[lines.length - 1].type).toBe('stopped');
+    expect(lines[lines.length - 1].reason).toBe('once');
+  });
+
+  it('should emit wallet_activity events for new records', async () => {
+    const { lines, output } = createOutputCollector();
+    const api = createMockApi([{
+      data: [
+        { transaction_hash: 'tx1', value_usd: 100 },
+        { transaction_hash: 'tx2', value_usd: 200 }
+      ]
+    }]);
+
+    await runWatch({
+      watchType: 'wallet',
+      address: '0x' + 'b'.repeat(40),
+      chain: 'ethereum',
+      interval: 30,
+      once: true,
+      api,
+      output,
+      errorOutput: () => {},
+    });
+
+    const dataEvents = lines.filter(l => l.type === 'wallet_activity');
+    expect(dataEvents).toHaveLength(2);
+    expect(dataEvents[0].data.transaction_hash).toBe('tx1');
+    expect(dataEvents[1].data.transaction_hash).toBe('tx2');
+    expect(dataEvents[0].address).toBe('0x' + 'b'.repeat(40));
+    expect(dataEvents[0].chain).toBe('ethereum');
+  });
+
+  it('should deduplicate records using state persistence across runs', async () => {
+    const address = '0x' + 'c'.repeat(40);
+
+    // First run: see tx1
+    const { lines: lines1, output: output1 } = createOutputCollector();
+    await runWatch({
+      watchType: 'wallet',
+      address,
+      chain: 'ethereum',
+      once: true,
+      api: createMockApi([{ data: [{ transaction_hash: 'tx1', value_usd: 100 }] }]),
+      output: output1,
+      errorOutput: () => {},
+    });
+
+    const run1Data = lines1.filter(l => l.type === 'wallet_activity');
+    expect(run1Data).toHaveLength(1);
+    expect(run1Data[0].data.transaction_hash).toBe('tx1');
+
+    // Second run: tx1 already seen (via state persistence), only tx3 is new
+    const { lines: lines2, output: output2 } = createOutputCollector();
+    await runWatch({
+      watchType: 'wallet',
+      address,
+      chain: 'ethereum',
+      once: true,
+      api: createMockApi([{ data: [
+        { transaction_hash: 'tx1', value_usd: 100 },
+        { transaction_hash: 'tx3', value_usd: 300 }
+      ] }]),
+      output: output2,
+      errorOutput: () => {},
+    });
+
+    const run2Data = lines2.filter(l => l.type === 'wallet_activity');
+    expect(run2Data).toHaveLength(1);
+    expect(run2Data[0].data.transaction_hash).toBe('tx3');
+  });
+
+  it('should emit heartbeat events between polls', async () => {
+    const { lines, output } = createOutputCollector();
+    let pollCount = 0;
+    let signalHandler = null;
+
+    const api = {
+      addressTransactions: vi.fn(async () => {
+        pollCount++;
+        if (pollCount >= 2) signalHandler();
+        return { data: [] };
+      })
+    };
+
+    await runWatch({
+      watchType: 'wallet',
+      address: '0x' + 'd'.repeat(40),
+      chain: 'ethereum',
+      interval: 10,
+      api,
+      output,
+      errorOutput: () => {},
+      onSignal: (handler) => { signalHandler = handler; }
+    });
+
+    const heartbeats = lines.filter(l => l.type === 'heartbeat');
+    expect(heartbeats.length).toBeGreaterThanOrEqual(1);
+    expect(heartbeats[0].nextPollIn).toBe(10);
+  });
+
+  it('should emit error event on missing address', async () => {
+    const { lines, output } = createOutputCollector();
+
+    const result = await runWatch({
+      watchType: 'wallet',
+      address: '',
+      chain: 'ethereum',
+      api: createMockApi(),
+      output,
+      errorOutput: () => {},
+    });
+
+    expect(result.exitCode).toBe(1);
+    const errors = lines.filter(l => l.type === 'error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].fatal).toBe(true);
+  });
+
+  it('should emit error event on invalid address', async () => {
+    const { lines, output } = createOutputCollector();
+
+    const result = await runWatch({
+      watchType: 'wallet',
+      address: 'not-an-address',
+      chain: 'ethereum',
+      api: createMockApi(),
+      output,
+      errorOutput: () => {},
+    });
+
+    expect(result.exitCode).toBe(1);
+    const errors = lines.filter(l => l.type === 'error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].fatal).toBe(true);
+    expect(errors[0].error).toContain('Invalid EVM address');
+  });
+
+  it('should emit error event on unknown watch type', async () => {
+    const { lines, output } = createOutputCollector();
+
+    const result = await runWatch({
+      watchType: 'something',
+      address: '0x' + 'a'.repeat(40),
+      chain: 'ethereum',
+      api: createMockApi(),
+      output,
+      errorOutput: () => {},
+    });
+
+    expect(result.exitCode).toBe(1);
+    const errors = lines.filter(l => l.type === 'error');
+    expect(errors[0].error).toContain('Unknown watch type');
+  });
+});
+
+describe('runWatch - token', () => {
+  beforeEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+  afterEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+
+  it('should poll tokenDexTrades for token watch type', async () => {
+    const { lines, output } = createOutputCollector();
+    const api = createMockApi([{
+      data: [
+        { tx_hash: 'dex1', value_usd: 500 }
+      ]
+    }]);
+
+    await runWatch({
+      watchType: 'token',
+      address: 'So11111111111111111111111111111111111111112',
+      chain: 'solana',
+      interval: 30,
+      once: true,
+      api,
+      output,
+      errorOutput: () => {},
+    });
+
+    expect(api.tokenDexTrades).toHaveBeenCalled();
+    const dataEvents = lines.filter(l => l.type === 'token_activity');
+    expect(dataEvents).toHaveLength(1);
+    expect(dataEvents[0].data.tx_hash).toBe('dex1');
+  });
+});
+
+describe('runWatch - retries', () => {
+  beforeEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+  afterEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+
+  it('should retry on API failure and emit error after exhausting retries', async () => {
+    const { lines, output } = createOutputCollector();
+
+    const api = {
+      addressTransactions: vi.fn(async () => {
+        throw new Error('API timeout');
+      })
+    };
+
+    await runWatch({
+      watchType: 'wallet',
+      address: '0x' + 'e'.repeat(40),
+      chain: 'ethereum',
+      once: true,
+      api,
+      output,
+      errorOutput: () => {},
+    });
+
+    // Should have been called 3 times (retry attempts)
+    expect(api.addressTransactions).toHaveBeenCalledTimes(3);
+
+    const errors = lines.filter(l => l.type === 'error' && l.error.includes('API call failed'));
+    expect(errors).toHaveLength(1);
+    expect(errors[0].fatal).toBe(false);
+    expect(errors[0].error).toContain('3 retries');
+  });
+});
+
+describe('runWatch - timeout', () => {
+  beforeEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+  afterEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+
+  it('should stop after timeout seconds', async () => {
+    const { lines, output } = createOutputCollector();
+    const api = createMockApi([{ data: [] }]);
+
+    const start = Date.now();
+    await runWatch({
+      watchType: 'wallet',
+      address: '0x' + 'f'.repeat(40),
+      chain: 'ethereum',
+      interval: 10,
+      timeout: 2, // 2 seconds
+      api,
+      output,
+      errorOutput: () => {},
+    });
+    const elapsed = Date.now() - start;
+
+    const stopped = lines.filter(l => l.type === 'stopped');
+    expect(stopped).toHaveLength(1);
+    expect(stopped[0].reason).toBe('timeout');
+    expect(elapsed).toBeLessThan(10000); // should stop well before 10s
+  });
+});
+
+describe('runWatch - interval clamping', () => {
+  beforeEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+  afterEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+
+  it('should clamp interval below minimum and emit warning', async () => {
+    const { lines, output } = createOutputCollector();
+    const api = createMockApi([{ data: [] }]);
+    const warnings = [];
+
+    await runWatch({
+      watchType: 'wallet',
+      address: '0x' + 'a'.repeat(40),
+      chain: 'ethereum',
+      interval: 3, // below minimum
+      once: true,
+      api,
+      output,
+      errorOutput: (msg) => warnings.push(msg),
+    });
+
+    // Should have emitted an error event about clamping
+    const clampErrors = lines.filter(l => l.type === 'error' && l.error.includes('Clamped'));
+    expect(clampErrors).toHaveLength(1);
+
+    // Started event should show clamped interval
+    const started = lines.find(l => l.type === 'started');
+    expect(started.interval).toBe(10);
+  });
+});
+
+describe('runWatch - state persistence', () => {
+  beforeEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+  afterEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+
+  it('should persist seen keys and skip them on restart', async () => {
+    const address = '0x' + 'a'.repeat(40);
+
+    // First run - see tx1
+    const { lines: lines1, output: output1 } = createOutputCollector();
+    await runWatch({
+      watchType: 'wallet',
+      address,
+      chain: 'ethereum',
+      once: true,
+      api: createMockApi([{ data: [{ transaction_hash: 'tx1', value_usd: 100 }] }]),
+      output: output1,
+      errorOutput: () => {},
+    });
+
+    const firstRunData = lines1.filter(l => l.type === 'wallet_activity');
+    expect(firstRunData).toHaveLength(1);
+
+    // Second run - same tx1 should be skipped, tx2 should be new
+    const { lines: lines2, output: output2 } = createOutputCollector();
+    await runWatch({
+      watchType: 'wallet',
+      address,
+      chain: 'ethereum',
+      once: true,
+      api: createMockApi([{ data: [{ transaction_hash: 'tx1', value_usd: 100 }, { transaction_hash: 'tx2', value_usd: 200 }] }]),
+      output: output2,
+      errorOutput: () => {},
+    });
+
+    const secondRunData = lines2.filter(l => l.type === 'wallet_activity');
+    expect(secondRunData).toHaveLength(1);
+    expect(secondRunData[0].data.transaction_hash).toBe('tx2');
+  });
+});
+
+describe('runWatch - graceful shutdown', () => {
+  beforeEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+  afterEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+
+  it('should emit stopped event on signal', async () => {
+    const { lines, output } = createOutputCollector();
+    let signalHandler = null;
+    let pollCount = 0;
+
+    const api = {
+      addressTransactions: vi.fn(async () => {
+        pollCount++;
+        if (pollCount >= 1) signalHandler();
+        return { data: [] };
+      })
+    };
+
+    await runWatch({
+      watchType: 'wallet',
+      address: '0x' + 'a'.repeat(40),
+      chain: 'ethereum',
+      interval: 10,
+      api,
+      output,
+      errorOutput: () => {},
+      onSignal: (handler) => { signalHandler = handler; }
+    });
+
+    const stopped = lines.filter(l => l.type === 'stopped');
+    expect(stopped).toHaveLength(1);
+    expect(stopped[0].reason).toBe('signal');
+  });
+});
+
+describe('runWatch - various response shapes', () => {
+  beforeEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+  afterEach(() => {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+  });
+
+  it('should handle nested results shape', async () => {
+    const { lines, output } = createOutputCollector();
+    const api = createMockApi([{
+      data: {
+        results: [
+          { transaction_hash: 'nested1', value_usd: 50 }
+        ]
+      }
+    }]);
+
+    await runWatch({
+      watchType: 'wallet',
+      address: '0x' + 'a'.repeat(40),
+      chain: 'ethereum',
+      once: true,
+      api,
+      output,
+      errorOutput: () => {},
+    });
+
+    const data = lines.filter(l => l.type === 'wallet_activity');
+    expect(data).toHaveLength(1);
+    expect(data[0].data.transaction_hash).toBe('nested1');
+  });
+
+  it('should handle array response shape', async () => {
+    const { lines, output } = createOutputCollector();
+    const api = createMockApi([[
+      { transaction_hash: 'arr1', value_usd: 10 }
+    ]]);
+
+    await runWatch({
+      watchType: 'wallet',
+      address: '0x' + 'a'.repeat(40),
+      chain: 'ethereum',
+      once: true,
+      api,
+      output,
+      errorOutput: () => {},
+    });
+
+    const data = lines.filter(l => l.type === 'wallet_activity');
+    expect(data).toHaveLength(1);
+  });
+});
+
+describe('buildWatchCommand', () => {
+  it('should output help when no subcommand given', async () => {
+    const outputLines = [];
+    const cmd = buildWatchCommand({ output: (l) => outputLines.push(l) });
+    await cmd([], null, {}, {});
+
+    const help = JSON.parse(outputLines[0]);
+    expect(help.command).toBe('watch');
+    expect(help.subcommands.wallet).toBeDefined();
+    expect(help.subcommands.token).toBeDefined();
+  });
+
+  it('should output help for "help" subcommand', async () => {
+    const outputLines = [];
+    const cmd = buildWatchCommand({ output: (l) => outputLines.push(l) });
+    await cmd(['help'], null, {}, {});
+
+    const help = JSON.parse(outputLines[0]);
+    expect(help.command).toBe('watch');
+  });
+});
+
+describe('runCLI watch integration', () => {
+  it('should route watch command and emit NDJSON', async () => {
+    const outputLines = [];
+    const mockApi = createMockApi([{ data: [{ transaction_hash: 'cli_tx1' }] }]);
+
+    const result = await runCLI(
+      ['watch', 'wallet', '--address', '0x' + 'a'.repeat(40), '--chain', 'ethereum', '--once'],
+      {
+        output: (line) => outputLines.push(line),
+        errorOutput: () => {},
+        exit: () => {},
+        NansenAPIClass: class {
+          constructor() { return mockApi; }
+        }
+      }
+    );
+
+    expect(result.type).toBe('watch');
+    // Should have NDJSON lines
+    const parsed = outputLines.map(l => JSON.parse(l));
+    expect(parsed.some(e => e.type === 'started')).toBe(true);
+    expect(parsed.some(e => e.type === 'stopped')).toBe(true);
+  });
+
+  it('should handle watch help', async () => {
+    const outputLines = [];
+
+    await runCLI(
+      ['watch'],
+      {
+        output: (line) => outputLines.push(line),
+        errorOutput: () => {},
+        exit: () => {},
+        NansenAPIClass: class {
+          constructor() { return createMockApi(); }
+        }
+      }
+    );
+
+    const help = JSON.parse(outputLines[0]);
+    expect(help.command).toBe('watch');
+  });
+});

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,6 +6,7 @@
 import { NansenAPI, NansenError, ErrorCode, saveConfig, deleteConfig, getConfigFile, clearCache, getCacheDir, validateAddress, sleep } from './api.js';
 import { buildWalletCommands } from './wallet.js';
 import { buildTradingCommands } from './trading.js';
+import { buildWatchCommand } from './watch.js';
 import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
@@ -135,6 +136,31 @@ export const SCHEMA = {
         }
       }
     },
+    'watch': {
+      description: 'Watch wallet or token activity in real-time (NDJSON output)',
+      subcommands: {
+        'wallet': {
+          description: 'Watch wallet transactions',
+          options: {
+            address: { type: 'string', required: true, description: 'Wallet address' },
+            chain: { type: 'string', default: 'ethereum', description: 'Blockchain' },
+            interval: { type: 'number', default: 30, description: 'Poll interval in seconds (min: 10, max: 3600)' },
+            once: { type: 'boolean', description: 'Poll once and exit' },
+            timeout: { type: 'number', description: 'Auto-stop after N seconds' }
+          }
+        },
+        'token': {
+          description: 'Watch token DEX trades',
+          options: {
+            address: { type: 'string', required: true, description: 'Token address' },
+            chain: { type: 'string', default: 'solana', description: 'Blockchain' },
+            interval: { type: 'number', default: 30, description: 'Poll interval in seconds (min: 10, max: 3600)' },
+            once: { type: 'boolean', description: 'Poll once and exit' },
+            timeout: { type: 'number', description: 'Auto-stop after N seconds' }
+          }
+        }
+      }
+    },
     'trade': {
       description: 'DEX trading commands',
       subcommands: {
@@ -244,7 +270,7 @@ export function parseArgs(args) {
       const key = arg.slice(2);
       const next = args[i + 1];
       
-      if (key === 'pretty' || key === 'help' || key === 'version' || key === 'table' || key === 'no-retry' || key === 'cache' || key === 'no-cache' || key === 'stream' || key === 'enrich') {
+      if (key === 'pretty' || key === 'help' || key === 'version' || key === 'table' || key === 'no-retry' || key === 'cache' || key === 'no-cache' || key === 'stream' || key === 'enrich' || key === 'once') {
         result.flags[key] = true;
       } else if (next && !next.startsWith('-')) {
         // Try to parse as JSON first (for objects/arrays/booleans),
@@ -1513,7 +1539,7 @@ export async function runCLI(rawArgs, deps = {}) {
     if (updateNotification) errorOutput(updateNotification);
   };
 
-  const commands = { ...buildCommands(deps), ...buildWalletCommands(deps), ...buildTradingCommands(deps), ...commandOverrides };
+  const commands = { ...buildCommands(deps), ...buildWalletCommands(deps), ...buildTradingCommands(deps), watch: buildWatchCommand(deps), ...commandOverrides };
 
   if (flags.version || flags.v) {
     output(VERSION);
@@ -1650,8 +1676,16 @@ export async function runCLI(rawArgs, deps = {}) {
       defaultHeaders['Payment-Signature'] = options['x402-payment-signature'];
     }
     const api = new NansenAPIClass(undefined, undefined, { retry: retryOptions, cache: cacheOptions, defaultHeaders });
+
+    // Watch command handles its own output (NDJSON)
+    if (command === 'watch') {
+      const result = await commands[command](subArgs, api, flags, options);
+      notify();
+      return { type: 'watch', data: result };
+    }
+
     let result = await commands[command](subArgs, api, flags, options);
-    
+
     // Apply field filtering if --fields is specified
     const fields = parseFields(options.fields);
     if (fields) {

--- a/src/watch.js
+++ b/src/watch.js
@@ -1,0 +1,359 @@
+/**
+ * Nansen CLI - Watch Command
+ * Long-running polling for wallet and token activity, outputting NDJSON events.
+ * Designed for AI agent consumption with heartbeats, state persistence, and graceful shutdown.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { validateAddress, validateTokenAddress, getConfigDir, sleep } from './api.js';
+
+// ============= Constants =============
+
+const MIN_INTERVAL = 10;
+const MAX_INTERVAL = 3600;
+const DEFAULT_INTERVAL = 30;
+const DEFAULT_TIMEOUT = 0; // 0 = no timeout
+const RETRY_ATTEMPTS = 3;
+const RETRY_DELAYS = [1000, 2000, 4000]; // exponential backoff
+
+const STATE_DIR = path.join(getConfigDir(), 'watch-state');
+const STATE_FILE = path.join(STATE_DIR, 'watch-state.json');
+
+// ============= State Persistence =============
+
+export function loadWatchState() {
+  try {
+    if (fs.existsSync(STATE_FILE)) {
+      return JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+    }
+  } catch {
+    // Corrupted state file, start fresh
+  }
+  return {};
+}
+
+export function saveWatchState(state) {
+  if (!fs.existsSync(STATE_DIR)) {
+    fs.mkdirSync(STATE_DIR, { mode: 0o700, recursive: true });
+  }
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), { mode: 0o600 });
+}
+
+function getStateKey(type, address, chain) {
+  return `${type}:${chain}:${address}`;
+}
+
+// ============= Interval Clamping =============
+
+export function clampInterval(interval, warn) {
+  let clamped = interval;
+  let warning = null;
+  if (clamped < MIN_INTERVAL) {
+    warning = `Interval ${clamped}s is below minimum. Clamped to ${MIN_INTERVAL}s.`;
+    clamped = MIN_INTERVAL;
+  } else if (clamped > MAX_INTERVAL) {
+    warning = `Interval ${clamped}s is above maximum. Clamped to ${MAX_INTERVAL}s.`;
+    clamped = MAX_INTERVAL;
+  }
+  if (warning && warn) {
+    warn(warning);
+  }
+  return { interval: clamped, warning };
+}
+
+// ============= Event Emitters =============
+
+function emitEvent(output, event) {
+  output(JSON.stringify(event));
+}
+
+function emitHeartbeat(output, nextPollIn) {
+  emitEvent(output, {
+    type: 'heartbeat',
+    timestamp: new Date().toISOString(),
+    nextPollIn
+  });
+}
+
+function emitError(output, message, fatal = false) {
+  emitEvent(output, {
+    type: 'error',
+    error: message,
+    timestamp: new Date().toISOString(),
+    fatal
+  });
+}
+
+function emitData(output, type, data, address, chain) {
+  emitEvent(output, {
+    type,
+    timestamp: new Date().toISOString(),
+    address,
+    chain,
+    data
+  });
+}
+
+function emitStarted(output, watchType, address, chain, interval, timeout) {
+  emitEvent(output, {
+    type: 'started',
+    watchType,
+    address,
+    chain,
+    interval,
+    timeout: timeout || null,
+    timestamp: new Date().toISOString()
+  });
+}
+
+function emitStopped(output, reason) {
+  emitEvent(output, {
+    type: 'stopped',
+    reason,
+    timestamp: new Date().toISOString()
+  });
+}
+
+// ============= Retry Logic =============
+
+async function fetchWithRetry(fn, output) {
+  for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt < RETRY_ATTEMPTS - 1) {
+        await sleep(RETRY_DELAYS[attempt]);
+      } else {
+        emitError(output, `API call failed after ${RETRY_ATTEMPTS} retries: ${err.message}`, false);
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+// ============= Deduplication =============
+
+function extractNewRecords(records, seenKeys) {
+  if (!Array.isArray(records) || records.length === 0) return [];
+
+  const newRecords = [];
+  for (const record of records) {
+    const key = generateRecordKey(record);
+    if (!seenKeys.has(key)) {
+      seenKeys.add(key);
+      newRecords.push(record);
+    }
+  }
+  return newRecords;
+}
+
+function generateRecordKey(record) {
+  // Use transaction_hash if available (most unique), otherwise hash the record
+  if (record.transaction_hash) return record.transaction_hash;
+  if (record.tx_hash) return record.tx_hash;
+  // Fallback: hash of key fields
+  const keyFields = ['address', 'token_address', 'token_symbol', 'value_usd', 'block_timestamp', 'timestamp'];
+  const parts = keyFields.map(f => record[f] || '').join('|');
+  return parts;
+}
+
+function extractRecords(result) {
+  if (!result) return [];
+  if (Array.isArray(result)) return result;
+  if (result.data && Array.isArray(result.data)) return result.data;
+  if (result.results && Array.isArray(result.results)) return result.results;
+  if (result.data?.results && Array.isArray(result.data.results)) return result.data.results;
+  if (result.data?.data && Array.isArray(result.data.data)) return result.data.data;
+  return [];
+}
+
+// ============= Watch Core =============
+
+export async function runWatch(params) {
+  const {
+    watchType,     // 'wallet' or 'token'
+    address,
+    chain = 'ethereum',
+    interval: rawInterval = DEFAULT_INTERVAL,
+    once = false,
+    timeout = DEFAULT_TIMEOUT,
+    api,
+    output = console.log,
+    errorOutput = console.error,
+    onSignal,      // for testing: custom signal handler setup
+  } = params;
+
+  // Validate address
+  if (!address) {
+    emitError(output, 'Address is required', true);
+    return { exitCode: 1 };
+  }
+
+  if (watchType === 'wallet') {
+    const validation = validateAddress(address, chain);
+    if (!validation.valid) {
+      emitError(output, validation.error, true);
+      return { exitCode: 1 };
+    }
+  } else if (watchType === 'token') {
+    const validation = validateTokenAddress(address, chain);
+    if (!validation.valid) {
+      emitError(output, validation.error, true);
+      return { exitCode: 1 };
+    }
+  } else {
+    emitError(output, `Unknown watch type: ${watchType}. Use "wallet" or "token".`, true);
+    return { exitCode: 1 };
+  }
+
+  // Clamp interval
+  const { interval, warning } = clampInterval(rawInterval, errorOutput);
+  if (warning) {
+    emitError(output, warning, false);
+  }
+
+  // Load persisted state for deduplication
+  const stateKey = getStateKey(watchType, address, chain);
+  const allState = loadWatchState();
+  const seenKeys = new Set(allState[stateKey]?.seenKeys || []);
+
+  // Graceful shutdown
+  let stopped = false;
+  const stop = (reason) => {
+    if (stopped) return;
+    stopped = true;
+    // Persist state before exit
+    const updatedState = loadWatchState();
+    // Keep only the last 1000 keys to prevent unbounded growth
+    const keysArray = [...seenKeys];
+    updatedState[stateKey] = {
+      seenKeys: keysArray.slice(-1000),
+      lastPoll: new Date().toISOString()
+    };
+    saveWatchState(updatedState);
+    emitStopped(output, reason);
+  };
+
+  if (onSignal) {
+    onSignal(() => stop('signal'));
+  } else {
+    const handler = () => {
+      stop('signal');
+      process.exit(0);
+    };
+    process.on('SIGINT', handler);
+    process.on('SIGTERM', handler);
+  }
+
+  // Timeout
+  let timeoutTimer = null;
+  if (timeout > 0) {
+    timeoutTimer = setTimeout(() => {
+      stop('timeout');
+    }, timeout * 1000);
+  }
+
+  // Fetch function based on watch type
+  const fetchData = watchType === 'wallet'
+    ? () => api.addressTransactions({ address, chain, days: 1 })
+    : () => api.tokenDexTrades({ tokenAddress: address, chain, days: 1 });
+
+  const eventType = watchType === 'wallet' ? 'wallet_activity' : 'token_activity';
+
+  // Emit started event
+  emitStarted(output, watchType, address, chain, interval, timeout);
+
+  // Poll loop
+  const startTime = Date.now();
+
+  while (!stopped) {
+    // Fetch data with retries
+    const result = await fetchWithRetry(fetchData, output);
+
+    if (result && !stopped) {
+      const records = extractRecords(result);
+      const newRecords = extractNewRecords(records, seenKeys);
+
+      for (const record of newRecords) {
+        if (stopped) break;
+        emitData(output, eventType, record, address, chain);
+      }
+    }
+
+    if (once || stopped) {
+      if (!stopped) stop('once');
+      break;
+    }
+
+    // Emit heartbeat
+    emitHeartbeat(output, interval);
+
+    // Wait for next poll
+    const waitEnd = Date.now() + interval * 1000;
+    while (Date.now() < waitEnd && !stopped) {
+      await sleep(Math.min(1000, waitEnd - Date.now()));
+    }
+  }
+
+  if (timeoutTimer) clearTimeout(timeoutTimer);
+  if (!stopped) stop('completed');
+
+  return { exitCode: 0 };
+}
+
+// ============= CLI Integration =============
+
+export function buildWatchCommand(deps = {}) {
+  const {
+    output = console.log,
+    errorOutput = console.error,
+  } = deps;
+
+  return async (args, apiInstance, flags, options) => {
+    const watchType = args[0]; // 'wallet' or 'token'
+
+    if (!watchType || watchType === 'help') {
+      output(JSON.stringify({
+        command: 'watch',
+        description: 'Watch wallet or token activity in real-time (NDJSON output)',
+        subcommands: {
+          wallet: 'Watch wallet transactions',
+          token: 'Watch token DEX trades'
+        },
+        options: {
+          address: 'Wallet or token address (required)',
+          chain: 'Blockchain (default: ethereum)',
+          interval: `Poll interval in seconds (default: ${DEFAULT_INTERVAL}, min: ${MIN_INTERVAL}, max: ${MAX_INTERVAL})`,
+          once: 'Poll once and exit',
+          timeout: 'Auto-stop after N seconds (default: no timeout)'
+        },
+        examples: [
+          'nansen watch wallet --address 0x123... --chain ethereum --interval 30',
+          'nansen watch token --address So1...xyz --chain solana --once',
+          'nansen watch wallet --address 0x123... --timeout 300'
+        ]
+      }));
+      return;
+    }
+
+    const address = options.address || options.token || args[1];
+    const chain = options.chain || (watchType === 'token' ? 'solana' : 'ethereum');
+    const interval = options.interval ? parseInt(options.interval, 10) : DEFAULT_INTERVAL;
+    const once = flags.once || false;
+    const timeout = options.timeout ? parseInt(options.timeout, 10) : DEFAULT_TIMEOUT;
+
+    return runWatch({
+      watchType,
+      address,
+      chain,
+      interval,
+      once,
+      timeout,
+      api: apiInstance,
+      output,
+      errorOutput
+    });
+  };
+}


### PR DESCRIPTION
## Summary

Adds the `nansen watch` command for real-time wallet and token monitoring with NDJSON output.

### Features
- **Retry + exponential backoff** — resilient to transient API failures
- **Graceful shutdown** — clean exit on SIGINT/SIGTERM
- **State persistence** — resumes from last seen position
- **Structured error events** — NDJSON error lines for agent parsing
- **Interval clamping** — enforces min/max poll intervals
- **`--timeout` flag** — auto-exits after N seconds
- **Heartbeat events** — periodic alive signals for agent monitoring
- **`--once` flag** — single poll mode

### Tests
26 new tests, all passing. Full suite (704 tests) passing.