### PR TITLE
fix: surface wallet prerequisite in 'trade quote' help text and schema

### DIFF
--- a/.changeset/fix-trade-quote-wallet-prereq.md
+++ b/.changeset/fix-trade-quote-wallet-prereq.md
@@ -1,0 +1,7 @@
+---
+"nansen-cli": patch
+---
+
+fix: surface wallet prerequisite in `trade quote` help text and schema
+
+`nansen trade quote` requires a configured wallet (the trading API builds a transaction specific to the sender address), but this was not communicated until the command failed. Adds a PREREQUISITE section to the usage text and a `prerequisites` field to the schema so agents can discover this requirement before running the command.

--- a/src/schema.json
+++ b/src/schema.json
@@ -1310,9 +1310,12 @@
             },
             "wallet": {
               "type": "string",
-              "description": "Wallet name, or \"walletconnect\"/\"wc\" for WalletConnect (EVM only)"
+              "description": "Wallet name (or \"walletconnect\"/\"wc\" for WalletConnect, EVM only). A configured wallet is required \u2014 run `nansen wallet create` if you haven't set one up yet."
             }
-          }
+          },
+          "prerequisites": [
+            "A local wallet must be configured. Run: nansen wallet create"
+          ]
         },
         "execute": {
           "description": "Sign and broadcast a quoted trade",

--- a/src/trading.js
+++ b/src/trading.js
@@ -794,12 +794,17 @@ export function buildTradingCommands(deps = {}) {
         errorOutput(`
 Usage: nansen trade quote --chain <chain> --from <token> --to <token> --amount <baseUnits>
 
+PREREQUISITE:
+  A wallet must be configured before using this command (the trading API builds
+  a transaction specific to your sender address).
+  Set one up with: nansen wallet create
+
 OPTIONS:
   --chain <chain>           Chain: solana, ethereum, base, bsc
   --from <symbol|address>   Input token (symbol like SOL, USDC or address)
   --to <symbol|address>     Output token (symbol like USDC, ETH or address)
   --amount <units>          Amount in BASE UNITS (e.g. lamports, wei)
-  --wallet <name>           Wallet name (default: default wallet)
+  --wallet <name>           Wallet name (default: default wallet). Use "walletconnect" or "wc" for WalletConnect (EVM only).
   --slippage <pct>          Slippage as decimal (e.g. 0.03 for 3%). Default: 0.03
   --auto-slippage           Enable auto slippage calculation
   --max-auto-slippage <pct> Max auto slippage when auto-slippage enabled


### PR DESCRIPTION
## Problem
`nansen trade quote` requires a configured wallet (the trading API builds a transaction specific to the sender address), but this was only surfaced as an error after the command was already attempted. The help text and schema gave no indication of this prerequisite. An agent that hasn't run `nansen wallet create` will hit this with no clear path forward.

## Fix
- Adds a `PREREQUISITE` section to the `trade quote` usage/help text in trading.js
- Adds a `prerequisites` array to `trade.quote` in schema.json so agents can read this before running the command
- Updates the wallet option description to clarify the requirement

## Before
Running `nansen trade quote --chain solana --from SOL --to USDC --amount 1000000000` without a wallet configured returns a confusing "No wallet found" error with no context visible in the schema.

## After
The schema and help text both surface: *"A local wallet must be configured. Run: nansen wallet create"*

Identified via 🦞 clawfooding report on v1.10.0.