### PR TITLE
Restrict trading to Base and Solana only

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ nansen schema [command] [--pretty]    # full command reference (no API key neede
 
 **Research categories:** `smart-money` (`sm`), `token` (`tgm`), `profiler` (`prof`), `portfolio` (`port`), `search`, `perp`, `points`
 
-**Trade:** `quote`, `execute` — DEX swaps via LiFi/Jupiter.
+**Trade:** `quote`, `execute` — DEX swaps on Base and Solana via LiFi/Jupiter.
 
 **Wallet:** `create`, `list`, `show`, `export`, `default`, `delete`, `send` — local keypairs (EVM + Solana).
 

--- a/skills/nansen-trade/SKILL.md
+++ b/skills/nansen-trade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nansen-trade
-description: Execute DEX swaps on Solana, Ethereum, Base, or BSC. Use when buying or selling a token, getting a swap quote, or executing a trade.
+description: Execute DEX swaps on Base or Solana. Use when buying or selling a token, getting a swap quote, or executing a trade.
 allowed-tools: Bash
 ---
 
@@ -20,7 +20,7 @@ nansen trade quote \
   --amount 1000000000
 ```
 
-Symbols resolve automatically: `SOL`, `ETH`, `BNB`, `USDC`, `USDT`, `WETH`, `WBNB`. Raw addresses also work.
+Symbols resolve automatically: `SOL`, `ETH`, `USDC`, `USDT`, `WETH`. Raw addresses also work.
 
 ## Execute
 
@@ -57,7 +57,7 @@ nansen trade execute --quote "$QUOTE_ID"
 
 | Flag | Purpose |
 |------|---------|
-| `--chain` | `solana`, `ethereum`, `base`, or `bsc` |
+| `--chain` | `solana` or `base` |
 | `--from` | Source token (symbol or address) |
 | `--to` | Destination token (symbol or address) |
 | `--amount` | Amount in base units (integer) |

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -60,9 +60,7 @@ describe('resolveChain', () => {
   it('should resolve all supported chains', () => {
     const expected = {
       solana:   { index: '501', type: 'solana', chainId: 501 },
-      ethereum: { index: '1',   type: 'evm',    chainId: 1 },
       base:     { index: '8453', type: 'evm',   chainId: 8453 },
-      bsc:      { index: '56',  type: 'evm',    chainId: 56 },
     };
     for (const [name, exp] of Object.entries(expected)) {
       const chain = resolveChain(name);
@@ -76,11 +74,12 @@ describe('resolveChain', () => {
   it('should be case-insensitive', () => {
     expect(resolveChain('SOLANA').index).toBe('501');
     expect(resolveChain('Base').index).toBe('8453');
-    expect(resolveChain('BSC').chainId).toBe(56);
   });
 
   it('should throw for unsupported chain', () => {
     expect(() => resolveChain('polygon')).toThrow('Unsupported chain');
+    expect(() => resolveChain('ethereum')).toThrow('Unsupported chain');
+    expect(() => resolveChain('bsc')).toThrow('Unsupported chain');
     expect(() => resolveChain('')).toThrow('Unsupported chain');
     expect(() => resolveChain(null)).toThrow('Unsupported chain');
     expect(() => resolveChain(undefined)).toThrow('Unsupported chain');
@@ -93,19 +92,17 @@ describe('resolveTokenAddress', () => {
     expect(resolveTokenAddress('USDC', 'solana')).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
     expect(resolveTokenAddress('ETH', 'base')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
     expect(resolveTokenAddress('USDC', 'base')).toBe('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913');
-    expect(resolveTokenAddress('BNB', 'bsc')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
-    expect(resolveTokenAddress('ETH', 'ethereum')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
   });
 
   it('should be case-insensitive for symbols', () => {
     expect(resolveTokenAddress('sol', 'solana')).toBe('So11111111111111111111111111111111111111112');
-    expect(resolveTokenAddress('usdc', 'ethereum')).toBe('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
+    expect(resolveTokenAddress('usdc', 'base')).toBe('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913');
     expect(resolveTokenAddress('Eth', 'base')).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
   });
 
   it('should pass through raw addresses unchanged', () => {
     const addr = '0x1234567890abcdef1234567890abcdef12345678';
-    expect(resolveTokenAddress(addr, 'ethereum')).toBe(addr);
+    expect(resolveTokenAddress(addr, 'base')).toBe(addr);
     expect(resolveTokenAddress('So11111111111111111111111111111111111111112', 'solana'))
       .toBe('So11111111111111111111111111111111111111112');
   });
@@ -125,10 +122,8 @@ describe('getWalletChainType', () => {
   it('should return solana for solana', () => {
     expect(getWalletChainType('solana')).toBe('solana');
   });
-  it('should return evm for all EVM chains', () => {
-    for (const chain of ['ethereum', 'base', 'bsc']) {
-      expect(getWalletChainType(chain)).toBe('evm');
-    }
+  it('should return evm for Base', () => {
+    expect(getWalletChainType('base')).toBe('evm');
   });
 });
 
@@ -612,7 +607,7 @@ describe('buildTradingCommands', () => {
         outAmount: '500000000000000',
         transaction: { to: '0xabc', data: '0x1234', value: '5000000000000000000', gas: '200000' },
       }],
-    }, 'ethereum');
+    }, 'base');
 
     const logs = [];
     const cmds = buildTradingCommands({
@@ -640,7 +635,7 @@ describe('buildTradingCommands', () => {
         outAmount: '3000000000',
         transaction: { to: '0xabc', data: '0x1234', value: '5000000000000000000', gas: '200000' },
       }],
-    }, 'ethereum');
+    }, 'base');
 
     const logs = [];
     const cmds = buildTradingCommands({
@@ -668,7 +663,7 @@ describe('buildTradingCommands', () => {
         outAmount: '500000000000000',
         transaction: { to: '0xabc', data: '0x1234', value: '0', gas: '200000' },
       }],
-    }, 'ethereum');
+    }, 'base');
 
     const logs = [];
     const cmds = buildTradingCommands({
@@ -698,7 +693,7 @@ describe('buildTradingCommands', () => {
         outAmount: '3000000000',
         transaction: { to: '0xabc', data: '0x1234', value: '1000000000000000000', gas: '200000' },
       }],
-    }, 'ethereum');
+    }, 'base');
 
     const logs = [];
     const cmds = buildTradingCommands({
@@ -728,7 +723,7 @@ describe('buildTradingCommands', () => {
         outAmount: '3000000000',
         transaction: { to: '0xabc', data: '0x1234', value: '5000000000000000000', gas: '200000' },
       }],
-    }, 'ethereum');
+    }, 'base');
 
     const logs = [];
     const cmds = buildTradingCommands({
@@ -984,18 +979,9 @@ describe('getWrappedNativeFromWarning', () => {
     expect(warning).toContain('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
   });
 
-  it('should warn when --from is WETH on Ethereum', () => {
-    const warning = getWrappedNativeFromWarning('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', 'ethereum');
-    expect(warning).toContain('WETH');
-    expect(warning).toContain('wrapped ETH');
-    expect(warning).toContain('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
-  });
-
-  it('should warn when --from is WBNB on BSC', () => {
-    const warning = getWrappedNativeFromWarning('0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c', 'bsc');
-    expect(warning).toContain('WBNB');
-    expect(warning).toContain('wrapped BNB');
-    expect(warning).toContain('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
+  it('should return null for unsupported chains (e.g. ethereum, bsc)', () => {
+    expect(getWrappedNativeFromWarning('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', 'ethereum')).toBeNull();
+    expect(getWrappedNativeFromWarning('0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c', 'bsc')).toBeNull();
   });
 
   it('should warn when --from is native sentinel on Base', () => {
@@ -1003,13 +989,6 @@ describe('getWrappedNativeFromWarning', () => {
     expect(warning).toContain('native ETH');
     expect(warning).toContain('WETH');
     expect(warning).toContain('0x4200000000000000000000000000000000000006');
-  });
-
-  it('should warn when --from is native sentinel on BSC', () => {
-    const warning = getWrappedNativeFromWarning('0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', 'bsc');
-    expect(warning).toContain('native BNB');
-    expect(warning).toContain('WBNB');
-    expect(warning).toContain('0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c');
   });
 
   it('should match addresses case-insensitively', () => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -628,7 +628,7 @@ EXAMPLES:
   nansen research smart-money netflow --chain solana
   nansen research token screener --chain solana --timeframe 24h
   nansen research profiler balance --address 0x... --chain ethereum
-  nansen trade quote --chain ethereum --from ETH --to USDC --amount 1
+  nansen trade quote --chain base --from ETH --to USDC --amount 1000000000000000000
 
 Chains: ethereum, solana, base, bnb, arbitrum, polygon, optimism, avalanche, linea, scroll, mantle, ronin, sei, plasma, sonic, monad, hyperevm, iotaevm
 Labels: Fund, Smart Trader, 30D/90D/180D Smart Trader, Smart HL Perps Trader

--- a/src/schema.json
+++ b/src/schema.json
@@ -1399,15 +1399,15 @@
       }
     },
     "trade": {
-      "description": "DEX trading commands",
+      "description": "DEX trading commands (Base and Solana only)",
       "subcommands": {
         "quote": {
           "description": "Get a DEX swap quote (chain, tokens, amount)",
           "options": {
             "chain": {
               "type": "string",
-              "default": "ethereum",
-              "description": "Blockchain"
+              "default": "base",
+              "description": "Blockchain (base or solana)"
             },
             "from": {
               "type": "string",
@@ -1435,8 +1435,8 @@
           "options": {
             "chain": {
               "type": "string",
-              "default": "ethereum",
-              "description": "Blockchain"
+              "default": "base",
+              "description": "Blockchain (base or solana)"
             },
             "wallet": {
               "type": "string",

--- a/src/trading.js
+++ b/src/trading.js
@@ -1,7 +1,7 @@
 /**
  * Nansen CLI - Trading Commands
  * Quote and execute DEX swaps via the Nansen Trading API.
- * Supports Solana and EVM chains (Ethereum, Base, BSC).
+ * Supports Solana and Base.
  * Zero external dependencies — uses Node.js built-in crypto only.
  */
 
@@ -19,16 +19,12 @@ const TRADING_API_URL = process.env.NANSEN_TRADING_API_URL || 'https://trading-a
 
 const CHAIN_MAP = {
   solana:   { index: '501', type: 'solana', chainId: 501,  name: 'Solana',   explorer: 'https://solscan.io/tx/' },
-  ethereum: { index: '1',   type: 'evm',    chainId: 1,    name: 'Ethereum', explorer: 'https://etherscan.io/tx/' },
   base:     { index: '8453', type: 'evm',   chainId: 8453, name: 'Base',     explorer: 'https://basescan.org/tx/' },
-  bsc:      { index: '56',  type: 'evm',    chainId: 56,   name: 'BSC',      explorer: 'https://bscscan.com/tx/' },
 };
 
-// Extend when adding new EVM chains (e.g. arbitrum WETH, polygon WMATIC)
+// Extend when adding new EVM chains (e.g. arbitrum WETH)
 const WRAPPED_NATIVE_TOKENS = {
-  ethereum: { address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', symbol: 'WETH', nativeSymbol: 'ETH' },
   base:     { address: '0x4200000000000000000000000000000000000006', symbol: 'WETH', nativeSymbol: 'ETH' },
-  bsc:      { address: '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c', symbol: 'WBNB', nativeSymbol: 'BNB' },
 };
 
 // Common token symbol → address lookup per chain.
@@ -43,12 +39,6 @@ const TOKEN_SYMBOLS = {
     USDC: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
     USDT: 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
   },
-  ethereum: {
-    ETH:  EVM_NATIVE,
-    WETH: WRAPPED_NATIVE_TOKENS.ethereum.address,
-    USDC: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-    USDT: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-  },
   base: {
     ETH:  EVM_NATIVE,
     WETH: WRAPPED_NATIVE_TOKENS.base.address,
@@ -56,12 +46,6 @@ const TOKEN_SYMBOLS = {
     // NOTE: Legacy L2-bridged USDT on Base. If Tether deploys natively on Base
     // (like Circle did with USDC), this address will need updating.
     USDT: '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2',
-  },
-  bsc: {
-    BNB:  EVM_NATIVE,
-    WBNB: WRAPPED_NATIVE_TOKENS.bsc.address,
-    USDC: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
-    USDT: '0x55d398326f99059ff775485246999027b3197955',
   },
 };
 
@@ -80,9 +64,7 @@ export function resolveTokenAddress(symbolOrAddress, chainName) {
 
 // Default public RPC endpoints (used for nonce fetching)
 const EVM_RPC_URLS = {
-  ethereum: process.env.NANSEN_RPC_ETHEREUM || 'https://eth.llamarpc.com',
   base:     process.env.NANSEN_RPC_BASE     || 'https://mainnet.base.org',
-  bsc:      process.env.NANSEN_RPC_BSC      || 'https://bsc-dataseed.binance.org',
 };
 
 function getQuotesDir() {
@@ -321,7 +303,7 @@ export function signSolanaTransaction(transactionBase64, privateKeyHex) {
  *
  * @param {object} txData - Transaction fields from quote.transaction { to, data, value, gas, gasPrice }
  * @param {string} privateKeyHex - 64-char hex (32-byte secp256k1 private key)
- * @param {string} chain - Chain name (ethereum, base, bsc)
+ * @param {string} chain - Chain name (base)
  * @param {number} nonce - Account nonce
  * @returns {string} 0x-prefixed signed transaction hex
  */
@@ -795,7 +777,7 @@ export function buildTradingCommands(deps = {}) {
 Usage: nansen trade quote --chain <chain> --from <token> --to <token> --amount <baseUnits>
 
 OPTIONS:
-  --chain <chain>           Chain: solana, ethereum, base, bsc
+  --chain <chain>           Chain: solana, base
   --from <symbol|address>   Input token (symbol like SOL, USDC or address)
   --to <symbol|address>     Output token (symbol like USDC, ETH or address)
   --amount <units>          Amount in BASE UNITS (e.g. lamports, wei)


### PR DESCRIPTION
## Summary
Restricts all trading operations to **Base and Solana chains only**. Removes support for Ethereum and BSC from trading functionality.

## Changes Made

### Core Trading Logic ()
- **CHAIN_MAP**: Removed ethereum and bsc, keeping only solana and base
- **WRAPPED_NATIVE_TOKENS**: Removed ethereum and bsc entries
- **TOKEN_SYMBOLS**: Removed ethereum and bsc token lookup tables
- **EVM_RPC_URLS**: Removed ethereum and bsc RPC endpoints
- **Help text**: Updated --chain option to show `solana, base` only
- **JSDoc**: Updated chain parameter documentation
- **Module docstring**: Updated to "Supports Solana and Base"
- Error messages dynamically generated from CHAIN_MAP keys (auto-reflect restriction)

### CLI Schema & Help ()
- **Schema defaults**: Changed trade quote/execute chain default from 'ethereum' to 'base'
- **Schema descriptions**: Added "(base or solana)" to chain field descriptions
- **Trade section description**: Added "(Base and Solana only)"
- **Help example**: Changed from --chain ethereum to --chain base

### Agent Skill Documentation ()
- Updated description to "Base or Solana"
- Removed BNB and WBNB from resolved symbols list
- Updated --chain flag documentation to "solana or base"

### Documentation ()
- Updated Trade section to clarify "Base and Solana" support

### Tests ()
- Updated resolveChain tests for solana and base only
- Added ethereum and bsc to unsupported chain test assertions
- Updated resolveTokenAddress tests (removed ethereum/bsc)
- Updated getWalletChainType test to check base only
- Changed all saveQuote calls from ethereum to base
- Replaced ethereum/bsc wrapped native tests with null-return assertions
- **All 676 tests pass** ✅

## Impact
- Trading commands now only accept --chain base or --chain solana
- Attempting to use ethereum or bsc will throw validation errors
- Default chain for trading is now Base (was Ethereum)
- All documentation, help text, and error messages reflect the restriction