### PR TITLE
fix: correct --date option incorrectly marked required:true in schema

### DIFF
--- a/.changeset/fix-date-required-schema.md
+++ b/.changeset/fix-date-required-schema.md
@@ -1,0 +1,12 @@
+---
+"nansen-cli": patch
+---
+
+fix: correct `--date` option marked as `required: true` when it is optional
+
+The schema incorrectly marked `--date` as `required: true` for three commands:
+- `research token flows`
+- `research token who-bought-sold`
+- `research profiler transactions`
+
+All three use `parseDateOption` with a `days` fallback, so `--date` is optional — omitting it defaults to a rolling window based on `--days`. An agent following the schema strictly would unnecessarily refuse to run these commands without a date.

--- a/src/schema.json
+++ b/src/schema.json
@@ -265,7 +265,7 @@
                 },
                 "date": {
                   "type": "string",
-                  "required": true,
+                  "required": false,
                   "description": "Date or date range"
                 },
                 "limit": {
@@ -792,7 +792,7 @@
                 },
                 "date": {
                   "type": "string",
-                  "required": true,
+                  "required": false,
                   "description": "Date or date range"
                 },
                 "days": {
@@ -909,7 +909,7 @@
                 },
                 "date": {
                   "type": "string",
-                  "required": true,
+                  "required": false,
                   "description": "Date or date range"
                 },
                 "days": {


### PR DESCRIPTION
## Problem
The schema marks `--date` as `required: true` for three commands, but in all three the option is actually optional — omitting it defaults to a rolling window based on `--days`:

- `nansen research token flows`
- `nansen research token who-bought-sold`  
- `nansen research profiler transactions`

An agent following the schema strictly would unnecessarily refuse to run these commands without a `--date` argument, causing avoidable failures.

## Fix
Sets `required: false` for `--date` in all three commands in schema.json. The underlying API handlers already handle the missing case via `parseDateOption(options.date, days)` which falls back to a days-based window.

## Verification
```bash
nansen research token flows --token <address>                   # works without --date
nansen research token who-bought-sold --token <address>         # works without --date
nansen research profiler transactions --address <address>       # works without --date
```

Identified via 🦞 clawfooding report on v1.10.0. Note: also found and fixed the same bug in `profiler transactions` and `token who-bought-sold` (same root cause, same fix).