### PR TITLE
Enforce USDC/native token on one side of every swap

### DIFF
--- a/.changeset/usdc-native-enforcement.md
+++ b/.changeset/usdc-native-enforcement.md
@@ -2,4 +2,4 @@
 "nansen-cli": patch
 ---
 
-Enforce USDC or native token on one side of every swap (ECINT-6557)
+Enforce USDC or native token on one side of every swap

--- a/.changeset/usdc-native-enforcement.md
+++ b/.changeset/usdc-native-enforcement.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Enforce USDC or native token on one side of every swap (ECINT-6557)

--- a/skills/nansen-trading/SKILL.md
+++ b/skills/nansen-trading/SKILL.md
@@ -33,7 +33,18 @@ nansen trade quote \
   --amount 1000000000
 ```
 
-Symbols resolve automatically: `SOL`, `ETH`, `USDC`, `USDT`, `WETH`. Raw addresses also work.
+Symbols resolve automatically: `SOL`, `ETH`, `USDC`, `USDT`, `WETH`. Raw addresses also work. Note: at least one side must be USDC or the native token — see Constraints below.
+
+## Constraints
+
+**Swap constraint:** At least one side of every swap must be **USDC** or the chain's **native token** (SOL on Solana, ETH on Base). Arbitrary token-to-token swaps (e.g. WETH→USDT, BONK→JUP) are rejected.
+
+- USDC (Solana): `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- USDC (Base): `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913`
+- Native SOL: `So11111111111111111111111111111111111111112`
+- Native ETH: `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`
+
+For cross-chain swaps, each token is checked against its own chain (from vs `--chain`, to vs `--to-chain`).
 
 ## Execute
 

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -207,6 +207,18 @@ describe('validateQuoteInput', () => {
         chain: 'solana', from: BONK, to: JUP, amount: '1000000000',
       })).toThrow(/USDC or the native token/);
     });
+
+    it('rejects cross-chain WETH → BONK (Base → Solana, neither anchor)', () => {
+      expect(() => validateQuoteInput({
+        chain: 'base', toChain: 'solana', from: WETH, to: BONK, amount: '1000000000000000000',
+      })).toThrow(/USDC or the native token/);
+    });
+
+    it('allows mixed-case USDC on Base (case-insensitive anchor recognition)', () => {
+      expect(() => validateQuoteInput({
+        chain: 'base', from: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', to: WETH, amount: '1000000',
+      })).not.toThrow();
+    });
   });
 });
 

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -145,6 +145,69 @@ describe('validateQuoteInput', () => {
       })).not.toThrow();
     });
   });
