### PR TITLE
fix: add 'trades' alias for 'dex-trades' in smart-money subcommands

### DIFF
--- a/.changeset/fix-smart-money-trades-alias.md
+++ b/.changeset/fix-smart-money-trades-alias.md
@@ -1,0 +1,7 @@
+---
+"nansen-cli": patch
+---
+
+fix: add `trades` as alias for `dex-trades` in smart-money subcommands
+
+Agents naturally try `nansen research smart-money trades` before discovering the canonical name `dex-trades`. This adds `trades` as a transparent alias so both work identically. The schema is also updated to list the alias.

--- a/src/cli.js
+++ b/src/cli.js
@@ -874,11 +874,14 @@ export function buildCommands(deps = {}) {
         'dcas': () => apiInstance.smartMoneyDcas({ filters, orderBy, pagination }),
         'historical-holdings': () => apiInstance.smartMoneyHistoricalHoldings({ chains, filters, orderBy, pagination, days }),
         'help': () => ({
-          commands: ['netflow', 'dex-trades', 'perp-trades', 'holdings', 'dcas', 'historical-holdings'],
+          commands: ['netflow', 'dex-trades', 'trades', 'perp-trades', 'holdings', 'dcas', 'historical-holdings'],
+          aliases: { 'trades': 'dex-trades' },
           description: 'Smart Money analytics endpoints',
           example: 'nansen smart-money netflow --chain solana --labels Fund'
         })
       };
+      // 'trades' is an alias for 'dex-trades' — agents naturally try this name first
+      handlers['trades'] = handlers['dex-trades'];
 
       if (!handlers[subcommand]) {
         return { error: `Unknown subcommand: ${subcommand}`, available: Object.keys(handlers) };

--- a/src/schema.json
+++ b/src/schema.json
@@ -83,6 +83,45 @@
                 "trade_value_usd"
               ]
             },
+            "trades": {
+              "description": "Alias for dex-trades. Real-time DEX trading activity",
+              "options": {
+                "chain": {
+                  "type": "string",
+                  "default": "solana"
+                },
+                "chains": {
+                  "type": "array"
+                },
+                "limit": {
+                  "type": "number"
+                },
+                "labels": {
+                  "type": "string|array"
+                },
+                "sort": {
+                  "type": "string"
+                },
+                "filters": {
+                  "type": "object"
+                }
+              },
+              "returns": [
+                "chain",
+                "block_timestamp",
+                "transaction_hash",
+                "trader_address",
+                "trader_address_label",
+                "token_bought_address",
+                "token_sold_address",
+                "token_bought_amount",
+                "token_sold_amount",
+                "token_bought_symbol",
+                "token_sold_symbol",
+                "trade_value_usd"
+              ],
+              "alias": "dex-trades"
+            },
             "perp-trades": {
               "description": "Perpetual trading on Hyperliquid",
               "options": {


### PR DESCRIPTION
## Problem
Running `nansen research smart-money trades` returns `"Unknown subcommand: trades"`. The canonical name is `dex-trades`, but agents naturally try `trades` first.

## Fix
- Adds `trades` as a transparent alias for `dex-trades` in the smart-money handler
- Updates schema.json to list the alias so agents can discover it before hitting the error
- Updates the help output to include `trades` in the available commands list

## Testing
```bash
nansen research smart-money trades --chain solana  # now works identically to dex-trades
nansen research smart-money dex-trades --chain solana  # unchanged
```

Identified via 🦞 clawfooding report on v1.10.0.