### PR TITLE
fix: add hint to empty smart-money responses when chain may be unsupported

### DIFF
--- a/.changeset/fix-empty-chain-response-hint.md
+++ b/.changeset/fix-empty-chain-response-hint.md
@@ -1,0 +1,7 @@
+---
+"nansen-cli": patch
+---
+
+fix: add hint to empty smart-money responses when chain may be unsupported
+
+When `nansen research smart-money netflow --chain monad` (or any chain not yet supported by a specific endpoint) returns an empty data array, the response was indistinguishable from "no activity found". Adds a `_hint` field to empty responses and a `notes` entry to the schema so agents have a clear signal to try a different chain.

--- a/src/cli.js
+++ b/src/cli.js
@@ -884,7 +884,15 @@ export function buildCommands(deps = {}) {
         return { error: `Unknown subcommand: ${subcommand}`, available: Object.keys(handlers) };
       }
 
-      return handlers[subcommand]();
+      const result = await handlers[subcommand]();
+
+      // If the API returned an empty data array, surface a hint so agents don't silently
+      // assume "no data" when the real cause might be an unsupported chain for this endpoint.
+      if (result && Array.isArray(result.data) && result.data.length === 0) {
+        result._hint = 'No results returned. If you expected data, the requested chain may not be supported by this endpoint yet. Try a different chain (e.g. solana or ethereum).';
+      }
+
+      return result;
     },
 
     'profiler': async (args, apiInstance, flags, options) => {

--- a/src/schema.json
+++ b/src/schema.json
@@ -201,7 +201,10 @@
                 "balance_usd"
               ]
             }
-          }
+          },
+          "notes": [
+            "Not all chains are supported by every endpoint. If a request returns an empty data array, the endpoint may not yet support the requested chain. Try ethereum or solana for broadest coverage."
+          ]
         },
         "profiler": {
           "description": "Wallet profiling - detailed information about any blockchain address",


### PR DESCRIPTION
## Problem
`nansen research smart-money netflow --chain monad` returns an empty `data: []` array with `is_last_page: true` and no error or message. Monad is listed in `schema.chains` so an agent has no way to distinguish "no smart money activity on this chain" from "this endpoint doesn't support this chain yet". This causes silent failures in agent workflows.

## Fix
- After any smart-money endpoint returns an empty `data` array, attaches a `_hint` field to the response indicating the chain may not be supported
- Adds a `notes` entry to `research.smart-money` in schema.json documenting this caveat upfront

## Before
```json
{ "data": [], "is_last_page": true }
```

## After
```json
{
  "data": [],
  "is_last_page": true,
  "_hint": "No results returned. If you expected data, the requested chain may not be supported by this endpoint yet. Try a different chain (e.g. solana or ethereum)."
}
```

Identified via 🦞 clawfooding report on v1.10.0.