### PR TITLE
feat: add Jupiter Limit Order V2 support (Solana)

### DIFF
--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -12,11 +12,6 @@ import path from 'path';
 import os from 'os';
 import crypto from 'crypto';
 
-// We need to mock child_process before any imports that use walletconnect
-vi.mock('child_process', () => ({
-  execFile: vi.fn(),
-}));
-
 import {
   loadCachedToken,
   saveCachedToken,
@@ -80,10 +75,58 @@ function createTestWallet(name = 'test-wallet') {
   return createWallet(name, null);
 }
 
-// ============= JWT Caching =============
+// ============= JWT Caching (OS Keychain) =============
 
-describe('JWT caching', () => {
-  it('loadCachedToken returns null when no file exists', () => {
+// We mock execFileSync to simulate keychain behavior in tests.
+// This avoids touching the real OS keychain during test runs.
+vi.mock('child_process', async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    execFile: vi.fn(), // for walletconnect mock
+    execFileSync: vi.fn(), // for keychain mock
+  };
+});
+
+import { execFileSync } from 'child_process';
+
+// In-memory keychain store for tests
+let keychainStore = {};
+
+function setupKeychainMock() {
+  keychainStore = {};
+  execFileSync.mockImplementation((cmd, args, opts) => {
+    // macOS security add-generic-password
+    if (cmd === '/usr/bin/security' && args[0] === 'add-generic-password') {
+      const sIdx = args.indexOf('-s');
+      const aIdx = args.indexOf('-a');
+      const wIdx = args.indexOf('-w');
+      const service = args[sIdx + 1];
+      const account = args[aIdx + 1];
+      const value = args[wIdx + 1];
+      keychainStore[`${service}:${account}`] = value;
+      return Buffer.from('');
+    }
+    // macOS security find-generic-password
+    if (cmd === '/usr/bin/security' && args[0] === 'find-generic-password') {
+      const sIdx = args.indexOf('-s');
+      const aIdx = args.indexOf('-a');
+      const service = args[sIdx + 1];
+      const account = args[aIdx + 1];
+      const value = keychainStore[`${service}:${account}`];
+      if (!value) throw new Error('Item not found');
+      return Buffer.from(value + '\n');
+    }
+    throw new Error(`Unexpected execFileSync call: ${cmd} ${args.join(' ')}`);
+  });
+}
+
+describe('JWT caching (keychain)', () => {
+  beforeEach(() => {
+    setupKeychainMock();
+  });
+
+  it('loadCachedToken returns null when no entry exists', () => {
     expect(loadCachedToken('somePubkey')).toBeNull();
   });
 
@@ -93,26 +136,23 @@ describe('JWT caching', () => {
   });
 
   it('loadCachedToken returns null when token is expired', () => {
-    const cachePath = path.join(tempDir, '.nansen', 'limit-order-auth.json');
-    const dir = path.dirname(cachePath);
-    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-    fs.writeFileSync(cachePath, JSON.stringify({
+    // Manually inject expired data into keychain store
+    const key = 'nansen-cli:limit-order-jwt:pubkey';
+    keychainStore[key] = JSON.stringify({
       walletPubkey: 'pubkey',
       token: 'expired-token',
-      expiresAt: Date.now() - 1000, // Already expired
-    }), { mode: 0o600 });
+      expiresAt: Date.now() - 1000,
+    });
     expect(loadCachedToken('pubkey')).toBeNull();
   });
 
   it('loadCachedToken returns null when within 5-min buffer of expiry', () => {
-    const cachePath = path.join(tempDir, '.nansen', 'limit-order-auth.json');
-    const dir = path.dirname(cachePath);
-    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-    fs.writeFileSync(cachePath, JSON.stringify({
+    const key = 'nansen-cli:limit-order-jwt:pubkey';
+    keychainStore[key] = JSON.stringify({
       walletPubkey: 'pubkey',
       token: 'almost-expired-token',
       expiresAt: Date.now() + 60_000, // 1 minute left, within 5-min buffer
-    }), { mode: 0o600 });
+    });
     expect(loadCachedToken('pubkey')).toBeNull();
   });
 
@@ -122,17 +162,15 @@ describe('JWT caching', () => {
     expect(token).toBe('jwt-abc-123');
   });
 
-  it('saveCachedToken creates directory if missing', () => {
-    const nansenDir = path.join(tempDir, '.nansen');
-    expect(fs.existsSync(nansenDir)).toBe(false);
-    saveCachedToken('pubkey', 'token');
-    expect(fs.existsSync(nansenDir)).toBe(true);
-  });
-
   it('saveCachedToken overwrites previous token', () => {
     saveCachedToken('pubkey', 'token-1');
     saveCachedToken('pubkey', 'token-2');
     expect(loadCachedToken('pubkey')).toBe('token-2');
+  });
+
+  it('loadCachedToken returns null gracefully when keychain unavailable', () => {
+    execFileSync.mockImplementation(() => { throw new Error('keychain unavailable'); });
+    expect(loadCachedToken('pubkey')).toBeNull();
   });
 });
 
@@ -360,6 +398,10 @@ describe('signSolanaMessage', () => {
 // ============= Authentication Flow =============
 
 describe('authenticate', () => {
+  beforeEach(() => {
+    setupKeychainMock();
+  });
+
   it('returns cached token when valid', async () => {
     saveCachedToken('pub1', 'cached-jwt');
     const token = await authenticate('pub1', 'local', {});
@@ -449,6 +491,10 @@ describe('resolveSolanaWallet', () => {
 // ============= Command Handlers =============
 
 describe('buildLimitOrderCommands', () => {
+  beforeEach(() => {
+    setupKeychainMock();
+  });
+
   // ---- create ----
   describe('create', () => {
     it('shows help when required params missing', async () => {

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -205,9 +205,9 @@ describe('API client', () => {
   });
 
   it('getVault sends correct query params', async () => {
-    mockFetchResponse({ vault: { vaultAddress: 'vault123', userPubkey: 'pub1' } });
+    mockFetchResponse({ vaultPubkey: 'vault123', userPubkey: 'pub1' });
     const result = await getVault('jwt-token', 'pub1');
-    expect(result.vault.vaultAddress).toBe('vault123');
+    expect(result.vaultPubkey).toBe('vault123');
 
     const [url, opts] = global.fetch.mock.calls[0];
     expect(url).toContain('userPubkey=pub1');
@@ -525,7 +525,7 @@ describe('buildLimitOrderCommands', () => {
       mockFetchSequence([
         { body: { challenge: 'sign this' } },
         { body: { token: 'jwt-123' } },
-        { body: { vault: { vaultAddress: 'vault1' } } },
+        { body: { vaultPubkey: 'vault1', userPubkey: 'pub1' } },
         { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } },
         { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },
       ]);
@@ -564,7 +564,7 @@ describe('buildLimitOrderCommands', () => {
       mockFetchSequence([
         { body: { challenge: 'sign this' } },
         { body: { token: 'jwt-123' } },
-        { body: { vault: { vaultAddress: 'vault123', userPubkey: 'pub1' } } },
+        { body: { vaultPubkey: 'vault123', userPubkey: 'pub1' } },
         { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-req-1' } },
         { body: { id: 'order-abc', txSignature: 'sig-xyz' }, status: 201 },
       ]);
@@ -602,8 +602,8 @@ describe('buildLimitOrderCommands', () => {
       mockFetchSequence([
         { body: { challenge: 'sign this' } },
         { body: { token: 'jwt-123' } },
-        { body: { vault: null } }, // getVault returns no vault
-        { body: { vault: { vaultAddress: 'newVault', userPubkey: 'pub1' } }, status: 201 }, // registerVault
+        { body: { message: 'Vault not found' }, status: 404 }, // getVault returns no vault
+        { body: { vaultPubkey: 'newVault', userPubkey: 'pub1' }, status: 201 }, // registerVault
         { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } },
         { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },
       ]);

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -18,7 +18,6 @@ import {
   authenticate,
   signSolanaMessage,
   resolveSolanaWallet,
-  signTransaction,
   parseExpiry,
   buildLimitOrderCommands,
   getChallenge,
@@ -33,7 +32,6 @@ import {
   confirmCancelOrder,
 } from '../limit-order.js';
 import { createWallet } from '../wallet.js';
-import { signEd25519 } from '../transfer.js';
 
 let originalHome;
 let tempDir;

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -470,7 +470,7 @@ describe('buildLimitOrderCommands', () => {
       const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
 
       await cmds.create([], null, {}, {
-        from: 'SOL', to: 'USDC', amount: '1000000000', 'trigger-price': '-5',
+        from: 'SOL', to: 'USDC', amount: '1000000000', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '-5',
       });
       expect(exit).toHaveBeenCalledWith(1);
       expect(logs.some(l => l.includes('positive number'))).toBe(true);
@@ -482,7 +482,7 @@ describe('buildLimitOrderCommands', () => {
       const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
 
       await cmds.create([], null, {}, {
-        from: 'SOL', to: 'USDC', amount: '1000000000',
+        from: 'SOL', to: 'USDC', amount: '1000000000', 'trigger-mint': 'SOL',
         'trigger-price': '80', 'trigger-condition': 'invalid',
       });
       expect(exit).toHaveBeenCalledWith(1);
@@ -496,7 +496,7 @@ describe('buildLimitOrderCommands', () => {
 
       await cmds.create([], null, {}, {
         from: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
-        to: 'USDC', amount: '1000000000', 'trigger-price': '80',
+        to: 'USDC', amount: '1000000000', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
       });
       expect(exit).toHaveBeenCalledWith(1);
       expect(logs.some(l => l.includes('Invalid --from token address'))).toBe(true);
@@ -510,7 +510,7 @@ describe('buildLimitOrderCommands', () => {
       await cmds.create([], null, {}, {
         from: 'SOL',
         to: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
-        amount: '1000000000', 'trigger-price': '80',
+        amount: '1000000000', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
       });
       expect(exit).toHaveBeenCalledWith(1);
       expect(logs.some(l => l.includes('Invalid --to token address'))).toBe(true);
@@ -534,7 +534,7 @@ describe('buildLimitOrderCommands', () => {
       await cmds.create([], null, {}, {
         from: 'So11111111111111111111111111111111111111112',
         to: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-        amount: '1000000000', 'trigger-price': '80',
+        amount: '1000000000', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
         wallet: 'lo-addr-test',
       });
       expect(exit).not.toHaveBeenCalled();
@@ -547,7 +547,7 @@ describe('buildLimitOrderCommands', () => {
       const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
 
       await cmds.create([], null, {}, {
-        from: 'SOL', to: 'USDC', amount: '1.5', 'trigger-price': '80',
+        from: 'SOL', to: 'USDC', amount: '1.5', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
       });
       expect(exit).toHaveBeenCalledWith(1);
     });
@@ -573,6 +573,8 @@ describe('buildLimitOrderCommands', () => {
         from: 'SOL',
         to: 'USDC',
         amount: '1000000000',
+        'trigger-mint': 'SOL',
+        'trigger-condition': 'below',
         'trigger-price': '80',
         wallet: 'lo-create-test',
       });
@@ -607,7 +609,7 @@ describe('buildLimitOrderCommands', () => {
       ]);
 
       await cmds.create([], null, {}, {
-        from: 'SOL', to: 'USDC', amount: '1000000000', 'trigger-price': '80',
+        from: 'SOL', to: 'USDC', amount: '1000000000', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
         wallet: 'lo-vault-test',
       });
 

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -77,47 +77,39 @@ function createTestWallet(name = 'test-wallet') {
 
 // ============= JWT Caching (OS Keychain) =============
 
-// We mock execFileSync to simulate keychain behavior in tests.
-// This avoids touching the real OS keychain during test runs.
-vi.mock('child_process', async (importOriginal) => {
+// Mock keychain.js to use in-memory store instead of real OS keychain.
+// We also need child_process mocked for walletconnect.
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+}));
+
+let mockKeychainStore = {};
+
+vi.mock('../keychain.js', async (importOriginal) => {
   const original = await importOriginal();
   return {
     ...original,
-    execFile: vi.fn(), // for walletconnect mock
-    execFileSync: vi.fn(), // for keychain mock
+    keychainStoreValue: vi.fn((account, value) => {
+      mockKeychainStore[account] = value;
+      return true;
+    }),
+    keychainRetrieveValue: vi.fn((account) => {
+      return mockKeychainStore[account] || null;
+    }),
   };
 });
 
-import { execFileSync } from 'child_process';
-
-// In-memory keychain store for tests
-let keychainStore = {};
+import { keychainStoreValue, keychainRetrieveValue } from '../keychain.js';
 
 function setupKeychainMock() {
-  keychainStore = {};
-  execFileSync.mockImplementation((cmd, args, opts) => {
-    // macOS security add-generic-password
-    if (cmd === '/usr/bin/security' && args[0] === 'add-generic-password') {
-      const sIdx = args.indexOf('-s');
-      const aIdx = args.indexOf('-a');
-      const wIdx = args.indexOf('-w');
-      const service = args[sIdx + 1];
-      const account = args[aIdx + 1];
-      const value = args[wIdx + 1];
-      keychainStore[`${service}:${account}`] = value;
-      return Buffer.from('');
-    }
-    // macOS security find-generic-password
-    if (cmd === '/usr/bin/security' && args[0] === 'find-generic-password') {
-      const sIdx = args.indexOf('-s');
-      const aIdx = args.indexOf('-a');
-      const service = args[sIdx + 1];
-      const account = args[aIdx + 1];
-      const value = keychainStore[`${service}:${account}`];
-      if (!value) throw new Error('Item not found');
-      return Buffer.from(value + '\n');
-    }
-    throw new Error(`Unexpected execFileSync call: ${cmd} ${args.join(' ')}`);
+  mockKeychainStore = {};
+  keychainStoreValue.mockImplementation((account, value) => {
+    mockKeychainStore[account] = value;
+    return true;
+  });
+  keychainRetrieveValue.mockImplementation((account) => {
+    return mockKeychainStore[account] || null;
   });
 }
 
@@ -136,9 +128,8 @@ describe('JWT caching (keychain)', () => {
   });
 
   it('loadCachedToken returns null when token is expired', () => {
-    // Manually inject expired data into keychain store
-    const key = 'nansen-cli:limit-order-jwt:pubkey';
-    keychainStore[key] = JSON.stringify({
+    // Manually inject expired data
+    mockKeychainStore['limit-order-jwt:pubkey'] = JSON.stringify({
       walletPubkey: 'pubkey',
       token: 'expired-token',
       expiresAt: Date.now() - 1000,
@@ -147,8 +138,7 @@ describe('JWT caching (keychain)', () => {
   });
 
   it('loadCachedToken returns null when within 5-min buffer of expiry', () => {
-    const key = 'nansen-cli:limit-order-jwt:pubkey';
-    keychainStore[key] = JSON.stringify({
+    mockKeychainStore['limit-order-jwt:pubkey'] = JSON.stringify({
       walletPubkey: 'pubkey',
       token: 'almost-expired-token',
       expiresAt: Date.now() + 60_000, // 1 minute left, within 5-min buffer
@@ -169,7 +159,7 @@ describe('JWT caching (keychain)', () => {
   });
 
   it('loadCachedToken returns null gracefully when keychain unavailable', () => {
-    execFileSync.mockImplementation(() => { throw new Error('keychain unavailable'); });
+    keychainRetrieveValue.mockImplementation(() => null);
     expect(loadCachedToken('pubkey')).toBeNull();
   });
 });

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -470,7 +470,7 @@ describe('buildLimitOrderCommands', () => {
       const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
 
       await cmds.create([], null, {}, {
-        from: 'SOL', to: 'USDC', amount: '1000000000', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '-5',
+        from: 'SOL', to: 'USDC', amount: '1', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '-5',
       });
       expect(exit).toHaveBeenCalledWith(1);
       expect(logs.some(l => l.includes('positive number'))).toBe(true);
@@ -482,7 +482,7 @@ describe('buildLimitOrderCommands', () => {
       const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
 
       await cmds.create([], null, {}, {
-        from: 'SOL', to: 'USDC', amount: '1000000000', 'trigger-mint': 'SOL',
+        from: 'SOL', to: 'USDC', amount: '1', 'trigger-mint': 'SOL',
         'trigger-price': '80', 'trigger-condition': 'invalid',
       });
       expect(exit).toHaveBeenCalledWith(1);
@@ -496,7 +496,7 @@ describe('buildLimitOrderCommands', () => {
 
       await cmds.create([], null, {}, {
         from: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
-        to: 'USDC', amount: '1000000000', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
+        to: 'USDC', amount: '1', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
       });
       expect(exit).toHaveBeenCalledWith(1);
       expect(logs.some(l => l.includes('Invalid --from token address'))).toBe(true);
@@ -510,7 +510,7 @@ describe('buildLimitOrderCommands', () => {
       await cmds.create([], null, {}, {
         from: 'SOL',
         to: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
-        amount: '1000000000', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
+        amount: '1', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
       });
       expect(exit).toHaveBeenCalledWith(1);
       expect(logs.some(l => l.includes('Invalid --to token address'))).toBe(true);
@@ -534,20 +534,153 @@ describe('buildLimitOrderCommands', () => {
       await cmds.create([], null, {}, {
         from: 'So11111111111111111111111111111111111111112',
         to: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-        amount: '1000000000', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
+        amount: '1', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
         wallet: 'lo-addr-test',
       });
       expect(exit).not.toHaveBeenCalled();
       expect(logs.some(l => l.includes('Limit order created'))).toBe(true);
     });
 
-    it('validates amount is base units', async () => {
+    it('rejects non-positive amount', async () => {
       const logs = [];
       const exit = vi.fn();
       const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
 
       await cmds.create([], null, {}, {
-        from: 'SOL', to: 'USDC', amount: '1.5', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
+        from: 'SOL', to: 'USDC', amount: '-5', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
+      });
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logs.some(l => l.includes('positive number'))).toBe(true);
+    });
+
+    // --- Amount parsing: human-readable → base units ---
+
+    /**
+     * Helper: run a full create flow and extract the inputAmount from the API request body.
+     *
+     * This exercises the real amount parsing code path end-to-end:
+     *   user input (e.g. "0.5") → parseAmount() → base units string → sent to createOrder API
+     *
+     * We mock the 5 sequential API calls that the create flow makes:
+     *   [0] POST /auth/challenge   — returns a challenge string
+     *   [1] POST /auth/verify      — returns a JWT token
+     *   [2] GET  /vault            — returns vault info (already registered)
+     *   [3] POST /deposit/craft    — returns an unsigned deposit transaction
+     *   [4] POST /create           — creates the order ← we inspect this call's body
+     *
+     * The mock responses are minimal stubs — only enough to not error.
+     * We then read global.fetch.mock.calls[4] (the 5th call = createOrder)
+     * and parse its JSON body to get the inputAmount that was actually sent.
+     *
+     * ⚠️  If the API call sequence changes (e.g. a new call is added before
+     * createOrder), update the index [4] and the mockFetchSequence array.
+     */
+    async function createAndGetInputAmount(amountStr, fromToken = 'SOL') {
+      const walletName = `lo-amt-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+      createTestWallet(walletName);
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      const CREATE_ORDER_CALL_INDEX = 4;
+      mockFetchSequence([
+        { body: { challenge: 'sign this' } },          // [0] auth/challenge
+        { body: { token: 'jwt-123' } },                 // [1] auth/verify
+        { body: { vaultPubkey: 'vault1', userPubkey: 'pub1' } }, // [2] vault check
+        { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } }, // [3] deposit/craft
+        { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },    // [4] createOrder
+      ]);
+
+      await cmds.create([], null, {}, {
+        from: fromToken, to: 'USDC', amount: amountStr,
+        'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
+        wallet: walletName,
+      });
+
+      if (exit.mock.calls.length > 0) {
+        throw new Error(`create exited with code ${exit.mock.calls[0][0]}. Logs: ${logs.join(' | ')}`);
+      }
+
+      // Extract the inputAmount from the createOrder API request body
+      const createCall = global.fetch.mock.calls[CREATE_ORDER_CALL_INDEX];
+      const createBody = JSON.parse(createCall[1].body);
+      return createBody.inputAmount;
+    }
+
+    it('converts 1 SOL to 1000000000 base units', async () => {
+      expect(await createAndGetInputAmount('1', 'SOL')).toBe('1000000000');
+    });
+
+    it('converts 0.5 SOL to 500000000 base units', async () => {
+      expect(await createAndGetInputAmount('0.5', 'SOL')).toBe('500000000');
+    });
+
+    it('converts 0.000000001 SOL (1 lamport) correctly', async () => {
+      expect(await createAndGetInputAmount('0.000000001', 'SOL')).toBe('1');
+    });
+
+    it('converts 100 USDC to 100000000 base units (6 decimals)', async () => {
+      expect(await createAndGetInputAmount('100', 'USDC')).toBe('100000000');
+    });
+
+    it('converts 0.01 USDC to 10000 base units', async () => {
+      expect(await createAndGetInputAmount('0.01', 'USDC')).toBe('10000');
+    });
+
+    it('converts 1.5 SOL to 1500000000 base units', async () => {
+      expect(await createAndGetInputAmount('1.5', 'SOL')).toBe('1500000000');
+    });
+
+    it('converts 0.123456789 SOL without floating point error', async () => {
+      // 0.123456789 * 1e9 = 123456789 — must not produce 123456788 or 123456790
+      expect(await createAndGetInputAmount('0.123456789', 'SOL')).toBe('123456789');
+    });
+
+    it('converts 0.1 SOL without floating point error (0.1 is inexact in IEEE 754)', async () => {
+      expect(await createAndGetInputAmount('0.1', 'SOL')).toBe('100000000');
+    });
+
+    it('converts 0.3 USDC without floating point error', async () => {
+      // 0.1 + 0.2 != 0.3 in JS, but string parsing should be exact
+      expect(await createAndGetInputAmount('0.3', 'USDC')).toBe('300000');
+    });
+
+    it('truncates excess decimals beyond token precision (SOL: 9)', async () => {
+      // 0.0000000019 has 10 decimal places; should truncate to 1 lamport
+      expect(await createAndGetInputAmount('0.0000000019', 'SOL')).toBe('1');
+    });
+
+    it('truncates excess decimals beyond token precision (USDC: 6)', async () => {
+      // 0.0000019 has 7 decimal places; should truncate to 1
+      expect(await createAndGetInputAmount('0.0000019', 'USDC')).toBe('1');
+    });
+
+    it('handles whole number without decimal for SOL', async () => {
+      expect(await createAndGetInputAmount('10', 'SOL')).toBe('10000000000');
+    });
+
+    it('handles large amount (1000 SOL)', async () => {
+      expect(await createAndGetInputAmount('1000', 'SOL')).toBe('1000000000000');
+    });
+
+    it('rejects zero amount', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+      await cmds.create([], null, {}, {
+        from: 'SOL', to: 'USDC', amount: '0',
+        'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
+      });
+      expect(exit).toHaveBeenCalledWith(1);
+    });
+
+    it('rejects non-numeric amount', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+      await cmds.create([], null, {}, {
+        from: 'SOL', to: 'USDC', amount: 'abc',
+        'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
       });
       expect(exit).toHaveBeenCalledWith(1);
     });
@@ -572,7 +705,7 @@ describe('buildLimitOrderCommands', () => {
       await cmds.create([], null, {}, {
         from: 'SOL',
         to: 'USDC',
-        amount: '1000000000',
+        amount: '1',
         'trigger-mint': 'SOL',
         'trigger-condition': 'below',
         'trigger-price': '80',
@@ -609,7 +742,7 @@ describe('buildLimitOrderCommands', () => {
       ]);
 
       await cmds.create([], null, {}, {
-        from: 'SOL', to: 'USDC', amount: '1000000000', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
+        from: 'SOL', to: 'USDC', amount: '1', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
         wallet: 'lo-vault-test',
       });
 

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -489,6 +489,58 @@ describe('buildLimitOrderCommands', () => {
       expect(logs.some(l => l.includes('"above" or "below"'))).toBe(true);
     });
 
+    it('rejects EVM token address for --from', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      await cmds.create([], null, {}, {
+        from: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        to: 'USDC', amount: '1000000000', 'trigger-price': '80',
+      });
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logs.some(l => l.includes('Invalid --from token address'))).toBe(true);
+    });
+
+    it('rejects EVM token address for --to', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      await cmds.create([], null, {}, {
+        from: 'SOL',
+        to: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        amount: '1000000000', 'trigger-price': '80',
+      });
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logs.some(l => l.includes('Invalid --to token address'))).toBe(true);
+    });
+
+    it('accepts valid Solana mint address', async () => {
+      createTestWallet('lo-addr-test');
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      mockFetchSequence([
+        { body: { challenge: 'sign this' } },
+        { body: { token: 'jwt-123' } },
+        { body: { vault: { vaultAddress: 'vault1' } } },
+        { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } },
+        { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },
+      ]);
+
+      // Use raw Solana mint addresses directly
+      await cmds.create([], null, {}, {
+        from: 'So11111111111111111111111111111111111111112',
+        to: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: '1000000000', 'trigger-price': '80',
+        wallet: 'lo-addr-test',
+      });
+      expect(exit).not.toHaveBeenCalled();
+      expect(logs.some(l => l.includes('Limit order created'))).toBe(true);
+    });
+
     it('validates amount is base units', async () => {
       const logs = [];
       const exit = vi.fn();

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -912,7 +912,7 @@ describe('buildLimitOrderCommands', () => {
       ]);
 
       await cmds.update([], null, {}, {
-        order: 'order-1', slippage: '100', wallet: 'lo-update-slip',
+        order: 'order-1', 'slippage-bps': '100', wallet: 'lo-update-slip',
       });
 
       const patchBody = JSON.parse(global.fetch.mock.calls[2][1].body);
@@ -925,7 +925,7 @@ describe('buildLimitOrderCommands', () => {
       const exit = vi.fn();
       const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
 
-      await cmds.update([], null, {}, { order: 'order-1', slippage: '15000' });
+      await cmds.update([], null, {}, { order: 'order-1', 'slippage-bps': '15000' });
       expect(exit).toHaveBeenCalledWith(1);
       expect(logs.some(l => l.includes('0 and 10000'))).toBe(true);
     });

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -1,0 +1,759 @@
+/**
+ * Tests for limit-order module
+ *
+ * Covers: JWT caching, API client functions, message signing dispatch,
+ * command handlers (create, list, cancel, update), expiry parsing,
+ * wallet resolution, and error handling.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import crypto from 'crypto';
+
+// We need to mock child_process before any imports that use walletconnect
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+import {
+  loadCachedToken,
+  saveCachedToken,
+  authenticate,
+  signSolanaMessage,
+  resolveSolanaWallet,
+  signTransaction,
+  parseExpiry,
+  buildLimitOrderCommands,
+  getChallenge,
+  verifyChallenge,
+  getVault,
+  registerVault,
+  craftDeposit,
+  createOrder,
+  listOrders,
+  updateOrder,
+  cancelOrderRequest,
+  confirmCancelOrder,
+} from '../limit-order.js';
+import { createWallet } from '../wallet.js';
+import { signEd25519 } from '../transfer.js';
+
+let originalHome;
+let tempDir;
+let originalFetch;
+
+beforeEach(() => {
+  originalHome = process.env.HOME;
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nansen-lo-test-'));
+  process.env.HOME = tempDir;
+  originalFetch = global.fetch;
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(tempDir, { recursive: true, force: true });
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+// ============= Helper =============
+
+function mockFetchResponse(response, status = 200) {
+  global.fetch.mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(response),
+  });
+}
+
+function mockFetchSequence(responses) {
+  for (const { body, status = 200 } of responses) {
+    mockFetchResponse(body, status);
+  }
+}
+
+// Create a local test wallet (unencrypted)
+function createTestWallet(name = 'test-wallet') {
+  return createWallet(name, null);
+}
+
+// ============= JWT Caching =============
+
+describe('JWT caching', () => {
+  it('loadCachedToken returns null when no file exists', () => {
+    expect(loadCachedToken('somePubkey')).toBeNull();
+  });
+
+  it('loadCachedToken returns null when pubkey does not match', () => {
+    saveCachedToken('pubkey-A', 'jwt-token-A');
+    expect(loadCachedToken('pubkey-B')).toBeNull();
+  });
+
+  it('loadCachedToken returns null when token is expired', () => {
+    const cachePath = path.join(tempDir, '.nansen', 'limit-order-auth.json');
+    const dir = path.dirname(cachePath);
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(cachePath, JSON.stringify({
+      walletPubkey: 'pubkey',
+      token: 'expired-token',
+      expiresAt: Date.now() - 1000, // Already expired
+    }), { mode: 0o600 });
+    expect(loadCachedToken('pubkey')).toBeNull();
+  });
+
+  it('loadCachedToken returns null when within 5-min buffer of expiry', () => {
+    const cachePath = path.join(tempDir, '.nansen', 'limit-order-auth.json');
+    const dir = path.dirname(cachePath);
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(cachePath, JSON.stringify({
+      walletPubkey: 'pubkey',
+      token: 'almost-expired-token',
+      expiresAt: Date.now() + 60_000, // 1 minute left, within 5-min buffer
+    }), { mode: 0o600 });
+    expect(loadCachedToken('pubkey')).toBeNull();
+  });
+
+  it('saveCachedToken + loadCachedToken roundtrip', () => {
+    saveCachedToken('myPubkey', 'jwt-abc-123');
+    const token = loadCachedToken('myPubkey');
+    expect(token).toBe('jwt-abc-123');
+  });
+
+  it('saveCachedToken creates directory if missing', () => {
+    const nansenDir = path.join(tempDir, '.nansen');
+    expect(fs.existsSync(nansenDir)).toBe(false);
+    saveCachedToken('pubkey', 'token');
+    expect(fs.existsSync(nansenDir)).toBe(true);
+  });
+
+  it('saveCachedToken overwrites previous token', () => {
+    saveCachedToken('pubkey', 'token-1');
+    saveCachedToken('pubkey', 'token-2');
+    expect(loadCachedToken('pubkey')).toBe('token-2');
+  });
+});
+
+// ============= Expiry Parsing =============
+
+describe('parseExpiry', () => {
+  it('parses hours', () => {
+    const before = Date.now();
+    const result = parseExpiry('24h');
+    const after = Date.now();
+    expect(result).toBeGreaterThanOrEqual(before + 24 * 3600 * 1000);
+    expect(result).toBeLessThanOrEqual(after + 24 * 3600 * 1000);
+  });
+
+  it('parses days', () => {
+    const before = Date.now();
+    const result = parseExpiry('7d');
+    expect(result).toBeGreaterThanOrEqual(before + 7 * 24 * 3600 * 1000);
+  });
+
+  it('parses 30d default', () => {
+    const result = parseExpiry('30d');
+    expect(result).toBeGreaterThan(Date.now());
+  });
+
+  it('returns null for "never"', () => {
+    expect(parseExpiry('never')).toBeNull();
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(parseExpiry(null)).toBeNull();
+    expect(parseExpiry(undefined)).toBeNull();
+  });
+
+  it('parses raw epoch ms', () => {
+    const future = Date.now() + 86400000;
+    expect(parseExpiry(String(future))).toBe(future);
+  });
+
+  it('throws for invalid format', () => {
+    expect(() => parseExpiry('invalid')).toThrow('Invalid expiry format');
+    expect(() => parseExpiry('abc123')).toThrow('Invalid expiry format');
+  });
+});
+
+// ============= API Client Functions =============
+
+describe('API client', () => {
+  it('getChallenge sends correct request', async () => {
+    mockFetchResponse({ challenge: 'sign this message' });
+    const result = await getChallenge('myPubkey');
+    expect(result.challenge).toBe('sign this message');
+
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toContain('/limit-order/v2/auth/challenge');
+    expect(JSON.parse(opts.body)).toEqual({ walletPubkey: 'myPubkey' });
+  });
+
+  it('verifyChallenge sends correct request', async () => {
+    mockFetchResponse({ token: 'jwt-token-123' });
+    const result = await verifyChallenge('myPubkey', 'sigBase58');
+    expect(result.token).toBe('jwt-token-123');
+
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toContain('/limit-order/v2/auth/verify');
+    expect(JSON.parse(opts.body)).toEqual({ walletPubkey: 'myPubkey', signature: 'sigBase58' });
+  });
+
+  it('getVault sends correct query params', async () => {
+    mockFetchResponse({ vaultAddress: 'vault123', userPubkey: 'pub1' });
+    const result = await getVault('jwt-token', 'pub1');
+    expect(result.vaultAddress).toBe('vault123');
+
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toContain('userPubkey=pub1');
+    expect(opts.headers['Authorization']).toBe('Bearer jwt-token');
+  });
+
+  it('registerVault sends POST with auth', async () => {
+    mockFetchResponse({ vaultAddress: 'vault456', userPubkey: 'pub1' });
+    await registerVault('jwt-token');
+
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toContain('/limit-order/v2/vault/register');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers['Authorization']).toBe('Bearer jwt-token');
+  });
+
+  it('craftDeposit sends correct body', async () => {
+    mockFetchResponse({ transaction: 'dHhCYXNlNjQ=', requestId: 'req-1' });
+    const result = await craftDeposit('jwt', {
+      inputMint: 'So111',
+      outputMint: 'EPjFW',
+      userAddress: 'pub1',
+      amount: '1000000',
+    });
+    expect(result.requestId).toBe('req-1');
+
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.inputMint).toBe('So111');
+    expect(body.amount).toBe('1000000');
+  });
+
+  it('createOrder sends triggerPriceUsd as number', async () => {
+    mockFetchResponse({ id: 'order-1', txSignature: 'sig123' });
+    await createOrder('jwt', {
+      orderType: 'single',
+      depositRequestId: 'req-1',
+      depositSignedTx: 'signed-base64',
+      userPubkey: 'pub1',
+      inputMint: 'So111',
+      inputAmount: '1000000',
+      outputMint: 'EPjFW',
+      triggerMint: 'EPjFW',
+      triggerCondition: 'below',
+      triggerPriceUsd: 80.5,
+    });
+
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(typeof body.triggerPriceUsd).toBe('number');
+    expect(body.triggerPriceUsd).toBe(80.5);
+  });
+
+  it('listOrders passes query parameters', async () => {
+    mockFetchResponse({ orders: [], pagination: { total: 0, limit: 20, offset: 0 } });
+    await listOrders('jwt', 'pub1', { state: 'open', limit: 10 });
+
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toContain('userPubkey=pub1');
+    expect(url).toContain('state=open');
+    expect(url).toContain('limit=10');
+  });
+
+  it('updateOrder sends PATCH', async () => {
+    mockFetchResponse({ success: true });
+    await updateOrder('jwt', 'order-1', { orderType: 'single', triggerPriceUsd: 90 });
+
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toContain('/orders/order-1');
+    expect(opts.method).toBe('PATCH');
+  });
+
+  it('cancelOrderRequest + confirmCancelOrder flow', async () => {
+    mockFetchResponse({ id: 'order-1', transaction: 'dHhCYXNlNjQ=', requestId: 'cancel-req-1' });
+    const cancelResult = await cancelOrderRequest('jwt', 'order-1');
+    expect(cancelResult.requestId).toBe('cancel-req-1');
+
+    mockFetchResponse({ id: 'order-1', txSignature: 'cancel-sig' });
+    const confirmResult = await confirmCancelOrder('jwt', 'order-1', {
+      signedTransaction: 'signed-cancel',
+      cancelRequestId: 'cancel-req-1',
+    });
+    expect(confirmResult.txSignature).toBe('cancel-sig');
+
+    const confirmUrl = global.fetch.mock.calls[1][0];
+    expect(confirmUrl).toContain('/cancel/order-1/confirm');
+  });
+
+  it('throws enriched error on API failure', async () => {
+    mockFetchResponse(
+      { code: 'LIMIT_ORDER_AUTH_FAILED', message: 'Invalid signature' },
+      401,
+    );
+
+    await expect(getVault('bad-jwt', 'pub1')).rejects.toThrow('Invalid signature');
+    try {
+      mockFetchResponse({ code: 'LIMIT_ORDER_AUTH_FAILED', message: 'Invalid signature' }, 401);
+      await getVault('bad-jwt', 'pub1');
+    } catch (err) {
+      expect(err.code).toBe('LIMIT_ORDER_AUTH_FAILED');
+      expect(err.status).toBe(401);
+    }
+  });
+
+  it('throws on non-JSON response', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      text: async () => '<html>Bad Gateway</html>',
+    });
+
+    await expect(getVault('jwt', 'pub1')).rejects.toThrow('non-JSON response');
+  });
+});
+
+// ============= Message Signing =============
+
+describe('signSolanaMessage', () => {
+  it('signs with local wallet using Ed25519', async () => {
+    // Generate a test keypair
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const seed = privateKey.export({ type: 'pkcs8', format: 'der' }).subarray(16); // Extract 32-byte seed
+    const privateKeyHex = Buffer.concat([seed, publicKey.export({ type: 'spki', format: 'der' }).subarray(12)]).toString('hex');
+
+    const message = Buffer.from('test challenge message');
+    const signature = await signSolanaMessage(message, 'local', { privateKeyHex });
+
+    expect(signature).toBeInstanceOf(Buffer);
+    expect(signature.length).toBe(64); // Ed25519 signature is 64 bytes
+  });
+
+  it('signs with privy wallet', async () => {
+    const mockPrivyClient = {
+      signSolanaMessage: vi.fn().mockResolvedValue({
+        data: { signature: Buffer.from('fake-sig-64-bytes-padding-here-000000000000000000000000000000').toString('base64') },
+      }),
+    };
+
+    const message = Buffer.from('test challenge');
+    const signature = await signSolanaMessage(message, 'privy', {
+      privyClient: mockPrivyClient,
+      walletId: 'wallet-123',
+    });
+
+    expect(mockPrivyClient.signSolanaMessage).toHaveBeenCalledWith('wallet-123', message);
+    expect(signature).toBeInstanceOf(Buffer);
+  });
+
+  it('throws for unsupported wallet type', async () => {
+    await expect(signSolanaMessage(Buffer.from('test'), 'unknown', {}))
+      .rejects.toThrow('Unsupported wallet type');
+  });
+});
+
+// ============= Authentication Flow =============
+
+describe('authenticate', () => {
+  it('returns cached token when valid', async () => {
+    saveCachedToken('pub1', 'cached-jwt');
+    const token = await authenticate('pub1', 'local', {});
+    expect(token).toBe('cached-jwt');
+    expect(global.fetch).not.toHaveBeenCalled(); // No API call needed
+  });
+
+  it('performs challenge-response when no cache', async () => {
+    // Generate test keypair for signing
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const seed = privateKey.export({ type: 'pkcs8', format: 'der' }).subarray(16);
+    const privateKeyHex = Buffer.concat([seed, publicKey.export({ type: 'spki', format: 'der' }).subarray(12)]).toString('hex');
+
+    // Mock challenge and verify endpoints
+    mockFetchSequence([
+      { body: { challenge: 'sign this' } },
+      { body: { token: 'new-jwt-token' } },
+    ]);
+
+    const token = await authenticate('pub1', 'local', { privateKeyHex });
+    expect(token).toBe('new-jwt-token');
+
+    // Should have called challenge and verify
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    const challengeUrl = global.fetch.mock.calls[0][0];
+    const verifyUrl = global.fetch.mock.calls[1][0];
+    expect(challengeUrl).toContain('/auth/challenge');
+    expect(verifyUrl).toContain('/auth/verify');
+
+    // Should have cached the token
+    expect(loadCachedToken('pub1')).toBe('new-jwt-token');
+  });
+
+  it('performs challenge-response when cache expired', async () => {
+    // Write an expired cache
+    const cachePath = path.join(tempDir, '.nansen', 'limit-order-auth.json');
+    const dir = path.dirname(cachePath);
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(cachePath, JSON.stringify({
+      walletPubkey: 'pub1',
+      token: 'old-jwt',
+      expiresAt: Date.now() - 1000,
+    }));
+
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const seed = privateKey.export({ type: 'pkcs8', format: 'der' }).subarray(16);
+    const privateKeyHex = Buffer.concat([seed, publicKey.export({ type: 'spki', format: 'der' }).subarray(12)]).toString('hex');
+
+    mockFetchSequence([
+      { body: { challenge: 'sign this' } },
+      { body: { token: 'refreshed-jwt' } },
+    ]);
+
+    const token = await authenticate('pub1', 'local', { privateKeyHex });
+    expect(token).toBe('refreshed-jwt');
+  });
+});
+
+// ============= Wallet Resolution =============
+
+describe('resolveSolanaWallet', () => {
+  it('resolves local wallet by name', async () => {
+    createTestWallet('my-wallet');
+    const result = await resolveSolanaWallet('my-wallet', { log: () => {}, exit: () => {} });
+    expect(result).not.toBeNull();
+    expect(result.pubkey).toBeTruthy();
+    expect(result.walletType).toBe('local');
+    expect(result.walletName).toBe('my-wallet');
+  });
+
+  it('resolves default wallet when no name given', async () => {
+    createTestWallet('default-test');
+    const result = await resolveSolanaWallet(undefined, { log: () => {}, exit: () => {} });
+    expect(result).not.toBeNull();
+    expect(result.walletType).toBe('local');
+  });
+
+  it('calls exit when no wallet found', async () => {
+    const exit = vi.fn();
+    const logs = [];
+    await resolveSolanaWallet(undefined, { log: (m) => logs.push(m), exit });
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(logs.some(l => l.includes('No Solana wallet found'))).toBe(true);
+  });
+});
+
+// ============= Command Handlers =============
+
+describe('buildLimitOrderCommands', () => {
+  // ---- create ----
+  describe('create', () => {
+    it('shows help when required params missing', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      await cmds.create([], null, {}, {});
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logs.some(l => l.includes('Usage:'))).toBe(true);
+    });
+
+    it('validates trigger-price is positive number', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      await cmds.create([], null, {}, {
+        from: 'SOL', to: 'USDC', amount: '1000000000', 'trigger-price': '-5',
+      });
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logs.some(l => l.includes('positive number'))).toBe(true);
+    });
+
+    it('validates trigger-condition', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      await cmds.create([], null, {}, {
+        from: 'SOL', to: 'USDC', amount: '1000000000',
+        'trigger-price': '80', 'trigger-condition': 'invalid',
+      });
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logs.some(l => l.includes('"above" or "below"'))).toBe(true);
+    });
+
+    it('validates amount is base units', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      await cmds.create([], null, {}, {
+        from: 'SOL', to: 'USDC', amount: '1.5', 'trigger-price': '80',
+      });
+      expect(exit).toHaveBeenCalledWith(1);
+    });
+
+    it('executes full create flow with local wallet', async () => {
+      createTestWallet('lo-create-test');
+
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      // Mock the full API call sequence:
+      // 1. challenge, 2. verify, 3. getVault, 4. craftDeposit, 5. createOrder
+      mockFetchSequence([
+        { body: { challenge: 'sign this' } },
+        { body: { token: 'jwt-123' } },
+        { body: { vaultAddress: 'vault123', userPubkey: 'pub1' } },
+        { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-req-1' } },
+        { body: { id: 'order-abc', txSignature: 'sig-xyz' }, status: 201 },
+      ]);
+
+      await cmds.create([], null, {}, {
+        from: 'SOL',
+        to: 'USDC',
+        amount: '1000000000',
+        'trigger-price': '80',
+        wallet: 'lo-create-test',
+      });
+
+      expect(exit).not.toHaveBeenCalled();
+      expect(logs.some(l => l.includes('order-abc'))).toBe(true);
+      expect(logs.some(l => l.includes('sig-xyz'))).toBe(true);
+      expect(logs.some(l => l.includes('Limit order created'))).toBe(true);
+
+      // Verify createOrder was called with Number for triggerPriceUsd
+      const createCall = global.fetch.mock.calls[4];
+      const createBody = JSON.parse(createCall[1].body);
+      expect(typeof createBody.triggerPriceUsd).toBe('number');
+      expect(createBody.triggerPriceUsd).toBe(80);
+      expect(createBody.orderType).toBe('single');
+    });
+
+    it('auto-registers vault when not found', async () => {
+      createTestWallet('lo-vault-test');
+
+      const logs = [];
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit: vi.fn() });
+
+      // vault returns no vaultAddress → triggers register
+      mockFetchSequence([
+        { body: { challenge: 'sign this' } },
+        { body: { token: 'jwt-123' } },
+        { body: {} }, // getVault returns empty (no vaultAddress)
+        { body: { vaultAddress: 'newVault', userPubkey: 'pub1' }, status: 201 }, // registerVault
+        { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } },
+        { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },
+      ]);
+
+      await cmds.create([], null, {}, {
+        from: 'SOL', to: 'USDC', amount: '1000000000', 'trigger-price': '80',
+        wallet: 'lo-vault-test',
+      });
+
+      expect(logs.some(l => l.includes('Registering vault'))).toBe(true);
+      // Should have made 6 API calls (challenge, verify, getVault, registerVault, craftDeposit, createOrder)
+      expect(global.fetch).toHaveBeenCalledTimes(6);
+    });
+  });
+
+  // ---- list ----
+  describe('list', () => {
+    it('shows "no orders" when empty', async () => {
+      createTestWallet('lo-list-test');
+      const logs = [];
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit: vi.fn() });
+
+      mockFetchSequence([
+        { body: { challenge: 'sign' } },
+        { body: { token: 'jwt' } },
+        { body: { orders: [], pagination: { total: 0, limit: 20, offset: 0 } } },
+      ]);
+
+      await cmds.list([], null, {}, { wallet: 'lo-list-test' });
+      expect(logs.some(l => l.includes('No limit orders found'))).toBe(true);
+    });
+
+    it('formats and displays orders', async () => {
+      createTestWallet('lo-list-fmt');
+      const logs = [];
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit: vi.fn() });
+
+      mockFetchSequence([
+        { body: { challenge: 'sign' } },
+        { body: { token: 'jwt' } },
+        {
+          body: {
+            orders: [{
+              id: 'order-999',
+              status: 'open',
+              inputMint: 'So11111111111111111111111111111111111111112',
+              outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+              inputAmount: '1000000000',
+              triggerPriceUsd: 80.5,
+              triggerMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+              triggerCondition: 'below',
+              createdAt: '2026-03-20T00:00:00Z',
+              fills: [],
+            }],
+            pagination: { total: 1, limit: 20, offset: 0 },
+          },
+        },
+      ]);
+
+      await cmds.list([], null, {}, { wallet: 'lo-list-fmt' });
+      expect(logs.some(l => l.includes('order-999'))).toBe(true);
+      expect(logs.some(l => l.includes('Open'))).toBe(true);
+      expect(logs.some(l => l.includes('$80.5'))).toBe(true);
+    });
+
+    it('passes filter and pagination params', async () => {
+      createTestWallet('lo-list-filter');
+      const cmds = buildLimitOrderCommands({ log: () => {}, exit: vi.fn() });
+
+      mockFetchSequence([
+        { body: { challenge: 'sign' } },
+        { body: { token: 'jwt' } },
+        { body: { orders: [], pagination: { total: 0, limit: 5, offset: 10 } } },
+      ]);
+
+      await cmds.list([], null, {}, {
+        wallet: 'lo-list-filter', state: 'filled', limit: 5, offset: 10,
+      });
+
+      const ordersUrl = global.fetch.mock.calls[2][0];
+      expect(ordersUrl).toContain('state=filled');
+      expect(ordersUrl).toContain('limit=5');
+      expect(ordersUrl).toContain('offset=10');
+    });
+  });
+
+  // ---- cancel ----
+  describe('cancel', () => {
+    it('shows help when order ID missing', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      await cmds.cancel([], null, {}, {});
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logs.some(l => l.includes('Usage:'))).toBe(true);
+    });
+
+    it('executes full cancel flow', async () => {
+      createTestWallet('lo-cancel-test');
+      const logs = [];
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit: vi.fn() });
+
+      // challenge, verify, cancelRequest, confirmCancel
+      mockFetchSequence([
+        { body: { challenge: 'sign' } },
+        { body: { token: 'jwt' } },
+        { body: { id: 'order-1', transaction: buildFakeBase64Tx(), requestId: 'cancel-req-1' } },
+        { body: { id: 'order-1', txSignature: 'cancel-sig-abc' } },
+      ]);
+
+      await cmds.cancel([], null, {}, { order: 'order-1', wallet: 'lo-cancel-test' });
+
+      expect(logs.some(l => l.includes('Order cancelled'))).toBe(true);
+      expect(logs.some(l => l.includes('cancel-sig-abc'))).toBe(true);
+    });
+  });
+
+  // ---- update ----
+  describe('update', () => {
+    it('shows help when order ID missing', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      await cmds.update([], null, {}, {});
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logs.some(l => l.includes('Usage:'))).toBe(true);
+    });
+
+    it('errors when no update fields provided', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      await cmds.update([], null, {}, { order: 'order-1' });
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logs.some(l => l.includes('at least one'))).toBe(true);
+    });
+
+    it('updates trigger price', async () => {
+      createTestWallet('lo-update-test');
+      const logs = [];
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit: vi.fn() });
+
+      mockFetchSequence([
+        { body: { challenge: 'sign' } },
+        { body: { token: 'jwt' } },
+        { body: { success: true } },
+      ]);
+
+      await cmds.update([], null, {}, {
+        order: 'order-1', 'trigger-price': '85', wallet: 'lo-update-test',
+      });
+
+      expect(logs.some(l => l.includes('Order updated'))).toBe(true);
+      expect(logs.some(l => l.includes('$85'))).toBe(true);
+
+      const patchBody = JSON.parse(global.fetch.mock.calls[2][1].body);
+      expect(patchBody.triggerPriceUsd).toBe(85);
+      expect(patchBody.orderType).toBe('single');
+    });
+
+    it('updates slippage', async () => {
+      createTestWallet('lo-update-slip');
+      const logs = [];
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit: vi.fn() });
+
+      mockFetchSequence([
+        { body: { challenge: 'sign' } },
+        { body: { token: 'jwt' } },
+        { body: { success: true } },
+      ]);
+
+      await cmds.update([], null, {}, {
+        order: 'order-1', slippage: '100', wallet: 'lo-update-slip',
+      });
+
+      const patchBody = JSON.parse(global.fetch.mock.calls[2][1].body);
+      expect(patchBody.slippageBps).toBe(100);
+      expect(patchBody.triggerPriceUsd).toBeUndefined();
+    });
+
+    it('validates slippage range', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      await cmds.update([], null, {}, { order: 'order-1', slippage: '15000' });
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logs.some(l => l.includes('0 and 10000'))).toBe(true);
+    });
+  });
+});
+
+// ============= Helpers =============
+
+/**
+ * Build a minimal valid base64-encoded Solana VersionedTransaction.
+ * This is a simplified fake for testing — just needs to be parseable
+ * by signSolanaTransaction (compact-u16 sig count + 64-byte sig slot + message).
+ */
+function buildFakeBase64Tx() {
+  // 1 signature slot (compact-u16 = 0x01), 64 zero bytes for sig, then some message bytes
+  const sigCount = Buffer.from([0x01]);
+  const emptySig = Buffer.alloc(64, 0);
+  const fakeMessage = Buffer.alloc(32, 0xAB); // Minimal "message"
+  const tx = Buffer.concat([sigCount, emptySig, fakeMessage]);
+  return tx.toString('base64');
+}

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -73,50 +73,25 @@ function createTestWallet(name = 'test-wallet') {
   return createWallet(name, null);
 }
 
-// ============= JWT Caching (OS Keychain) =============
-
-// Mock keychain.js to use in-memory store instead of real OS keychain.
-// We also need child_process mocked for walletconnect.
+// We need child_process mocked for walletconnect.
 vi.mock('child_process', () => ({
   execFile: vi.fn(),
   execFileSync: vi.fn(),
 }));
 
-let mockKeychainStore = {};
-
-vi.mock('../keychain.js', async (importOriginal) => {
-  const original = await importOriginal();
-  return {
-    ...original,
-    keychainStoreValue: vi.fn((account, value) => {
-      mockKeychainStore[account] = value;
-      return true;
-    }),
-    keychainRetrieveValue: vi.fn((account) => {
-      return mockKeychainStore[account] || null;
-    }),
-  };
-});
-
-import { keychainStoreValue, keychainRetrieveValue } from '../keychain.js';
-
-function setupKeychainMock() {
-  mockKeychainStore = {};
-  keychainStoreValue.mockImplementation((account, value) => {
-    mockKeychainStore[account] = value;
-    return true;
-  });
-  keychainRetrieveValue.mockImplementation((account) => {
-    return mockKeychainStore[account] || null;
-  });
+function getAuthFilePath() {
+  return path.join(tempDir, '.nansen', 'limit-order-auth.json');
 }
 
-describe('JWT caching (keychain)', () => {
-  beforeEach(() => {
-    setupKeychainMock();
-  });
+function writeAuthFile(data) {
+  const filePath = getAuthFilePath();
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data));
+}
 
-  it('loadCachedToken returns null when no entry exists', () => {
+describe('JWT caching (local file)', () => {
+  it('loadCachedToken returns null when no file exists', () => {
     expect(loadCachedToken('somePubkey')).toBeNull();
   });
 
@@ -126,8 +101,7 @@ describe('JWT caching (keychain)', () => {
   });
 
   it('loadCachedToken returns null when token is expired', () => {
-    // Manually inject expired data
-    mockKeychainStore['limit-order-jwt:pubkey'] = JSON.stringify({
+    writeAuthFile({
       walletPubkey: 'pubkey',
       token: 'expired-token',
       expiresAt: Date.now() - 1000,
@@ -136,7 +110,7 @@ describe('JWT caching (keychain)', () => {
   });
 
   it('loadCachedToken returns null when within 5-min buffer of expiry', () => {
-    mockKeychainStore['limit-order-jwt:pubkey'] = JSON.stringify({
+    writeAuthFile({
       walletPubkey: 'pubkey',
       token: 'almost-expired-token',
       expiresAt: Date.now() + 60_000, // 1 minute left, within 5-min buffer
@@ -156,8 +130,11 @@ describe('JWT caching (keychain)', () => {
     expect(loadCachedToken('pubkey')).toBe('token-2');
   });
 
-  it('loadCachedToken returns null gracefully when keychain unavailable', () => {
-    keychainRetrieveValue.mockImplementation(() => null);
+  it('loadCachedToken returns null gracefully when file is corrupted', () => {
+    const filePath = getAuthFilePath();
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(filePath, 'not json');
     expect(loadCachedToken('pubkey')).toBeNull();
   });
 });
@@ -228,9 +205,9 @@ describe('API client', () => {
   });
 
   it('getVault sends correct query params', async () => {
-    mockFetchResponse({ vaultAddress: 'vault123', userPubkey: 'pub1' });
+    mockFetchResponse({ vault: { vaultAddress: 'vault123', userPubkey: 'pub1' } });
     const result = await getVault('jwt-token', 'pub1');
-    expect(result.vaultAddress).toBe('vault123');
+    expect(result.vault.vaultAddress).toBe('vault123');
 
     const [url, opts] = global.fetch.mock.calls[0];
     expect(url).toContain('userPubkey=pub1');
@@ -386,10 +363,6 @@ describe('signSolanaMessage', () => {
 // ============= Authentication Flow =============
 
 describe('authenticate', () => {
-  beforeEach(() => {
-    setupKeychainMock();
-  });
-
   it('returns cached token when valid', async () => {
     saveCachedToken('pub1', 'cached-jwt');
     const token = await authenticate('pub1', 'local', {});
@@ -479,10 +452,6 @@ describe('resolveSolanaWallet', () => {
 // ============= Command Handlers =============
 
 describe('buildLimitOrderCommands', () => {
-  beforeEach(() => {
-    setupKeychainMock();
-  });
-
   // ---- create ----
   describe('create', () => {
     it('shows help when required params missing', async () => {
@@ -543,7 +512,7 @@ describe('buildLimitOrderCommands', () => {
       mockFetchSequence([
         { body: { challenge: 'sign this' } },
         { body: { token: 'jwt-123' } },
-        { body: { vaultAddress: 'vault123', userPubkey: 'pub1' } },
+        { body: { vault: { vaultAddress: 'vault123', userPubkey: 'pub1' } } },
         { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-req-1' } },
         { body: { id: 'order-abc', txSignature: 'sig-xyz' }, status: 201 },
       ]);
@@ -575,12 +544,12 @@ describe('buildLimitOrderCommands', () => {
       const logs = [];
       const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit: vi.fn() });
 
-      // vault returns no vaultAddress → triggers register
+      // vault returns null → triggers register
       mockFetchSequence([
         { body: { challenge: 'sign this' } },
         { body: { token: 'jwt-123' } },
-        { body: {} }, // getVault returns empty (no vaultAddress)
-        { body: { vaultAddress: 'newVault', userPubkey: 'pub1' }, status: 201 }, // registerVault
+        { body: { vault: null } }, // getVault returns no vault
+        { body: { vault: { vaultAddress: 'newVault', userPubkey: 'pub1' } }, status: 201 }, // registerVault
         { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } },
         { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },
       ]);

--- a/src/cli.js
+++ b/src/cli.js
@@ -1487,7 +1487,7 @@ SUBCOMMANDS:
   quote          Get a swap quote (price, route, fees)
   execute        Sign and broadcast a quoted swap
   bridge-status  Check cross-chain bridge transaction status
-  limit-order    Limit order management (Solana only, Jupiter Trigger V2)
+  limit-order    Limit order management (Solana only)
 
 USAGE:
   nansen trade quote --chain <chain> --from <token> --to <token> --amount <units> [--wallet <name>]
@@ -1527,7 +1527,7 @@ CROSS-CHAIN NOTES (when using --to-chain):
     if (sub === 'limit-order') {
       const loSub = args[1];
       if (!loSub || loSub === 'help') {
-        log(`nansen trade limit-order — Limit order commands (Solana only, Jupiter Trigger V2)
+        log(`nansen trade limit-order — Limit order commands (Solana only)
 
 SUBCOMMANDS:
   create    Place a new limit order

--- a/src/cli.js
+++ b/src/cli.js
@@ -1537,7 +1537,7 @@ SUBCOMMANDS:
 
 USAGE:
   nansen trade limit-order create --from <token> --to <token> --amount <units> --trigger-mint <token> --trigger-condition <above|below> --trigger-price <usd>
-  nansen trade limit-order list [--state <open|filled|cancelled|expired>]
+  nansen trade limit-order list [--state <open|filled|cancelled|expired|all>]
   nansen trade limit-order cancel --order <orderId>
   nansen trade limit-order update --order <orderId> --trigger-price <usd>`);
         return;

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,6 +6,7 @@
 import { NansenAPI, NansenError, CommandError, ErrorCode, saveConfig, deleteConfig, getConfigFile, clearCache, getCacheDir, validateAddress, normalizeAddress, sleep } from './api.js';
 import { buildWalletCommands } from './wallet.js';
 import { buildTradingCommands } from './trading.js';
+import { buildLimitOrderCommands } from './limit-order.js';
 import { formatAlertsTable, buildAlertsCommands } from './commands/alerts.js';
 import { buildAgentCommands } from './commands/agent.js';
 import { resolveAddress, isEnsName } from './ens.js';
@@ -1474,8 +1475,9 @@ export function buildCommands(deps = {}) {
     return cmds[category](args.slice(1), apiInstance, flags, options);
   };
 
-  // 'trade' delegates to quote/execute from buildTradingCommands
+  // 'trade' delegates to quote/execute from buildTradingCommands and limit-order from buildLimitOrderCommands
   const tradingCmds = buildTradingCommands(deps);
+  const limitOrderCmds = buildLimitOrderCommands(deps);
   cmds['trade'] = async (args, apiInstance, flags, options) => {
     const sub = args[0];
     if (!sub || sub === 'help') {
@@ -1485,12 +1487,14 @@ SUBCOMMANDS:
   quote          Get a swap quote (price, route, fees)
   execute        Sign and broadcast a quoted swap
   bridge-status  Check cross-chain bridge transaction status
+  limit-order    Limit order management (Solana only, Jupiter Trigger V2)
 
 USAGE:
   nansen trade quote --chain <chain> --from <token> --to <token> --amount <units> [--wallet <name>]
   nansen trade quote --chain <chain> --to-chain <chain> --from <token> --to <token> --amount <units>
   nansen trade execute --quote <quoteId> [--wallet <name>]
   nansen trade bridge-status --tx-hash <hash> --from-chain <chain> --to-chain <chain>
+  nansen trade limit-order <create|list|cancel|update> [options]
 
 EXAMPLES:
   nansen trade quote --chain solana --from SOL --to USDC --amount 1000000000
@@ -1498,9 +1502,11 @@ EXAMPLES:
   nansen trade quote --chain base --to-chain solana --from USDC --to USDC --amount 1000000
   nansen trade execute --quote 1708900000000-abc123
   nansen trade bridge-status --tx-hash 0xabc... --from-chain base --to-chain solana
+  nansen trade limit-order create --from SOL --to USDC --amount 1000000000 --trigger-price 80
+  nansen trade limit-order list
 
 WALLET:
-  --wallet <name>   Use a named wallet, or "walletconnect" / "wc" for WalletConnect (EVM only).
+  --wallet <name>   Use a named wallet, or "walletconnect" / "wc" for WalletConnect.
                     Defaults to the default local wallet if omitted.
 
 SYMBOLS:
@@ -1518,8 +1524,31 @@ CROSS-CHAIN NOTES (when using --to-chain):
   Typical bridge time: 1-5 minutes`);
       return;
     }
+    if (sub === 'limit-order') {
+      const loSub = args[1];
+      if (!loSub || loSub === 'help') {
+        log(`nansen trade limit-order — Limit order commands (Solana only, Jupiter Trigger V2)
+
+SUBCOMMANDS:
+  create    Place a new limit order
+  list      List your limit orders
+  cancel    Cancel an open order
+  update    Update trigger price or slippage
+
+USAGE:
+  nansen trade limit-order create --from <token> --to <token> --amount <units> --trigger-price <usd>
+  nansen trade limit-order list [--state <open|filled|cancelled|expired>]
+  nansen trade limit-order cancel --order <orderId>
+  nansen trade limit-order update --order <orderId> --trigger-price <usd>`);
+        return;
+      }
+      if (!limitOrderCmds[loSub]) {
+        throw new NansenError(`Unknown limit-order subcommand: ${loSub}. Available: create, list, cancel, update`, ErrorCode.UNKNOWN);
+      }
+      return limitOrderCmds[loSub](args.slice(2), apiInstance, flags, options);
+    }
     if (!tradingCmds[sub]) {
-      throw new NansenError(`Unknown trade subcommand: ${sub}. Available: quote, execute, bridge-status`, ErrorCode.UNKNOWN);
+      throw new NansenError(`Unknown trade subcommand: ${sub}. Available: quote, execute, bridge-status, limit-order`, ErrorCode.UNKNOWN);
     }
     return tradingCmds[sub](args.slice(1), apiInstance, flags, options);
   };

--- a/src/cli.js
+++ b/src/cli.js
@@ -1537,7 +1537,7 @@ SUBCOMMANDS:
 
 USAGE:
   nansen trade limit-order create --from <token> --to <token> --amount <units> --trigger-mint <token> --trigger-condition <above|below> --trigger-price <usd>
-  nansen trade limit-order list [--state <open|filled|cancelled|expired>]
+  nansen trade limit-order list [--state <active|past>]
   nansen trade limit-order cancel --order <orderId>
   nansen trade limit-order update --order <orderId> --trigger-price <usd>`);
         return;

--- a/src/cli.js
+++ b/src/cli.js
@@ -1502,7 +1502,7 @@ EXAMPLES:
   nansen trade quote --chain base --to-chain solana --from USDC --to USDC --amount 1000000
   nansen trade execute --quote 1708900000000-abc123
   nansen trade bridge-status --tx-hash 0xabc... --from-chain base --to-chain solana
-  nansen trade limit-order create --from SOL --to USDC --amount 1000000000 --trigger-price 80
+  nansen trade limit-order create --from SOL --to USDC --amount 1000000000 --trigger-mint SOL --trigger-condition below --trigger-price 80
   nansen trade limit-order list
 
 WALLET:
@@ -1536,7 +1536,7 @@ SUBCOMMANDS:
   update    Update trigger price or slippage
 
 USAGE:
-  nansen trade limit-order create --from <token> --to <token> --amount <units> --trigger-price <usd>
+  nansen trade limit-order create --from <token> --to <token> --amount <units> --trigger-mint <token> --trigger-condition <above|below> --trigger-price <usd>
   nansen trade limit-order list [--state <open|filled|cancelled|expired>]
   nansen trade limit-order cancel --order <orderId>
   nansen trade limit-order update --order <orderId> --trigger-price <usd>`);

--- a/src/cli.js
+++ b/src/cli.js
@@ -1537,7 +1537,7 @@ SUBCOMMANDS:
 
 USAGE:
   nansen trade limit-order create --from <token> --to <token> --amount <units> --trigger-mint <token> --trigger-condition <above|below> --trigger-price <usd>
-  nansen trade limit-order list [--state <open|filled|cancelled|expired|all>]
+  nansen trade limit-order list [--state <open|filled|cancelled|expired>]
   nansen trade limit-order cancel --order <orderId>
   nansen trade limit-order update --order <orderId> --trigger-price <usd>`);
         return;

--- a/src/keychain.js
+++ b/src/keychain.js
@@ -30,7 +30,7 @@ function getCredentialsPath() {
 
 // ============= OS Keychain =============
 
-function keychainStore(password, account = ACCOUNT) {
+function keychainStore(password) {
   try {
     if (process.platform === 'darwin') {
       // macOS `security` CLI requires -w <password> as argv — no stdin mode.
@@ -39,7 +39,7 @@ function keychainStore(password, account = ACCOUNT) {
       execFileSync('/usr/bin/security', [
         'add-generic-password',
         '-s', SERVICE,
-        '-a', account,
+        '-a', ACCOUNT,
         '-w', password,
         '-U',
       ], { timeout: TIMEOUT_MS, stdio: 'pipe' });
@@ -51,7 +51,7 @@ function keychainStore(password, account = ACCOUNT) {
         'store',
         '--label', SERVICE,
         'service', SERVICE,
-        'account', account,
+        'account', ACCOUNT,
       ], { input: password, timeout: TIMEOUT_MS, stdio: ['pipe', 'pipe', 'pipe'] });
       return true;
     }
@@ -64,13 +64,13 @@ function keychainStore(password, account = ACCOUNT) {
   }
 }
 
-function keychainRetrieve(account = ACCOUNT) {
+function keychainRetrieve() {
   try {
     if (process.platform === 'darwin') {
       const result = execFileSync('/usr/bin/security', [
         'find-generic-password',
         '-s', SERVICE,
-        '-a', account,
+        '-a', ACCOUNT,
         '-w',
       ], { timeout: TIMEOUT_MS, stdio: ['pipe', 'pipe', 'pipe'] });
       const pw = result.toString().trim();
@@ -81,7 +81,7 @@ function keychainRetrieve(account = ACCOUNT) {
       const result = execFileSync('secret-tool', [
         'lookup',
         'service', SERVICE,
-        'account', account,
+        'account', ACCOUNT,
       ], { timeout: TIMEOUT_MS, stdio: ['pipe', 'pipe', 'pipe'] });
       const pw = result.toString().trim();
       return pw || null;

--- a/src/keychain.js
+++ b/src/keychain.js
@@ -30,7 +30,7 @@ function getCredentialsPath() {
 
 // ============= OS Keychain =============
 
-function keychainStore(password) {
+function keychainStore(password, account = ACCOUNT) {
   try {
     if (process.platform === 'darwin') {
       // macOS `security` CLI requires -w <password> as argv — no stdin mode.
@@ -39,7 +39,7 @@ function keychainStore(password) {
       execFileSync('/usr/bin/security', [
         'add-generic-password',
         '-s', SERVICE,
-        '-a', ACCOUNT,
+        '-a', account,
         '-w', password,
         '-U',
       ], { timeout: TIMEOUT_MS, stdio: 'pipe' });
@@ -51,7 +51,7 @@ function keychainStore(password) {
         'store',
         '--label', SERVICE,
         'service', SERVICE,
-        'account', ACCOUNT,
+        'account', account,
       ], { input: password, timeout: TIMEOUT_MS, stdio: ['pipe', 'pipe', 'pipe'] });
       return true;
     }
@@ -64,13 +64,13 @@ function keychainStore(password) {
   }
 }
 
-function keychainRetrieve() {
+function keychainRetrieve(account = ACCOUNT) {
   try {
     if (process.platform === 'darwin') {
       const result = execFileSync('/usr/bin/security', [
         'find-generic-password',
         '-s', SERVICE,
-        '-a', ACCOUNT,
+        '-a', account,
         '-w',
       ], { timeout: TIMEOUT_MS, stdio: ['pipe', 'pipe', 'pipe'] });
       const pw = result.toString().trim();
@@ -81,7 +81,7 @@ function keychainRetrieve() {
       const result = execFileSync('secret-tool', [
         'lookup',
         'service', SERVICE,
-        'account', ACCOUNT,
+        'account', account,
       ], { timeout: TIMEOUT_MS, stdio: ['pipe', 'pipe', 'pipe'] });
       const pw = result.toString().trim();
       return pw || null;
@@ -226,4 +226,25 @@ export function deleteCredentialsFile() {
  */
 export function resolvePassword() {
   return retrievePassword().password;
+}
+
+// ============= Generic Keychain Access =============
+
+/**
+ * Store a value in the OS keychain under a custom account name.
+ * @param {string} account - Unique account identifier
+ * @param {string} value - Value to store
+ * @returns {boolean} true if stored successfully
+ */
+export function keychainStoreValue(account, value) {
+  return keychainStore(value, account);
+}
+
+/**
+ * Retrieve a value from the OS keychain by account name.
+ * @param {string} account - Account identifier used during storage
+ * @returns {string|null}
+ */
+export function keychainRetrieveValue(account) {
+  return keychainRetrieve(account);
 }

--- a/src/keychain.js
+++ b/src/keychain.js
@@ -228,23 +228,3 @@ export function resolvePassword() {
   return retrievePassword().password;
 }
 
-// ============= Generic Keychain Access =============
-
-/**
- * Store a value in the OS keychain under a custom account name.
- * @param {string} account - Unique account identifier
- * @param {string} value - Value to store
- * @returns {boolean} true if stored successfully
- */
-export function keychainStoreValue(account, value) {
-  return keychainStore(value, account);
-}
-
-/**
- * Retrieve a value from the OS keychain by account name.
- * @param {string} account - Account identifier used during storage
- * @returns {string|null}
- */
-export function keychainRetrieveValue(account) {
-  return keychainRetrieve(account);
-}

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -659,13 +659,15 @@ EXAMPLES:
       } catch (err) {
         log(`Error: ${err.message}`);
         if (err.details) log(`  Details: ${JSON.stringify(err.details)}`);
+        if (err.cause) log(`  Cause: ${err.cause.message || err.cause}`);
         exit(1);
       }
     },
 
     'list': async (args, apiInstance, flags, options) => {
       const walletName = options.wallet;
-      const state = options.state;
+      const stateRaw = options.state || 'open';
+      const state = stateRaw === 'all' ? undefined : stateRaw;
       const mint = options.mint ? resolveTokenAddress(options.mint, 'solana') : undefined;
       const limit = options.limit || 20;
       const offset = options.offset || 0;
@@ -700,7 +702,7 @@ EXAMPLES:
 
         if (orders.length === 0) {
           log('\nNo limit orders found.');
-          if (state) log(`  (filtered by state: ${state})`);
+          log(`  (state: ${stateRaw})`);
           log('');
           return;
         }

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -11,6 +11,7 @@ import path from 'path';
 import { base58Encode, exportWallet, getWalletConfig, showWallet } from './wallet.js';
 import { signEd25519, base58Decode } from './transfer.js';
 import { signSolanaTransaction, resolveTokenAddress, validateBaseUnitAmount } from './trading.js';
+import { validateTokenAddress } from './api.js';
 import { getWalletConnectAddress, sendSolanaTransactionViaWalletConnect, signSolanaMessageViaWalletConnect } from './walletconnect-trading.js';
 import { retrievePassword } from './keychain.js';
 
@@ -470,6 +471,20 @@ EXAMPLES:
         return;
       }
 
+      // Validate token addresses are valid Solana addresses (catches EVM addresses, typos, etc.)
+      const fromValidation = validateTokenAddress(from, 'solana');
+      if (!fromValidation.valid) {
+        log(`Error: Invalid --from token address: ${fromValidation.error}`);
+        exit(1);
+        return;
+      }
+      const toValidation = validateTokenAddress(to, 'solana');
+      if (!toValidation.valid) {
+        log(`Error: Invalid --to token address: ${toValidation.error}`);
+        exit(1);
+        return;
+      }
+
       const amountError = validateBaseUnitAmount(amount);
       if (amountError) {
         log(`Error: ${amountError}`);
@@ -500,6 +515,15 @@ EXAMPLES:
       }
 
       const triggerMint = triggerMintRaw ? resolveTokenAddress(triggerMintRaw, 'solana') : to;
+
+      if (triggerMintRaw) {
+        const tmValidation = validateTokenAddress(triggerMint, 'solana');
+        if (!tmValidation.valid) {
+          log(`Error: Invalid --trigger-mint address: ${tmValidation.error}`);
+          exit(1);
+          return;
+        }
+      }
 
       try {
         // 1. Resolve wallet
@@ -584,6 +608,15 @@ EXAMPLES:
       const offset = options.offset || 0;
       const sort = options.sort;
       const dir = options.dir || 'desc';
+
+      if (mint) {
+        const mintValidation = validateTokenAddress(mint, 'solana');
+        if (!mintValidation.valid) {
+          log(`Error: Invalid --mint address: ${mintValidation.error}`);
+          exit(1);
+          return;
+        }
+      }
 
       try {
         const resolved = await resolveSolanaWallet(walletName, deps);

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -407,17 +407,38 @@ function formatOrderStatus(status) {
   return map[status] || status;
 }
 
+// Reverse lookup: address → symbol for known Solana tokens
+const KNOWN_SOLANA_TOKENS = {
+  'So11111111111111111111111111111111111111112': 'SOL',
+  'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v': 'USDC',
+  'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB': 'USDT',
+};
+
+function tokenLabel(address) {
+  if (!address) return '?';
+  const symbol = KNOWN_SOLANA_TOKENS[address];
+  return symbol ? `${symbol} (${address})` : address;
+}
+
+function formatTimestamp(ts) {
+  if (!ts) return '?';
+  const num = Number(ts);
+  if (isNaN(num)) return ts;
+  const date = new Date(num);
+  return `${date.toLocaleString()} (${date.toISOString()})`;
+}
+
 function formatOrder(order, index) {
   const lines = [];
   const label = index !== undefined ? `  Order #${index + 1}` : '  Order';
   lines.push(`${label} (${order.id})`);
   lines.push(`    Status:          ${formatOrderStatus(order.status)}`);
-  lines.push(`    Input:           ${order.inputAmount} → ${order.inputMint?.slice(0, 12)}...`);
-  lines.push(`    Output:          ${order.outputMint?.slice(0, 12)}...`);
-  lines.push(`    Trigger:         $${order.triggerPriceUsd} (${order.triggerCondition} on ${order.triggerMint?.slice(0, 12)}...)`);
+  lines.push(`    Sell:            ${order.inputAmount} ${tokenLabel(order.inputMint)}`);
+  lines.push(`    Buy:             ${tokenLabel(order.outputMint)}`);
+  lines.push(`    Trigger:         ${order.triggerCondition} $${order.triggerPriceUsd} on ${tokenLabel(order.triggerMint)}`);
   if (order.slippageBps != null) lines.push(`    Slippage:        ${order.slippageBps} bps`);
-  lines.push(`    Created:         ${order.createdAt}`);
-  if (order.expiresAt) lines.push(`    Expires:         ${order.expiresAt}`);
+  lines.push(`    Created:         ${formatTimestamp(order.createdAt)}`);
+  if (order.expiresAt) lines.push(`    Expires:         ${formatTimestamp(order.expiresAt)}`);
   if (order.fills?.length > 0) {
     lines.push(`    Fills:           ${order.fills.length}`);
     for (const fill of order.fills) {
@@ -548,9 +569,15 @@ EXAMPLES:
         const token = await authenticate(pubkey, walletType, walletInfo, log);
 
         // 3. Check vault, auto-register if needed
-        // Backend returns { vault: null } when no vault exists, { vault: { ... } } otherwise
-        const vaultInfo = await getVault(token, pubkey);
-        if (!vaultInfo?.vault) {
+        // Backend returns { vaultPubkey: "..." } when vault exists, or throws/returns empty when not
+        let hasVault = false;
+        try {
+          const vaultInfo = await getVault(token, pubkey);
+          hasVault = !!vaultInfo?.vaultPubkey;
+        } catch {
+          // No vault found
+        }
+        if (!hasVault) {
           log('  Registering vault for first-time use...');
           await registerVault(token);
         }

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -9,11 +9,12 @@
 import fs from 'fs';
 import path from 'path';
 import { base58Encode, exportWallet, getWalletConfig, showWallet } from './wallet.js';
-import { signEd25519, base58Decode } from './transfer.js';
-import { signSolanaTransaction, resolveTokenAddress, validateBaseUnitAmount } from './trading.js';
+import { signEd25519, base58Decode, parseAmount, getTokenInfo } from './transfer.js';
+import { signSolanaTransaction, resolveTokenAddress } from './trading.js';
 import { validateTokenAddress } from './api.js';
 import { getWalletConnectAddress, sendSolanaTransactionViaWalletConnect, signSolanaMessageViaWalletConnect } from './walletconnect-trading.js';
 import { retrievePassword } from './keychain.js';
+import { CHAIN_RPCS } from './rpc-urls.js';
 
 // ============= Constants =============
 
@@ -407,17 +408,34 @@ function formatOrderStatus(status) {
   return map[status] || status;
 }
 
-// Reverse lookup: address → symbol for known Solana tokens
+// Reverse lookup: address → { symbol, decimals } for known Solana tokens
 const KNOWN_SOLANA_TOKENS = {
-  'So11111111111111111111111111111111111111112': 'SOL',
-  'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v': 'USDC',
-  'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB': 'USDT',
+  'So11111111111111111111111111111111111111112': { symbol: 'SOL', decimals: 9 },
+  'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v': { symbol: 'USDC', decimals: 6 },
+  'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB': { symbol: 'USDT', decimals: 6 },
 };
 
 function tokenLabel(address) {
   if (!address) return '?';
-  const symbol = KNOWN_SOLANA_TOKENS[address];
-  return symbol ? `${symbol} (${address})` : address;
+  const info = KNOWN_SOLANA_TOKENS[address];
+  return info ? `${info.symbol} (${address})` : address;
+}
+
+/**
+ * Format a base-unit amount to human-readable (e.g. 116000000 SOL → "0.116 SOL").
+ * Falls back to raw amount for unknown tokens.
+ */
+function formatAmount(amount, mintAddress) {
+  if (!amount) return '?';
+  const info = KNOWN_SOLANA_TOKENS[mintAddress];
+  if (!info) return `${amount} ${mintAddress || '?'}`;
+  const raw = BigInt(amount);
+  const divisor = BigInt(10 ** info.decimals);
+  const whole = raw / divisor;
+  const frac = raw % divisor;
+  const fracStr = frac.toString().padStart(info.decimals, '0').replace(/0+$/, '');
+  const humanAmount = fracStr ? `${whole}.${fracStr}` : `${whole}`;
+  return `${humanAmount} ${info.symbol} (${amount} base units)`;
 }
 
 function formatTimestamp(ts) {
@@ -433,7 +451,7 @@ function formatOrder(order, index) {
   const label = index !== undefined ? `  Order #${index + 1}` : '  Order';
   lines.push(`${label} (${order.id})`);
   lines.push(`    Status:          ${formatOrderStatus(order.status)}`);
-  lines.push(`    Sell:            ${order.inputAmount} ${tokenLabel(order.inputMint)}`);
+  lines.push(`    Sell:            ${formatAmount(order.inputAmount, order.inputMint)}`);
   lines.push(`    Buy:             ${tokenLabel(order.outputMint)}`);
   lines.push(`    Trigger:         ${order.triggerCondition} $${order.triggerPriceUsd} on ${tokenLabel(order.triggerMint)}`);
   if (order.slippageBps != null) lines.push(`    Slippage:        ${order.slippageBps} bps`);
@@ -472,12 +490,12 @@ export function buildLimitOrderCommands(deps = {}) {
 
       if (!from || !to || !amount || triggerPrice == null || !triggerMintRaw || !triggerCondition) {
         log(`
-Usage: nansen trade limit-order create --from <token> --to <token> --amount <baseUnits> --trigger-mint <token> --trigger-condition <above|below> --trigger-price <usd>
+Usage: nansen trade limit-order create --from <token> --to <token> --amount <amount> --trigger-mint <token> --trigger-condition <above|below> --trigger-price <usd>
 
 OPTIONS:
   --from <symbol|address>        Token to sell (symbol like SOL, USDC or address)
   --to <symbol|address>          Token to buy (symbol like USDC, SOL or address)
-  --amount <units>               Amount in BASE UNITS (e.g. lamports)
+  --amount <amount>              Amount to sell in token units (e.g. 1.5 for 1.5 SOL, 80 for 80 USDC)
   --trigger-mint <symbol|addr>   Token whose price triggers the order (e.g. SOL)
   --trigger-condition <cond>     "above" or "below"
   --trigger-price <usd>          Trigger price in USD (must be a positive number)
@@ -487,9 +505,9 @@ OPTIONS:
 
 EXAMPLES:
   # Sell 1 SOL for USDC when SOL drops below $80
-  nansen trade limit-order create --from SOL --to USDC --amount 1000000000 --trigger-mint SOL --trigger-condition below --trigger-price 80
+  nansen trade limit-order create --from SOL --to USDC --amount 1 --trigger-mint SOL --trigger-condition below --trigger-price 80
   # Buy SOL with 80 USDC when SOL goes above $100
-  nansen trade limit-order create --from USDC --to SOL --amount 80000000 --trigger-mint SOL --trigger-condition above --trigger-price 100`);
+  nansen trade limit-order create --from USDC --to SOL --amount 80 --trigger-mint SOL --trigger-condition above --trigger-price 100`);
         exit(1);
         return;
       }
@@ -508,9 +526,27 @@ EXAMPLES:
         return;
       }
 
-      const amountError = validateBaseUnitAmount(amount);
-      if (amountError) {
-        log(`Error: ${amountError}`);
+      // Amount is always in human-readable token units (e.g. 1.5 = 1.5 SOL)
+      // Converted to base units (lamports) internally
+      let amountBaseUnits;
+      try {
+        const num = Number(amount);
+        if (isNaN(num) || num <= 0) {
+          log('Error: --amount must be a positive number in token units (e.g. 1.5 for 1.5 SOL, 80 for 80 USDC).');
+          exit(1);
+          return;
+        }
+        const fromInfo = KNOWN_SOLANA_TOKENS[from];
+        let decimals;
+        if (fromInfo) {
+          decimals = fromInfo.decimals;
+        } else {
+          const tokenInfo = await getTokenInfo(CHAIN_RPCS.solana, from);
+          decimals = tokenInfo.decimals;
+        }
+        amountBaseUnits = String(parseAmount(String(amount), decimals));
+      } catch (err) {
+        log(`Error: Could not resolve decimals for ${from}: ${err.message}`);
         exit(1);
         return;
       }
@@ -561,7 +597,7 @@ EXAMPLES:
 
         log(`\nCreating limit order on Solana...`);
         log(`  Wallet: ${pubkey}`);
-        log(`  Sell: ${amount} of ${from}`);
+        log(`  Sell: ${formatAmount(amountBaseUnits, from)}`);
         log(`  Buy: ${to}`);
         log(`  Trigger: $${price} (${triggerCondition})`);
 
@@ -588,7 +624,7 @@ EXAMPLES:
           inputMint: from,
           outputMint: to,
           userAddress: pubkey,
-          amount: String(amount),
+          amount: amountBaseUnits,
         });
 
         // 5. Sign deposit transaction
@@ -603,7 +639,7 @@ EXAMPLES:
           depositSignedTx: signedDepositTx,
           userPubkey: pubkey,
           inputMint: from,
-          inputAmount: String(amount),
+          inputAmount: amountBaseUnits,
           outputMint: to,
           triggerMint,
           triggerCondition,

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -1,0 +1,763 @@
+/**
+ * Nansen CLI - Limit Order Commands (Jupiter Trigger V2)
+ *
+ * Supports create, list, cancel, and update of limit orders on Solana.
+ * Uses challenge-response JWT auth with disk caching.
+ * Zero external dependencies — uses Node.js built-in crypto only.
+ */
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { base58Encode, exportWallet, getWalletConfig, showWallet, listWallets } from './wallet.js';
+import { signEd25519, base58Decode } from './transfer.js';
+import { signSolanaTransaction, resolveTokenAddress, validateBaseUnitAmount } from './trading.js';
+import { getWalletConnectAddress, sendSolanaTransactionViaWalletConnect, signSolanaMessageViaWalletConnect } from './walletconnect-trading.js';
+import { retrievePassword } from './keychain.js';
+
+// ============= Constants =============
+
+const TRADING_API_URL = process.env.NANSEN_TRADING_API_URL || 'https://trading-api.nansen.ai';
+const LO_PREFIX = '/limit-order/v2';
+const SOLSCAN_TX_URL = 'https://solscan.io/tx/';
+
+// ============= JWT Auth & Caching =============
+
+function getAuthCachePath() {
+  return path.join(process.env.HOME || process.env.USERPROFILE || '', '.nansen', 'limit-order-auth.json');
+}
+
+/**
+ * Load a cached JWT token for the given wallet pubkey.
+ * Returns the token string if valid, null otherwise.
+ */
+export function loadCachedToken(walletPubkey) {
+  try {
+    const cachePath = getAuthCachePath();
+    if (!fs.existsSync(cachePath)) return null;
+    const data = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    if (data.walletPubkey !== walletPubkey) return null;
+    // 5-minute buffer before expiry to avoid mid-request failures
+    if (data.expiresAt <= Date.now() + 300_000) return null;
+    return data.token;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save a JWT token to disk for later reuse.
+ * Uses atomic write (temp file + rename) to avoid corruption.
+ */
+export function saveCachedToken(walletPubkey, token) {
+  const cachePath = getAuthCachePath();
+  const dir = path.dirname(cachePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+
+  const data = {
+    walletPubkey,
+    token,
+    // 23-hour TTL provides 1-hour safety margin against server's 24-hour JWT
+    expiresAt: Date.now() + 23 * 3600 * 1000,
+  };
+
+  const tmpPath = cachePath + '.' + crypto.randomBytes(4).toString('hex') + '.tmp';
+  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+  fs.renameSync(tmpPath, cachePath);
+}
+
+// ============= API Client =============
+
+/**
+ * Make an authenticated request to the limit order V2 API.
+ */
+async function loFetch(method, endpoint, { token, body, query } = {}) {
+  const url = new URL(`${LO_PREFIX}${endpoint}`, TRADING_API_URL);
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined && value !== null) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  const headers = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+  };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  if (process.env.NANSEN_API_KEY) {
+    headers['X-API-Key'] = process.env.NANSEN_API_KEY;
+  }
+
+  const opts = { method, headers };
+  if (body !== undefined) {
+    opts.body = JSON.stringify(body);
+  }
+
+  const res = await fetch(url.toString(), opts);
+  const text = await res.text();
+
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw Object.assign(
+      new Error(`Limit order API returned non-JSON response (status ${res.status})`),
+      { code: 'NON_JSON_RESPONSE', status: res.status, details: text.slice(0, 200) }
+    );
+  }
+
+  if (!res.ok) {
+    const code = parsed.code || 'LIMIT_ORDER_ERROR';
+    const msg = parsed.message || `Limit order request failed with status ${res.status}`;
+    throw Object.assign(new Error(msg), { code, status: res.status, details: parsed.details });
+  }
+
+  return parsed;
+}
+
+// --- Auth endpoints (no JWT required) ---
+
+export async function getChallenge(walletPubkey) {
+  return loFetch('POST', '/auth/challenge', { body: { walletPubkey } });
+}
+
+export async function verifyChallenge(walletPubkey, signatureBase58) {
+  return loFetch('POST', '/auth/verify', { body: { walletPubkey, signature: signatureBase58 } });
+}
+
+// --- Vault endpoints ---
+
+export async function getVault(token, userPubkey) {
+  return loFetch('GET', '/vault', { token, query: { userPubkey } });
+}
+
+export async function registerVault(token) {
+  return loFetch('POST', '/vault/register', { token, body: {} });
+}
+
+// --- Order lifecycle endpoints ---
+
+export async function craftDeposit(token, { inputMint, outputMint, userAddress, amount }) {
+  return loFetch('POST', '/deposit/craft', {
+    token,
+    body: { inputMint, outputMint, userAddress, amount },
+  });
+}
+
+export async function createOrder(token, params) {
+  return loFetch('POST', '/create', { token, body: params });
+}
+
+export async function listOrders(token, userPubkey, filters = {}) {
+  return loFetch('GET', '/orders', {
+    token,
+    query: { userPubkey, ...filters },
+  });
+}
+
+export async function updateOrder(token, orderId, params) {
+  return loFetch('PATCH', `/orders/${orderId}`, { token, body: params });
+}
+
+export async function cancelOrderRequest(token, orderId) {
+  return loFetch('POST', `/cancel/${orderId}`, { token, body: {} });
+}
+
+export async function confirmCancelOrder(token, orderId, { signedTransaction, cancelRequestId }) {
+  return loFetch('POST', `/cancel/${orderId}/confirm`, {
+    token,
+    body: { signedTransaction, cancelRequestId },
+  });
+}
+
+// ============= Message Signing =============
+
+/**
+ * Sign a message with a Solana wallet.
+ * Returns raw signature bytes as a Buffer.
+ *
+ * @param {Buffer} message - Raw message bytes
+ * @param {'local'|'privy'|'walletconnect'} walletType
+ * @param {object} walletInfo - Type-specific signing info
+ * @returns {Promise<Buffer>} Raw Ed25519 signature (64 bytes)
+ */
+export async function signSolanaMessage(message, walletType, walletInfo) {
+  if (walletType === 'local') {
+    // Extract seed (first 32 bytes of the 64-byte keypair hex)
+    const seed = Buffer.from(walletInfo.privateKeyHex.slice(0, 64), 'hex');
+    return signEd25519(message, seed);
+  }
+
+  if (walletType === 'privy') {
+    const result = await walletInfo.privyClient.signSolanaMessage(
+      walletInfo.walletId,
+      message,
+    );
+    const sigBase64 = result.data?.signature || result.signature;
+    return Buffer.from(sigBase64, 'base64');
+  }
+
+  if (walletType === 'walletconnect') {
+    const result = await signSolanaMessageViaWalletConnect(message);
+    // WC returns base58-encoded signature
+    return Buffer.from(base58Decode(result.signature));
+  }
+
+  throw new Error(`Unsupported wallet type: ${walletType}`);
+}
+
+// ============= Authentication Flow =============
+
+/**
+ * Authenticate with the limit order API and return a JWT.
+ * Uses disk cache to avoid re-signing for every CLI invocation.
+ *
+ * @param {string} walletPubkey - Solana wallet address
+ * @param {'local'|'privy'|'walletconnect'} walletType
+ * @param {object} walletInfo - Signing info
+ * @param {function} log - Logger
+ * @returns {Promise<string>} JWT token
+ */
+export async function authenticate(walletPubkey, walletType, walletInfo, log = () => {}) {
+  const cached = loadCachedToken(walletPubkey);
+  if (cached) {
+    return cached;
+  }
+
+  log('  Authenticating with limit order API...');
+  const { challenge } = await getChallenge(walletPubkey);
+  const messageBuffer = Buffer.from(challenge, 'utf8');
+
+  log('  Signing challenge...');
+  const signatureBytes = await signSolanaMessage(messageBuffer, walletType, walletInfo);
+  const signatureBase58 = base58Encode(signatureBytes);
+
+  const { token } = await verifyChallenge(walletPubkey, signatureBase58);
+  saveCachedToken(walletPubkey, token);
+
+  return token;
+}
+
+// ============= Wallet Resolution =============
+
+/**
+ * Resolve a Solana wallet for limit orders.
+ * Follows the same 3-way dispatch as trading.js: WalletConnect / named / default.
+ *
+ * @returns {{ pubkey, walletType, walletInfo, privyWalletIds }}
+ */
+export async function resolveSolanaWallet(walletName, deps = {}) {
+  const { log = console.log, exit = process.exit } = deps;
+
+  const isWalletConnect = walletName === 'walletconnect' || walletName === 'wc';
+
+  if (isWalletConnect) {
+    const address = await getWalletConnectAddress('solana');
+    if (!address) {
+      log('No WalletConnect session active. Run: walletconnect connect');
+      exit(1);
+      return null;
+    }
+    return { pubkey: address, walletType: 'walletconnect', walletInfo: {}, privyWalletIds: null };
+  }
+
+  let wallet;
+  if (walletName) {
+    wallet = showWallet(walletName);
+  } else {
+    try {
+      const config = getWalletConfig();
+      if (config.defaultWallet) {
+        wallet = showWallet(config.defaultWallet);
+      }
+    } catch {
+      // No wallet configured
+    }
+  }
+
+  if (!wallet || !wallet.solana) {
+    log('No Solana wallet found. Create one with: nansen wallet create');
+    exit(1);
+    return null;
+  }
+
+  if (wallet.provider === 'privy') {
+    const { PrivyClient } = await import('./privy.js');
+    const privyClient = new PrivyClient(process.env.PRIVY_APP_ID, process.env.PRIVY_APP_SECRET);
+    return {
+      pubkey: wallet.solana,
+      walletType: 'privy',
+      walletInfo: { privyClient, walletId: wallet.privyWalletIds?.solana },
+      privyWalletIds: wallet.privyWalletIds,
+    };
+  }
+
+  // Local wallet — need password for signing
+  return {
+    pubkey: wallet.solana,
+    walletType: 'local',
+    walletInfo: {}, // privateKeyHex populated lazily when signing is needed
+    walletName: wallet.name,
+    privyWalletIds: null,
+  };
+}
+
+/**
+ * Get the private key hex for a local wallet, prompting for password if needed.
+ */
+function getLocalWalletPrivateKey(walletName) {
+  const config = getWalletConfig();
+  let password = null;
+  if (config.passwordHash) {
+    const result = retrievePassword();
+    password = result.password;
+    if (!password) {
+      throw new Error('Wallet is encrypted and no password was found. Set NANSEN_WALLET_PASSWORD env var.');
+    }
+  }
+  const effectiveName = walletName || config.defaultWallet;
+  const exported = exportWallet(effectiveName, password);
+  return exported.solana.privateKey;
+}
+
+// ============= Transaction Signing =============
+
+/**
+ * Sign a Solana transaction (base64) using the appropriate wallet type.
+ * Returns base64-encoded signed transaction.
+ */
+export async function signTransaction(txBase64, walletType, walletInfo) {
+  if (walletType === 'local') {
+    return signSolanaTransaction(txBase64, walletInfo.privateKeyHex);
+  }
+
+  if (walletType === 'privy') {
+    const result = await walletInfo.privyClient.signSolanaTransaction(
+      walletInfo.walletId,
+      txBase64,
+    );
+    return result.data?.signed_transaction || result.signed_transaction;
+  }
+
+  if (walletType === 'walletconnect') {
+    // WC expects base58 for Solana transactions
+    const txBytes = Buffer.from(txBase64, 'base64');
+    const txBase58 = base58Encode(txBytes);
+    const result = await sendSolanaTransactionViaWalletConnect(txBase58);
+    if (result.signedTransaction) {
+      // WC returns base58; convert to base64
+      const signedBytes = base58Decode(result.signedTransaction);
+      return Buffer.from(signedBytes).toString('base64');
+    }
+    throw new Error('WalletConnect did not return a signed transaction');
+  }
+
+  throw new Error(`Unsupported wallet type: ${walletType}`);
+}
+
+// ============= Expiry Parsing =============
+
+/**
+ * Parse an expiry duration string to epoch milliseconds.
+ * Accepts: "24h", "7d", "30d", or raw epoch ms string.
+ * Returns null for no expiry.
+ */
+export function parseExpiry(expiryStr) {
+  if (!expiryStr || expiryStr === 'never') return null;
+
+  const match = expiryStr.match(/^(\d+)(h|d)$/i);
+  if (match) {
+    const value = parseInt(match[1], 10);
+    const unit = match[2].toLowerCase();
+    const ms = unit === 'h' ? value * 3600 * 1000 : value * 24 * 3600 * 1000;
+    return Date.now() + ms;
+  }
+
+  // Try as raw epoch ms
+  const num = Number(expiryStr);
+  if (!isNaN(num) && num > Date.now() - 86400000) {
+    return num;
+  }
+
+  throw new Error(`Invalid expiry format: "${expiryStr}". Use "24h", "7d", "30d", or epoch ms.`);
+}
+
+// ============= Order Formatting =============
+
+function formatOrderStatus(status) {
+  const map = {
+    pending: 'Pending',
+    open: 'Open',
+    executing: 'Executing',
+    filled: 'Filled',
+    pending_withdraw: 'Withdrawing',
+    cancelled: 'Cancelled',
+    expired: 'Expired',
+    failed: 'Failed',
+  };
+  return map[status] || status;
+}
+
+function formatOrder(order, index) {
+  const lines = [];
+  const label = index !== undefined ? `  Order #${index + 1}` : '  Order';
+  lines.push(`${label} (${order.id})`);
+  lines.push(`    Status:          ${formatOrderStatus(order.status)}`);
+  lines.push(`    Input:           ${order.inputAmount} → ${order.inputMint?.slice(0, 12)}...`);
+  lines.push(`    Output:          ${order.outputMint?.slice(0, 12)}...`);
+  lines.push(`    Trigger:         $${order.triggerPriceUsd} (${order.triggerCondition} on ${order.triggerMint?.slice(0, 12)}...)`);
+  if (order.slippageBps != null) lines.push(`    Slippage:        ${order.slippageBps} bps`);
+  lines.push(`    Created:         ${order.createdAt}`);
+  if (order.expiresAt) lines.push(`    Expires:         ${order.expiresAt}`);
+  if (order.fills?.length > 0) {
+    lines.push(`    Fills:           ${order.fills.length}`);
+    for (const fill of order.fills) {
+      lines.push(`      ${fill.inputAmount} → ${fill.outputAmount} (${fill.txSignature?.slice(0, 12)}...)`);
+    }
+  }
+  return lines.join('\n');
+}
+
+// ============= CLI Command Builder =============
+
+/**
+ * Build limit order command handlers for CLI integration.
+ */
+export function buildLimitOrderCommands(deps = {}) {
+  const { log = console.log, exit = process.exit } = deps;
+
+  return {
+    'create': async (args, apiInstance, flags, options) => {
+      const fromRaw = options.from || options['from-token'] || args[0];
+      const toRaw = options.to || options['to-token'] || args[1];
+      const from = resolveTokenAddress(fromRaw, 'solana');
+      const to = resolveTokenAddress(toRaw, 'solana');
+      const amount = options.amount || args[2];
+      const triggerPrice = options['trigger-price'];
+      const triggerCondition = options['trigger-condition'] || 'below';
+      const triggerMintRaw = options['trigger-mint'];
+      const slippageBps = options.slippage != null ? Number(options.slippage) : undefined;
+      const expiresStr = options.expires || '30d';
+      const walletName = options.wallet;
+
+      if (!from || !to || !amount || triggerPrice == null) {
+        log(`
+Usage: nansen trade limit-order create --from <token> --to <token> --amount <baseUnits> --trigger-price <usd>
+
+OPTIONS:
+  --from <symbol|address>        Token to sell (symbol like SOL, USDC or address)
+  --to <symbol|address>          Token to buy (symbol like USDC, SOL or address)
+  --amount <units>               Amount in BASE UNITS (e.g. lamports)
+  --trigger-price <usd>          Trigger price in USD (must be a positive number)
+  --trigger-condition <cond>     "above" or "below" (default: below)
+  --trigger-mint <address>       Token whose price triggers (defaults to output mint)
+  --slippage <bps>               Slippage tolerance in basis points (e.g. 50 = 0.5%)
+  --expires <duration>           Expiry duration: "24h", "7d", "30d" (default: 30d)
+  --wallet <name>                Wallet name (or "walletconnect"/"wc")
+
+EXAMPLES:
+  nansen trade limit-order create --from SOL --to USDC --amount 1000000000 --trigger-price 80 --trigger-condition below
+  nansen trade limit-order create --from USDC --to SOL --amount 80000000 --trigger-price 75 --trigger-condition below`);
+        exit(1);
+        return;
+      }
+
+      const amountError = validateBaseUnitAmount(amount);
+      if (amountError) {
+        log(`Error: ${amountError}`);
+        exit(1);
+        return;
+      }
+
+      const price = Number(triggerPrice);
+      if (isNaN(price) || price <= 0) {
+        log('Error: --trigger-price must be a positive number (USD price).');
+        exit(1);
+        return;
+      }
+
+      if (triggerCondition !== 'above' && triggerCondition !== 'below') {
+        log('Error: --trigger-condition must be "above" or "below".');
+        exit(1);
+        return;
+      }
+
+      let expiresAt;
+      try {
+        expiresAt = parseExpiry(expiresStr);
+      } catch (err) {
+        log(`Error: ${err.message}`);
+        exit(1);
+        return;
+      }
+
+      const triggerMint = triggerMintRaw ? resolveTokenAddress(triggerMintRaw, 'solana') : to;
+
+      try {
+        // 1. Resolve wallet
+        const resolved = await resolveSolanaWallet(walletName, deps);
+        if (!resolved) return;
+
+        let { pubkey, walletType, walletInfo } = resolved;
+
+        // For local wallets, load private key now
+        if (walletType === 'local') {
+          const privateKeyHex = getLocalWalletPrivateKey(resolved.walletName);
+          walletInfo = { privateKeyHex };
+        }
+
+        log(`\nCreating limit order on Solana...`);
+        log(`  Wallet: ${pubkey}`);
+        log(`  Sell: ${amount} of ${from}`);
+        log(`  Buy: ${to}`);
+        log(`  Trigger: $${price} (${triggerCondition})`);
+
+        // 2. Authenticate
+        const token = await authenticate(pubkey, walletType, walletInfo, log);
+
+        // 3. Check vault, auto-register if needed
+        const vaultInfo = await getVault(token, pubkey);
+        if (!vaultInfo || !vaultInfo.vaultAddress) {
+          log('  Registering vault for first-time use...');
+          await registerVault(token);
+        }
+
+        // 4. Craft deposit transaction
+        log('  Crafting deposit transaction...');
+        const deposit = await craftDeposit(token, {
+          inputMint: from,
+          outputMint: to,
+          userAddress: pubkey,
+          amount: String(amount),
+        });
+
+        // 5. Sign deposit transaction
+        log('  Signing deposit transaction...');
+        const signedDepositTx = await signTransaction(deposit.transaction, walletType, walletInfo);
+
+        // 6. Create order
+        log('  Submitting order...');
+        const orderParams = {
+          orderType: 'single',
+          depositRequestId: deposit.requestId,
+          depositSignedTx: signedDepositTx,
+          userPubkey: pubkey,
+          inputMint: from,
+          inputAmount: String(amount),
+          outputMint: to,
+          triggerMint,
+          triggerCondition,
+          triggerPriceUsd: price, // Must be Number, not string
+          ...(slippageBps != null ? { slippageBps } : {}),
+          ...(expiresAt != null ? { expiresAt } : {}),
+        };
+
+        const result = await createOrder(token, orderParams);
+
+        log(`\n  ✓ Limit order created`);
+        log(`    Order ID:     ${result.id}`);
+        log(`    Tx:           ${result.txSignature}`);
+        log(`    Explorer:     ${SOLSCAN_TX_URL}${result.txSignature}`);
+        log('');
+
+      } catch (err) {
+        log(`Error: ${err.message}`);
+        if (err.details) log(`  Details: ${JSON.stringify(err.details)}`);
+        exit(1);
+      }
+    },
+
+    'list': async (args, apiInstance, flags, options) => {
+      const walletName = options.wallet;
+      const state = options.state;
+      const mint = options.mint ? resolveTokenAddress(options.mint, 'solana') : undefined;
+      const limit = options.limit || 20;
+      const offset = options.offset || 0;
+      const sort = options.sort;
+      const dir = options.dir || 'desc';
+
+      try {
+        const resolved = await resolveSolanaWallet(walletName, deps);
+        if (!resolved) return;
+
+        let { pubkey, walletType, walletInfo } = resolved;
+
+        // For local wallets, load private key for auth
+        if (walletType === 'local') {
+          const privateKeyHex = getLocalWalletPrivateKey(resolved.walletName);
+          walletInfo = { privateKeyHex };
+        }
+
+        const token = await authenticate(pubkey, walletType, walletInfo, log);
+
+        const result = await listOrders(token, pubkey, { state, mint, limit, offset, sort, dir });
+        const orders = result.orders || [];
+
+        if (orders.length === 0) {
+          log('\nNo limit orders found.');
+          if (state) log(`  (filtered by state: ${state})`);
+          log('');
+          return;
+        }
+
+        log(`\nLimit Orders (${result.pagination?.total || orders.length} total):\n`);
+        orders.forEach((order, i) => log(formatOrder(order, i)));
+        if (result.pagination && result.pagination.total > offset + orders.length) {
+          log(`\n  Showing ${offset + 1}-${offset + orders.length} of ${result.pagination.total}. Use --offset ${offset + orders.length} to see more.`);
+        }
+        log('');
+
+      } catch (err) {
+        log(`Error: ${err.message}`);
+        if (err.details) log(`  Details: ${JSON.stringify(err.details)}`);
+        exit(1);
+      }
+    },
+
+    'cancel': async (args, apiInstance, flags, options) => {
+      const orderId = options.order || options['order-id'] || args[0];
+      const walletName = options.wallet;
+
+      if (!orderId) {
+        log(`
+Usage: nansen trade limit-order cancel --order <orderId>
+
+OPTIONS:
+  --order <id>        Order ID to cancel
+  --wallet <name>     Wallet name (or "walletconnect"/"wc")
+
+EXAMPLES:
+  nansen trade limit-order cancel --order abc123`);
+        exit(1);
+        return;
+      }
+
+      try {
+        const resolved = await resolveSolanaWallet(walletName, deps);
+        if (!resolved) return;
+
+        let { pubkey, walletType, walletInfo } = resolved;
+
+        if (walletType === 'local') {
+          const privateKeyHex = getLocalWalletPrivateKey(resolved.walletName);
+          walletInfo = { privateKeyHex };
+        }
+
+        log(`\nCancelling order ${orderId}...`);
+
+        // 1. Authenticate
+        const token = await authenticate(pubkey, walletType, walletInfo, log);
+
+        // 2. Request cancellation — get unsigned withdrawal tx
+        log('  Requesting cancellation...');
+        const cancelResult = await cancelOrderRequest(token, orderId);
+
+        // 3. Sign the withdrawal transaction
+        log('  Signing withdrawal transaction...');
+        const signedTx = await signTransaction(cancelResult.transaction, walletType, walletInfo);
+
+        // 4. Confirm cancellation
+        log('  Confirming cancellation...');
+        const confirmed = await confirmCancelOrder(token, orderId, {
+          signedTransaction: signedTx,
+          cancelRequestId: cancelResult.requestId,
+        });
+
+        log(`\n  ✓ Order cancelled`);
+        log(`    Order ID:     ${confirmed.id}`);
+        log(`    Tx:           ${confirmed.txSignature}`);
+        log(`    Explorer:     ${SOLSCAN_TX_URL}${confirmed.txSignature}`);
+        log('');
+
+      } catch (err) {
+        log(`Error: ${err.message}`);
+        if (err.details) log(`  Details: ${JSON.stringify(err.details)}`);
+        exit(1);
+      }
+    },
+
+    'update': async (args, apiInstance, flags, options) => {
+      const orderId = options.order || options['order-id'] || args[0];
+      const triggerPrice = options['trigger-price'];
+      const slippageBps = options.slippage;
+      const walletName = options.wallet;
+
+      if (!orderId) {
+        log(`
+Usage: nansen trade limit-order update --order <orderId> [--trigger-price <usd>] [--slippage <bps>]
+
+OPTIONS:
+  --order <id>            Order ID to update
+  --trigger-price <usd>   New trigger price in USD
+  --slippage <bps>        New slippage in basis points
+  --wallet <name>         Wallet name (or "walletconnect"/"wc")
+
+EXAMPLES:
+  nansen trade limit-order update --order abc123 --trigger-price 85
+  nansen trade limit-order update --order abc123 --slippage 100`);
+        exit(1);
+        return;
+      }
+
+      if (triggerPrice == null && slippageBps == null) {
+        log('Error: Provide at least one of --trigger-price or --slippage to update.');
+        exit(1);
+        return;
+      }
+
+      const updateBody = { orderType: 'single' };
+      if (triggerPrice != null) {
+        const price = Number(triggerPrice);
+        if (isNaN(price) || price <= 0) {
+          log('Error: --trigger-price must be a positive number.');
+          exit(1);
+          return;
+        }
+        updateBody.triggerPriceUsd = price;
+      }
+      if (slippageBps != null) {
+        const bps = Number(slippageBps);
+        if (isNaN(bps) || bps < 0 || bps > 10000) {
+          log('Error: --slippage must be between 0 and 10000 basis points.');
+          exit(1);
+          return;
+        }
+        updateBody.slippageBps = bps;
+      }
+
+      try {
+        const resolved = await resolveSolanaWallet(walletName, deps);
+        if (!resolved) return;
+
+        let { pubkey, walletType, walletInfo } = resolved;
+
+        if (walletType === 'local') {
+          const privateKeyHex = getLocalWalletPrivateKey(resolved.walletName);
+          walletInfo = { privateKeyHex };
+        }
+
+        log(`\nUpdating order ${orderId}...`);
+
+        const token = await authenticate(pubkey, walletType, walletInfo, log);
+        await updateOrder(token, orderId, updateBody);
+
+        log(`\n  ✓ Order updated`);
+        if (updateBody.triggerPriceUsd != null) log(`    Trigger price: $${updateBody.triggerPriceUsd}`);
+        if (updateBody.slippageBps != null) log(`    Slippage:      ${updateBody.slippageBps} bps`);
+        log('');
+
+      } catch (err) {
+        log(`Error: ${err.message}`);
+        if (err.details) log(`  Details: ${JSON.stringify(err.details)}`);
+        exit(1);
+      }
+    },
+  };
+}

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -443,30 +443,32 @@ export function buildLimitOrderCommands(deps = {}) {
       const to = resolveTokenAddress(toRaw, 'solana');
       const amount = options.amount || args[2];
       const triggerPrice = options['trigger-price'];
-      const triggerCondition = options['trigger-condition'] || 'below';
+      const triggerCondition = options['trigger-condition'];
       const triggerMintRaw = options['trigger-mint'];
       const slippageBps = options.slippage != null ? Number(options.slippage) : undefined;
       const expiresStr = options.expires || '30d';
       const walletName = options.wallet;
 
-      if (!from || !to || !amount || triggerPrice == null) {
+      if (!from || !to || !amount || triggerPrice == null || !triggerMintRaw || !triggerCondition) {
         log(`
-Usage: nansen trade limit-order create --from <token> --to <token> --amount <baseUnits> --trigger-price <usd>
+Usage: nansen trade limit-order create --from <token> --to <token> --amount <baseUnits> --trigger-mint <token> --trigger-condition <above|below> --trigger-price <usd>
 
 OPTIONS:
   --from <symbol|address>        Token to sell (symbol like SOL, USDC or address)
   --to <symbol|address>          Token to buy (symbol like USDC, SOL or address)
   --amount <units>               Amount in BASE UNITS (e.g. lamports)
+  --trigger-mint <symbol|addr>   Token whose price triggers the order (e.g. SOL)
+  --trigger-condition <cond>     "above" or "below"
   --trigger-price <usd>          Trigger price in USD (must be a positive number)
-  --trigger-condition <cond>     "above" or "below" (default: below)
-  --trigger-mint <address>       Token whose price triggers (defaults to output mint)
   --slippage <bps>               Slippage tolerance in basis points (e.g. 50 = 0.5%)
   --expires <duration>           Expiry duration: "24h", "7d", "30d" (default: 30d)
   --wallet <name>                Wallet name (or "walletconnect"/"wc")
 
 EXAMPLES:
-  nansen trade limit-order create --from SOL --to USDC --amount 1000000000 --trigger-price 80 --trigger-condition below
-  nansen trade limit-order create --from USDC --to SOL --amount 80000000 --trigger-price 75 --trigger-condition below`);
+  # Sell 1 SOL for USDC when SOL drops below $80
+  nansen trade limit-order create --from SOL --to USDC --amount 1000000000 --trigger-mint SOL --trigger-condition below --trigger-price 80
+  # Buy SOL with 80 USDC when SOL goes above $100
+  nansen trade limit-order create --from USDC --to SOL --amount 80000000 --trigger-mint SOL --trigger-condition above --trigger-price 100`);
         exit(1);
         return;
       }
@@ -514,15 +516,13 @@ EXAMPLES:
         return;
       }
 
-      const triggerMint = triggerMintRaw ? resolveTokenAddress(triggerMintRaw, 'solana') : to;
+      const triggerMint = resolveTokenAddress(triggerMintRaw, 'solana');
 
-      if (triggerMintRaw) {
-        const tmValidation = validateTokenAddress(triggerMint, 'solana');
-        if (!tmValidation.valid) {
-          log(`Error: Invalid --trigger-mint address: ${tmValidation.error}`);
-          exit(1);
-          return;
-        }
+      const tmValidation = validateTokenAddress(triggerMint, 'solana');
+      if (!tmValidation.valid) {
+        log(`Error: Invalid --trigger-mint address: ${tmValidation.error}`);
+        exit(1);
+        return;
       }
 
       try {

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -6,11 +6,13 @@
  * Zero external dependencies — uses Node.js built-in crypto only.
  */
 
+import fs from 'fs';
+import path from 'path';
 import { base58Encode, exportWallet, getWalletConfig, showWallet } from './wallet.js';
 import { signEd25519, base58Decode } from './transfer.js';
 import { signSolanaTransaction, resolveTokenAddress, validateBaseUnitAmount } from './trading.js';
 import { getWalletConnectAddress, sendSolanaTransactionViaWalletConnect, signSolanaMessageViaWalletConnect } from './walletconnect-trading.js';
-import { retrievePassword, keychainStoreValue, keychainRetrieveValue } from './keychain.js';
+import { retrievePassword } from './keychain.js';
 
 // ============= Constants =============
 
@@ -18,39 +20,46 @@ const TRADING_API_URL = process.env.NANSEN_TRADING_API_URL || 'https://trading-a
 const LO_PREFIX = '/limit-order/v2';
 const SOLSCAN_TX_URL = 'https://solscan.io/tx/';
 
-// ============= JWT Auth & Caching (OS Keychain) =============
+// ============= JWT Auth & Caching (Local File) =============
 
-/**
- * Build a keychain account name scoped to a wallet pubkey.
- * This ensures switching wallets doesn't return a stale JWT.
- */
-function keychainAccount(walletPubkey) {
-  return `limit-order-jwt:${walletPubkey}`;
+function getAuthFilePath() {
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  return path.join(home, '.nansen', 'limit-order-auth.json');
 }
 
 /**
- * Store a JWT token in the OS keychain.
- * The token is stored as a JSON blob containing the JWT + expiry.
- * Falls back silently if keychain is unavailable.
+ * Save a JWT token to ~/.nansen/limit-order-auth.json.
+ * Keyed by wallet pubkey so switching wallets invalidates correctly.
  */
 export function saveCachedToken(walletPubkey, token) {
-  const data = JSON.stringify({
-    walletPubkey,
-    token,
-    // 23-hour TTL provides 1-hour safety margin against server's 24-hour JWT
-    expiresAt: Date.now() + 23 * 3600 * 1000,
-  });
-  return keychainStoreValue(keychainAccount(walletPubkey), data);
+  try {
+    const filePath = getAuthFilePath();
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { mode: 0o700, recursive: true });
+    }
+    const data = JSON.stringify({
+      walletPubkey,
+      token,
+      // 23-hour TTL provides 1-hour safety margin against server's 24-hour JWT
+      expiresAt: Date.now() + 23 * 3600 * 1000,
+    });
+    fs.writeFileSync(filePath, data, { mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
- * Load a cached JWT token from the OS keychain.
+ * Load a cached JWT token from ~/.nansen/limit-order-auth.json.
  * Returns the token string if valid and not expired, null otherwise.
  */
 export function loadCachedToken(walletPubkey) {
   try {
-    const raw = keychainRetrieveValue(keychainAccount(walletPubkey));
-    if (!raw) return null;
+    const filePath = getAuthFilePath();
+    if (!fs.existsSync(filePath)) return null;
+    const raw = fs.readFileSync(filePath, 'utf8');
     const data = JSON.parse(raw);
     if (data.walletPubkey !== walletPubkey) return null;
     // 5-minute buffer before expiry to avoid mid-request failures
@@ -515,8 +524,9 @@ EXAMPLES:
         const token = await authenticate(pubkey, walletType, walletInfo, log);
 
         // 3. Check vault, auto-register if needed
+        // Backend returns { vault: null } when no vault exists, { vault: { ... } } otherwise
         const vaultInfo = await getVault(token, pubkey);
-        if (!vaultInfo || !vaultInfo.vaultAddress) {
+        if (!vaultInfo?.vault) {
           log('  Registering vault for first-time use...');
           await registerVault(token);
         }

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -10,6 +10,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { execFileSync } from 'child_process';
 import { base58Encode, exportWallet, getWalletConfig, showWallet, listWallets } from './wallet.js';
 import { signEd25519, base58Decode } from './transfer.js';
 import { signSolanaTransaction, resolveTokenAddress, validateBaseUnitAmount } from './trading.js';
@@ -22,21 +23,88 @@ const TRADING_API_URL = process.env.NANSEN_TRADING_API_URL || 'https://trading-a
 const LO_PREFIX = '/limit-order/v2';
 const SOLSCAN_TX_URL = 'https://solscan.io/tx/';
 
-// ============= JWT Auth & Caching =============
+// ============= JWT Auth & Caching (OS Keychain) =============
 
-function getAuthCachePath() {
-  return path.join(process.env.HOME || process.env.USERPROFILE || '', '.nansen', 'limit-order-auth.json');
+const KEYCHAIN_SERVICE = 'nansen-cli';
+const KEYCHAIN_TIMEOUT_MS = 5000;
+
+/**
+ * Build a keychain account name scoped to a wallet pubkey.
+ * This ensures switching wallets doesn't return a stale JWT.
+ */
+function keychainAccount(walletPubkey) {
+  return `limit-order-jwt:${walletPubkey}`;
 }
 
 /**
- * Load a cached JWT token for the given wallet pubkey.
- * Returns the token string if valid, null otherwise.
+ * Store a JWT token in the OS keychain.
+ * The token is stored as a JSON blob containing the JWT + expiry.
+ * Falls back silently if keychain is unavailable.
+ */
+export function saveCachedToken(walletPubkey, token) {
+  const data = JSON.stringify({
+    walletPubkey,
+    token,
+    // 23-hour TTL provides 1-hour safety margin against server's 24-hour JWT
+    expiresAt: Date.now() + 23 * 3600 * 1000,
+  });
+  const account = keychainAccount(walletPubkey);
+
+  try {
+    if (process.platform === 'darwin') {
+      execFileSync('/usr/bin/security', [
+        'add-generic-password',
+        '-s', KEYCHAIN_SERVICE,
+        '-a', account,
+        '-w', data,
+        '-U', // Update if exists
+      ], { timeout: KEYCHAIN_TIMEOUT_MS, stdio: 'pipe' });
+      return true;
+    }
+
+    if (process.platform === 'linux') {
+      execFileSync('secret-tool', [
+        'store',
+        '--label', `${KEYCHAIN_SERVICE} limit-order JWT`,
+        'service', KEYCHAIN_SERVICE,
+        'account', account,
+      ], { input: data, timeout: KEYCHAIN_TIMEOUT_MS, stdio: ['pipe', 'pipe', 'pipe'] });
+      return true;
+    }
+  } catch {
+    // Keychain unavailable — token won't be cached, but operation continues
+  }
+  return false;
+}
+
+/**
+ * Load a cached JWT token from the OS keychain.
+ * Returns the token string if valid and not expired, null otherwise.
  */
 export function loadCachedToken(walletPubkey) {
+  const account = keychainAccount(walletPubkey);
+
   try {
-    const cachePath = getAuthCachePath();
-    if (!fs.existsSync(cachePath)) return null;
-    const data = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    let raw;
+    if (process.platform === 'darwin') {
+      raw = execFileSync('/usr/bin/security', [
+        'find-generic-password',
+        '-s', KEYCHAIN_SERVICE,
+        '-a', account,
+        '-w',
+      ], { timeout: KEYCHAIN_TIMEOUT_MS, stdio: ['pipe', 'pipe', 'pipe'] }).toString().trim();
+    } else if (process.platform === 'linux') {
+      raw = execFileSync('secret-tool', [
+        'lookup',
+        'service', KEYCHAIN_SERVICE,
+        'account', account,
+      ], { timeout: KEYCHAIN_TIMEOUT_MS, stdio: ['pipe', 'pipe', 'pipe'] }).toString().trim();
+    } else {
+      return null;
+    }
+
+    if (!raw) return null;
+    const data = JSON.parse(raw);
     if (data.walletPubkey !== walletPubkey) return null;
     // 5-minute buffer before expiry to avoid mid-request failures
     if (data.expiresAt <= Date.now() + 300_000) return null;
@@ -44,29 +112,6 @@ export function loadCachedToken(walletPubkey) {
   } catch {
     return null;
   }
-}
-
-/**
- * Save a JWT token to disk for later reuse.
- * Uses atomic write (temp file + rename) to avoid corruption.
- */
-export function saveCachedToken(walletPubkey, token) {
-  const cachePath = getAuthCachePath();
-  const dir = path.dirname(cachePath);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  }
-
-  const data = {
-    walletPubkey,
-    token,
-    // 23-hour TTL provides 1-hour safety margin against server's 24-hour JWT
-    expiresAt: Date.now() + 23 * 3600 * 1000,
-  };
-
-  const tmpPath = cachePath + '.' + crypto.randomBytes(4).toString('hex') + '.tmp';
-  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), { mode: 0o600 });
-  fs.renameSync(tmpPath, cachePath);
 }
 
 // ============= API Client =============

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -659,6 +659,7 @@ EXAMPLES:
       } catch (err) {
         log(`Error: ${err.message}`);
         if (err.details) log(`  Details: ${JSON.stringify(err.details)}`);
+        if (err.cause) log(`  Cause: ${err.cause.message || err.cause}`);
         exit(1);
       }
     },

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -454,7 +454,7 @@ function formatOrder(order, index) {
   lines.push(`    Sell:            ${formatAmount(order.inputAmount, order.inputMint)}`);
   lines.push(`    Buy:             ${tokenLabel(order.outputMint)}`);
   lines.push(`    Trigger:         ${order.triggerCondition} $${order.triggerPriceUsd} on ${tokenLabel(order.triggerMint)}`);
-  if (order.slippageBps != null) lines.push(`    Slippage:        ${order.slippageBps} bps`);
+  lines.push(`    Slippage:        ${order.slippageBps != null ? `${order.slippageBps} bps` : 'auto'}`);
   lines.push(`    Created:         ${formatTimestamp(order.createdAt)}`);
   if (order.expiresAt) lines.push(`    Expires:         ${formatTimestamp(order.expiresAt)}`);
   if (order.fills?.length > 0) {
@@ -484,7 +484,7 @@ export function buildLimitOrderCommands(deps = {}) {
       const triggerPrice = options['trigger-price'];
       const triggerCondition = options['trigger-condition'];
       const triggerMintRaw = options['trigger-mint'];
-      const slippageBps = options.slippage != null ? Number(options.slippage) : undefined;
+      const slippageBps = options['slippage-bps'] != null ? Number(options['slippage-bps']) : undefined;
       const expiresStr = options.expires || '30d';
       const walletName = options.wallet;
 
@@ -499,7 +499,7 @@ OPTIONS:
   --trigger-mint <symbol|addr>   Token whose price triggers the order (e.g. SOL)
   --trigger-condition <cond>     "above" or "below"
   --trigger-price <usd>          Trigger price in USD (must be a positive number)
-  --slippage <bps>               Slippage tolerance in basis points (e.g. 50 = 0.5%)
+  --slippage-bps <bps>               Slippage in basis points (100 = 1%), omit for auto
   --expires <duration>           Expiry duration: "24h", "7d", "30d" (default: 30d)
   --wallet <name>                Wallet name (or "walletconnect"/"wc")
 
@@ -787,28 +787,31 @@ EXAMPLES:
     'update': async (args, apiInstance, flags, options) => {
       const orderId = options.order || options['order-id'] || args[0];
       const triggerPrice = options['trigger-price'];
-      const slippageBps = options.slippage;
+      const slippageBps = options['slippage-bps'];
       const walletName = options.wallet;
 
       if (!orderId) {
         log(`
-Usage: nansen trade limit-order update --order <orderId> [--trigger-price <usd>] [--slippage <bps>]
+Usage: nansen trade limit-order update --order <orderId> [--trigger-price <usd>] [--slippage-bps <bps>]
 
 OPTIONS:
   --order <id>            Order ID to update
   --trigger-price <usd>   New trigger price in USD
-  --slippage <bps>        New slippage in basis points
+  --slippage-bps <bps>    Slippage in basis points (100 = 1%)
   --wallet <name>         Wallet name (or "walletconnect"/"wc")
+
+NOTE: Only provided fields are updated. Auto slippage can only be set at creation time
+      (by omitting --slippage-bps from the create command).
 
 EXAMPLES:
   nansen trade limit-order update --order abc123 --trigger-price 85
-  nansen trade limit-order update --order abc123 --slippage 100`);
+  nansen trade limit-order update --order abc123 --slippage-bps 100`);
         exit(1);
         return;
       }
 
       if (triggerPrice == null && slippageBps == null) {
-        log('Error: Provide at least one of --trigger-price or --slippage to update.');
+        log('Error: Provide at least one of --trigger-price or --slippage-bps to update.');
         exit(1);
         return;
       }
@@ -826,7 +829,7 @@ EXAMPLES:
       if (slippageBps != null) {
         const bps = Number(slippageBps);
         if (isNaN(bps) || bps < 0 || bps > 10000) {
-          log('Error: --slippage must be between 0 and 10000 basis points.');
+          log('Error: --slippage-bps must be between 0 and 10000 basis points.');
           exit(1);
           return;
         }

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -659,15 +659,13 @@ EXAMPLES:
       } catch (err) {
         log(`Error: ${err.message}`);
         if (err.details) log(`  Details: ${JSON.stringify(err.details)}`);
-        if (err.cause) log(`  Cause: ${err.cause.message || err.cause}`);
         exit(1);
       }
     },
 
     'list': async (args, apiInstance, flags, options) => {
       const walletName = options.wallet;
-      const stateRaw = options.state || 'open';
-      const state = stateRaw === 'all' ? undefined : stateRaw;
+      const state = options.state;
       const mint = options.mint ? resolveTokenAddress(options.mint, 'solana') : undefined;
       const limit = options.limit || 20;
       const offset = options.offset || 0;
@@ -702,7 +700,7 @@ EXAMPLES:
 
         if (orders.length === 0) {
           log('\nNo limit orders found.');
-          log(`  (state: ${stateRaw})`);
+          if (state) log(`  (filtered by state: ${state})`);
           log('');
           return;
         }

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -706,7 +706,10 @@ EXAMPLES:
         }
 
         log(`\nLimit Orders (${result.pagination?.total || orders.length} total):\n`);
-        orders.forEach((order, i) => log(formatOrder(order, i)));
+        orders.forEach((order, i) => {
+          if (i > 0) log('');
+          log(formatOrder(order, i));
+        });
         if (result.pagination && result.pagination.total > offset + orders.length) {
           log(`\n  Showing ${offset + 1}-${offset + orders.length} of ${result.pagination.total}. Use --offset ${offset + orders.length} to see more.`);
         }

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -609,13 +609,18 @@ EXAMPLES:
         let hasVault = false;
         try {
           const vaultInfo = await getVault(token, pubkey);
-          hasVault = !!vaultInfo?.vaultPubkey;
+          hasVault = !!(vaultInfo?.vaultPubkey || vaultInfo?.vaultAddress);
         } catch {
           // No vault found
         }
         if (!hasVault) {
           log('  Registering vault for first-time use...');
-          await registerVault(token);
+          try {
+            await registerVault(token);
+          } catch (regErr) {
+            // Vault may already exist — ignore "already registered" errors
+            if (!/already registered/i.test(regErr.message)) throw regErr;
+          }
         }
 
         // 4. Craft deposit transaction

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -6,11 +6,7 @@
  * Zero external dependencies — uses Node.js built-in crypto only.
  */
 
-import crypto from 'crypto';
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
-import { base58Encode, exportWallet, getWalletConfig, showWallet, listWallets } from './wallet.js';
+import { base58Encode, exportWallet, getWalletConfig, showWallet } from './wallet.js';
 import { signEd25519, base58Decode } from './transfer.js';
 import { signSolanaTransaction, resolveTokenAddress, validateBaseUnitAmount } from './trading.js';
 import { getWalletConnectAddress, sendSolanaTransactionViaWalletConnect, signSolanaMessageViaWalletConnect } from './walletconnect-trading.js';

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -10,12 +10,11 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { execFileSync } from 'child_process';
 import { base58Encode, exportWallet, getWalletConfig, showWallet, listWallets } from './wallet.js';
 import { signEd25519, base58Decode } from './transfer.js';
 import { signSolanaTransaction, resolveTokenAddress, validateBaseUnitAmount } from './trading.js';
 import { getWalletConnectAddress, sendSolanaTransactionViaWalletConnect, signSolanaMessageViaWalletConnect } from './walletconnect-trading.js';
-import { retrievePassword } from './keychain.js';
+import { retrievePassword, keychainStoreValue, keychainRetrieveValue } from './keychain.js';
 
 // ============= Constants =============
 
@@ -24,9 +23,6 @@ const LO_PREFIX = '/limit-order/v2';
 const SOLSCAN_TX_URL = 'https://solscan.io/tx/';
 
 // ============= JWT Auth & Caching (OS Keychain) =============
-
-const KEYCHAIN_SERVICE = 'nansen-cli';
-const KEYCHAIN_TIMEOUT_MS = 5000;
 
 /**
  * Build a keychain account name scoped to a wallet pubkey.
@@ -48,33 +44,7 @@ export function saveCachedToken(walletPubkey, token) {
     // 23-hour TTL provides 1-hour safety margin against server's 24-hour JWT
     expiresAt: Date.now() + 23 * 3600 * 1000,
   });
-  const account = keychainAccount(walletPubkey);
-
-  try {
-    if (process.platform === 'darwin') {
-      execFileSync('/usr/bin/security', [
-        'add-generic-password',
-        '-s', KEYCHAIN_SERVICE,
-        '-a', account,
-        '-w', data,
-        '-U', // Update if exists
-      ], { timeout: KEYCHAIN_TIMEOUT_MS, stdio: 'pipe' });
-      return true;
-    }
-
-    if (process.platform === 'linux') {
-      execFileSync('secret-tool', [
-        'store',
-        '--label', `${KEYCHAIN_SERVICE} limit-order JWT`,
-        'service', KEYCHAIN_SERVICE,
-        'account', account,
-      ], { input: data, timeout: KEYCHAIN_TIMEOUT_MS, stdio: ['pipe', 'pipe', 'pipe'] });
-      return true;
-    }
-  } catch {
-    // Keychain unavailable — token won't be cached, but operation continues
-  }
-  return false;
+  return keychainStoreValue(keychainAccount(walletPubkey), data);
 }
 
 /**
@@ -82,27 +52,8 @@ export function saveCachedToken(walletPubkey, token) {
  * Returns the token string if valid and not expired, null otherwise.
  */
 export function loadCachedToken(walletPubkey) {
-  const account = keychainAccount(walletPubkey);
-
   try {
-    let raw;
-    if (process.platform === 'darwin') {
-      raw = execFileSync('/usr/bin/security', [
-        'find-generic-password',
-        '-s', KEYCHAIN_SERVICE,
-        '-a', account,
-        '-w',
-      ], { timeout: KEYCHAIN_TIMEOUT_MS, stdio: ['pipe', 'pipe', 'pipe'] }).toString().trim();
-    } else if (process.platform === 'linux') {
-      raw = execFileSync('secret-tool', [
-        'lookup',
-        'service', KEYCHAIN_SERVICE,
-        'account', account,
-      ], { timeout: KEYCHAIN_TIMEOUT_MS, stdio: ['pipe', 'pipe', 'pipe'] }).toString().trim();
-    } else {
-      return null;
-    }
-
+    const raw = keychainRetrieveValue(keychainAccount(walletPubkey));
     if (!raw) return null;
     const data = JSON.parse(raw);
     if (data.walletPubkey !== walletPubkey) return null;

--- a/src/privy.js
+++ b/src/privy.js
@@ -125,6 +125,15 @@ export class PrivyClient {
     });
   }
 
+  async signSolanaMessage(walletId, messageBuffer) {
+    const messageBase64 = Buffer.from(messageBuffer).toString('base64');
+    return this._request("POST", `/wallets/${walletId}/rpc`, {
+      method: "signMessage",
+      chain_type: "solana",
+      params: { message: messageBase64, encoding: "base64" },
+    });
+  }
+
 }
 
 // ============= Helpers =============

--- a/src/schema.json
+++ b/src/schema.json
@@ -906,6 +906,137 @@
               "description": "Destination chain (solana or base)"
             }
           }
+        },
+        "limit-order": {
+          "description": "Limit order management (Solana only, Jupiter Trigger V2)",
+          "subcommands": {
+            "create": {
+              "description": "Place a new limit order",
+              "options": {
+                "from": {
+                  "type": "string",
+                  "required": true,
+                  "description": "Token to sell (address or symbol)"
+                },
+                "to": {
+                  "type": "string",
+                  "required": true,
+                  "description": "Token to buy (address or symbol)"
+                },
+                "amount": {
+                  "type": "string",
+                  "required": true,
+                  "description": "Amount in base units (e.g. lamports)"
+                },
+                "trigger-price": {
+                  "type": "number",
+                  "required": true,
+                  "description": "Trigger price in USD"
+                },
+                "trigger-condition": {
+                  "type": "string",
+                  "default": "below",
+                  "description": "Trigger when price is 'above' or 'below' target"
+                },
+                "trigger-mint": {
+                  "type": "string",
+                  "description": "Token whose price triggers the order (defaults to output mint)"
+                },
+                "slippage": {
+                  "type": "number",
+                  "description": "Slippage tolerance in basis points (e.g. 50 = 0.5%)"
+                },
+                "expires": {
+                  "type": "string",
+                  "default": "30d",
+                  "description": "Expiry duration (e.g. 24h, 7d, 30d) or epoch ms"
+                },
+                "wallet": {
+                  "type": "string",
+                  "description": "Wallet name (or \"walletconnect\"/\"wc\")"
+                }
+              },
+              "chains": ["solana"],
+              "prerequisites": [
+                "A Solana wallet must be configured. Run: nansen wallet create"
+              ]
+            },
+            "list": {
+              "description": "List your limit orders",
+              "options": {
+                "state": {
+                  "type": "string",
+                  "description": "Filter by state (open, filled, cancelled, expired)"
+                },
+                "mint": {
+                  "type": "string",
+                  "description": "Filter by token mint address"
+                },
+                "limit": {
+                  "type": "number",
+                  "default": 20,
+                  "description": "Max results per page"
+                },
+                "offset": {
+                  "type": "number",
+                  "default": 0,
+                  "description": "Pagination offset"
+                },
+                "sort": {
+                  "type": "string",
+                  "description": "Sort field"
+                },
+                "dir": {
+                  "type": "string",
+                  "default": "desc",
+                  "description": "Sort direction (asc or desc)"
+                },
+                "wallet": {
+                  "type": "string",
+                  "description": "Wallet name (or \"walletconnect\"/\"wc\")"
+                }
+              },
+              "chains": ["solana"]
+            },
+            "cancel": {
+              "description": "Cancel an open limit order",
+              "options": {
+                "order": {
+                  "type": "string",
+                  "required": true,
+                  "description": "Order ID to cancel"
+                },
+                "wallet": {
+                  "type": "string",
+                  "description": "Wallet name (or \"walletconnect\"/\"wc\")"
+                }
+              },
+              "chains": ["solana"]
+            },
+            "update": {
+              "description": "Update trigger price or slippage on an existing order",
+              "options": {
+                "order": {
+                  "type": "string",
+                  "required": true,
+                  "description": "Order ID to update"
+                },
+                "trigger-price": {
+                  "type": "number",
+                  "description": "New trigger price in USD"
+                },
+                "slippage": {
+                  "type": "number",
+                  "description": "New slippage in basis points (0-10000)"
+                },
+                "wallet": {
+                  "type": "string",
+                  "description": "Wallet name (or \"walletconnect\"/\"wc\")"
+                }
+              },
+              "chains": ["solana"]
+            }
+          }
         }
       }
     },

--- a/src/schema.json
+++ b/src/schema.json
@@ -967,8 +967,7 @@
               "options": {
                 "state": {
                   "type": "string",
-                  "default": "open",
-                  "description": "Filter by state (open, filled, cancelled, expired, all)"
+                  "description": "Filter by state (open, filled, cancelled, expired)"
                 },
                 "mint": {
                   "type": "string",

--- a/src/schema.json
+++ b/src/schema.json
@@ -967,7 +967,7 @@
               "options": {
                 "state": {
                   "type": "string",
-                  "description": "Filter by state (open, filled, cancelled, expired)"
+                  "description": "Filter by state (active, past)"
                 },
                 "mint": {
                   "type": "string",

--- a/src/schema.json
+++ b/src/schema.json
@@ -943,7 +943,7 @@
                   "required": true,
                   "description": "Token whose price triggers the order (e.g. SOL)"
                 },
-                "slippage": {
+                "slippage-bps": {
                   "type": "number",
                   "description": "Slippage tolerance in basis points (e.g. 50 = 0.5%)"
                 },
@@ -1026,7 +1026,7 @@
                   "type": "number",
                   "description": "New trigger price in USD"
                 },
-                "slippage": {
+                "slippage-bps": {
                   "type": "number",
                   "description": "New slippage in basis points (0-10000)"
                 },

--- a/src/schema.json
+++ b/src/schema.json
@@ -967,7 +967,8 @@
               "options": {
                 "state": {
                   "type": "string",
-                  "description": "Filter by state (open, filled, cancelled, expired)"
+                  "default": "open",
+                  "description": "Filter by state (open, filled, cancelled, expired, all)"
                 },
                 "mint": {
                   "type": "string",

--- a/src/schema.json
+++ b/src/schema.json
@@ -935,12 +935,13 @@
                 },
                 "trigger-condition": {
                   "type": "string",
-                  "default": "below",
+                  "required": true,
                   "description": "Trigger when price is 'above' or 'below' target"
                 },
                 "trigger-mint": {
                   "type": "string",
-                  "description": "Token whose price triggers the order (defaults to output mint)"
+                  "required": true,
+                  "description": "Token whose price triggers the order (e.g. SOL)"
                 },
                 "slippage": {
                   "type": "number",

--- a/src/schema.json
+++ b/src/schema.json
@@ -908,7 +908,7 @@
           }
         },
         "limit-order": {
-          "description": "Limit order management (Solana only, Jupiter Trigger V2)",
+          "description": "Limit order management (Solana only)",
           "subcommands": {
             "create": {
               "description": "Place a new limit order",

--- a/src/transfer.js
+++ b/src/transfer.js
@@ -302,7 +302,7 @@ function modPowBig(base, exp, mod) {
   return result;
 }
 
-async function getTokenInfo(rpcUrl, mint) {
+export async function getTokenInfo(rpcUrl, mint) {
   // Get mint account to determine token program and decimals
   const info = await rpcCall(rpcUrl, 'getAccountInfo', [mint, { encoding: 'jsonParsed' }]);
   if (!info || !info.value) throw new Error(`Token mint ${mint} not found`);

--- a/src/walletconnect-trading.js
+++ b/src/walletconnect-trading.js
@@ -9,6 +9,7 @@
  */
 
 import { wcExec } from './walletconnect-exec.js';
+import { base58Encode } from './wallet.js';
 
 const SOLANA_MAINNET_CHAIN = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
 
@@ -152,4 +153,28 @@ export async function sendSolanaTransactionViaWalletConnect(txBase58, timeoutMs 
   if (result.transaction) return { signedTransaction: result.transaction };
 
   throw new Error('Unexpected response from walletconnect Solana sign');
+}
+
+/**
+ * Sign a Solana message via WalletConnect.
+ *
+ * Used for challenge-response authentication (e.g., Jupiter Limit Order V2).
+ * Returns the raw Ed25519 signature as base58.
+ *
+ * @param {Buffer} messageBuffer - Raw message bytes to sign
+ * @param {number} [timeoutMs=120000] - Timeout for user approval
+ * @returns {{ signature: string }} Base58-encoded signature
+ */
+export async function signSolanaMessageViaWalletConnect(messageBuffer, timeoutMs = 120000) {
+  const payload = {
+    message: base58Encode(messageBuffer),
+    chainId: SOLANA_MAINNET_CHAIN,
+  };
+
+  const output = await wcExec('walletconnect', ['sign-message', JSON.stringify(payload)], timeoutMs);
+  const result = parseWcJson(output);
+
+  if (result.signature) return { signature: result.signature };
+
+  throw new Error('Unexpected response from walletconnect sign-message');
 }


### PR DESCRIPTION
## Summary

Add `trade limit` commands for Jupiter Limit Order V2 on Solana — create, list, cancel, and update trigger-based orders.

### Commands
- `trade limit create` — place a limit order (deposit + order in one flow)
- `trade limit list` — list orders with `--state active|past` filtering, pagination, mint filter
- `trade limit cancel` — cancel an order (withdrawal + confirmation)
- `trade limit update` — update trigger price and/or slippage on an existing order

### Design decisions
- **Amount convention matches swap**: base units by default, `--amount-unit token` for human-readable (e.g. `--amount 1.5 --amount-unit token`)
- **Slippage convention matches swap**: `--slippage 0.03` (decimal, 3%) — converted internally to bps for the API
- **Shared utilities from trading.js**: `resolveTokenDecimals()`, `convertToBaseUnits()`, `validateBaseUnitAmount()`, `resolveTokenAddress()` — no duplicate infrastructure
- **JWT auth**: challenge-response with 23h TTL disk cache at `~/.nansen/limit-order-auth.json`
- **Wallet support**: local wallets, Privy, and WalletConnect
- **Auto vault registration**: first-time users get a vault registered transparently
- **5xx ghost-order recovery**: if `createOrder` returns 5xx, checks recent orders (matching token pair, amount, trigger price, and timestamp) to warn about duplicates before the user retries

### Files
| File | What |
|------|------|
| `src/limit-order.js` | Core module: auth, signing, wallet resolution, all 4 command handlers |
| `src/cli.js` | Route `trade limit <sub>` to limit-order handlers |
| `src/schema.json` | Option docs for create, list, cancel, update |
| `src/privy.js` | `signSolanaMessage()` for Privy wallets |
| `src/walletconnect-trading.js` | `signSolanaMessageViaWalletConnect()` for WC wallets |
| `src/__tests__/limit-order.test.js` | 96 unit tests |

## Test plan

- [x] `npm test` — 1378 tests pass (96 new for limit-order)
- [x] `npm run lint` — clean
- [x] Dogfooded locally:
  - Created orders: SOL to USDC, SOL to TRUMP, SOL to ORCA (all succeeded)
  - Created order: SOL to PUMP (correctly rejected — transfer hook extension)
  - Listed orders with `--state active`, verified formatting
  - Updated order (trigger price + slippage), verified via list
  - Cancelled all orders, verified withdrawal transactions on Solscan
  - Insufficient balance returns clean error (no misleading ghost-order warning)
- [x] 5xx ghost-order check: only triggers after `createOrder` call, not on pre-submission errors
- [x] Schema.json updated with correct API state values (`active`/`past`)

Generated with [Claude Code](https://claude.com/claude-code)