+
+  describe('USDC/native anchor enforcement', () => {
+    const SOL = 'So11111111111111111111111111111111111111112';
+    const USDC_SOL = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+    const ETH = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+    const USDC_BASE = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+    // Non-native, non-USDC tokens
+    const USDT_SOL = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB';
+    const BONK = 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263';
+    const JUP = 'JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN';
+    const WETH = '0x4200000000000000000000000000000000000006';
+    const USDT_BASE = '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2';
+
+    // Happy paths
+    it('allows SOL → USDT (native on from-side, Solana)', () => {
+      expect(() => validateQuoteInput({
+        chain: 'solana', from: SOL, to: USDT_SOL, amount: '1000000000',
+      })).not.toThrow();
+    });
+
+    it('allows USDT → SOL (native on to-side, Solana)', () => {
+      expect(() => validateQuoteInput({
+        chain: 'solana', from: USDT_SOL, to: SOL, amount: '1000000000',
+      })).not.toThrow();
+    });
+
+    it('allows SOL → USDC (native + USDC, Solana)', () => {
+      expect(() => validateQuoteInput({
+        chain: 'solana', from: SOL, to: USDC_SOL, amount: '1000000000',
+      })).not.toThrow();
+    });
+
+    it('allows USDC → WETH (USDC on from-side, Base)', () => {
+      expect(() => validateQuoteInput({
+        chain: 'base', from: USDC_BASE, to: WETH, amount: '1000000',
+      })).not.toThrow();
+    });
+
+    it('allows ETH → USDT (native on from-side, Base)', () => {
+      expect(() => validateQuoteInput({
+        chain: 'base', from: ETH, to: USDT_BASE, amount: '1000000000000000000',
+      })).not.toThrow();
+    });
+
+    it('allows cross-chain USDC → USDC (Base → Solana)', () => {
+      expect(() => validateQuoteInput({
+        chain: 'base', toChain: 'solana', from: USDC_BASE, to: USDC_SOL, amount: '1000000',
+      })).not.toThrow();
+    });
+
+    // Failure paths
+    it('rejects WETH → USDT on Base (neither side is native or USDC)', () => {
+      expect(() => validateQuoteInput({
+        chain: 'base', from: WETH, to: USDT_BASE, amount: '1000000000000000000',
+      })).toThrow(/USDC or the native token/);
+    });
+
+    it('rejects BONK → JUP on Solana (neither side is native or USDC)', () => {
+      expect(() => validateQuoteInput({
+        chain: 'solana', from: BONK, to: JUP, amount: '1000000000',
+      })).toThrow(/USDC or the native token/);
+    });
+  });
 });
 
 describe('fetchNativeBalance', () => {

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -66,10 +66,10 @@ export function validateQuoteInput({ chain, toChain, from, to, amount }) {
   const fromIsAnchor = isUsdcOrNative(from, normalizedChain);
   const toIsAnchor = isUsdcOrNative(to, normalizedToChain);
   if (!fromIsAnchor && !toIsAnchor) {
-    throw new Error(
-      `Invalid swap: at least one token must be USDC or the native token (${NATIVE_SYMBOLS[normalizedChain] ?? normalizedChain}). ` +
-      `Got: ${from} → ${to}.`
-    );
+    const anchorDesc = normalizedChain === normalizedToChain
+      ? `USDC or the native token (${NATIVE_SYMBOLS[normalizedChain] ?? normalizedChain})`
+      : `USDC or the native token on either side (${NATIVE_SYMBOLS[normalizedChain] ?? normalizedChain} on ${normalizedChain}, ${NATIVE_SYMBOLS[normalizedToChain] ?? normalizedToChain} on ${normalizedToChain})`;
+    throw new Error(`Invalid swap: at least one token must be ${anchorDesc}. Got: ${from} → ${to}.`);
   }
 }
 

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -61,6 +61,16 @@ export function validateQuoteInput({ chain, toChain, from, to, amount }) {
       );
     }
   }
+
+  // 5. At least one side must be USDC or the native token
+  const fromIsAnchor = isUsdcOrNative(from, normalizedChain);
+  const toIsAnchor = isUsdcOrNative(to, normalizedToChain);
+  if (!fromIsAnchor && !toIsAnchor) {
+    throw new Error(
+      `Invalid swap: at least one token must be USDC or the native token (${NATIVE_SYMBOLS[normalizedChain] ?? normalizedChain}). ` +
+      `Got: ${from} → ${to}.`
+    );
+  }
 }
 
 // Native token decimals per chain (for converting balance from base units)
@@ -112,6 +122,12 @@ const NATIVE_TOKEN_ADDRESSES = {
   base: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
 };
 
+// USDC contract addresses per chain.
+const USDC_ADDRESSES = {
+  solana: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+  base: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+};
+
 // Native token symbols for error messages.
 const NATIVE_SYMBOLS = { solana: 'SOL', base: 'ETH' };
 
@@ -119,6 +135,21 @@ const MIN_GAS_AMOUNTS = { solana: 0.01, base: 0.000024 };
 const FEE_BUFFER = { solana: 0.005, base: 0.00004 };
 const HIGH_PERCENTAGE_THRESHOLD = 95;
 const AUTO_ADJUST_THRESHOLD_PERCENT = 2;
+
+/**
+ * Check if an address is USDC or the native token for a chain (case-insensitive for EVM).
+ */
+function isUsdcOrNative(address, chain) {
+  const usdc = USDC_ADDRESSES[chain];
+  const native = NATIVE_TOKEN_ADDRESSES[chain];
+  if (!usdc && !native) return false;
+  if (chain === 'solana') {
+    return address === usdc || address === native;
+  }
+  // EVM: case-insensitive
+  const lower = address.toLowerCase();
+  return (usdc && lower === usdc.toLowerCase()) || (native && lower === native.toLowerCase());
+}
 
 /**
  * Check if an address is the native token for a chain (case-insensitive for EVM).


### PR DESCRIPTION
Adds a validation rule to validateQuoteInput that requires at least one of the swap tokens to be USDC or the chain's native token (SOL/ETH). Rejects arbitrary token-to-token swaps like WETH→USDT or BONK→JUP.