### PR TITLE
feat(sig-6603): add order_by, advanced filters, and address-summary

### DIFF
--- a/.changeset/pm-filtering-address-summary.md
+++ b/.changeset/pm-filtering-address-summary.md
@@ -2,4 +2,4 @@
 "nansen-cli": minor
 ---
 
-Add prediction market filtering (sort_direction, volume/liquidity/OI/trader/price/date filters, neg_risk, tags) and address-summary endpoint
+Add prediction market filtering (order_by, volume/liquidity/OI/trader/price/date filters, neg_risk, tags) and address-summary endpoint

--- a/.changeset/pm-filtering-address-summary.md
+++ b/.changeset/pm-filtering-address-summary.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add prediction market filtering (sort_direction, volume/liquidity/OI/trader/price/date filters, neg_risk, tags) and address-summary endpoint

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -1957,67 +1957,60 @@ describe('NansenAPI', () => {
     });
 
     describe('order_by parameter', () => {
-      it('should send both order_by and sort for backward compat on pmOhlcv', async () => {
+      it('should pass order_by to pmOhlcv', async () => {
         setupMock(MOCK_RESPONSES.pmOhlcv);
         const orderBy = [{ field: 'volume_usd', direction: 'ASC' }];
         await api.pmOhlcv({ marketId: '654412', orderBy });
         const body = expectFetchCalledWith('/api/v1/prediction-market/ohlcv');
         expect(body.order_by).toEqual(orderBy);
-        expect(body.sort).toEqual(orderBy);
       });
 
-      it('should fall back to sort param for pmOhlcv when no orderBy', async () => {
+      it('should fall back to sort param as order_by for pmOhlcv', async () => {
         setupMock(MOCK_RESPONSES.pmOhlcv);
         const sort = [{ field: 'period_start', direction: 'DESC' }];
         await api.pmOhlcv({ marketId: '654412', sort });
         const body = expectFetchCalledWith('/api/v1/prediction-market/ohlcv');
         expect(body.order_by).toEqual(sort);
-        expect(body.sort).toEqual(sort);
       });
 
-      it('should send both order_by and sort for backward compat on pmTopHolders', async () => {
+      it('should pass order_by to pmTopHolders', async () => {
         setupMock(MOCK_RESPONSES.pmTopHolders);
         const orderBy = [{ field: 'position_size', direction: 'ASC' }];
         await api.pmTopHolders({ marketId: '654412', orderBy });
         const body = expectFetchCalledWith('/api/v1/prediction-market/top-holders');
         expect(body.order_by).toEqual(orderBy);
-        expect(body.sort).toEqual(orderBy);
       });
 
-      it('should send both order_by and sort on pmTradesByMarket', async () => {
+      it('should pass order_by to pmTradesByMarket', async () => {
         setupMock(MOCK_RESPONSES.pmTradesByMarket);
         const orderBy = [{ field: 'timestamp', direction: 'ASC' }];
         await api.pmTradesByMarket({ marketId: '654412', orderBy });
         const body = expectFetchCalledWith('/api/v1/prediction-market/trades-by-market');
         expect(body.order_by).toEqual(orderBy);
-        expect(body.sort).toEqual(orderBy);
       });
 
-      it('should send both order_by and sort on pmTradesByAddress', async () => {
+      it('should pass order_by to pmTradesByAddress', async () => {
         setupMock(MOCK_RESPONSES.pmTradesByAddress);
         const orderBy = [{ field: 'timestamp', direction: 'DESC' }];
         await api.pmTradesByAddress({ address: '0x1234567890abcdef1234567890abcdef12345678', orderBy });
         const body = expectFetchCalledWith('/api/v1/prediction-market/trades-by-address');
         expect(body.order_by).toEqual(orderBy);
-        expect(body.sort).toEqual(orderBy);
       });
 
-      it('should send both order_by and sort on pmPnlByMarket', async () => {
+      it('should pass order_by to pmPnlByMarket', async () => {
         setupMock(MOCK_RESPONSES.pmPnlByMarket);
         const orderBy = [{ field: 'total_pnl_usd', direction: 'ASC' }];
         await api.pmPnlByMarket({ marketId: '654412', orderBy });
         const body = expectFetchCalledWith('/api/v1/prediction-market/pnl-by-market');
         expect(body.order_by).toEqual(orderBy);
-        expect(body.sort).toEqual(orderBy);
       });
 
-      it('should send both order_by and sort on pmPnlByAddress', async () => {
+      it('should pass order_by to pmPnlByAddress', async () => {
         setupMock(MOCK_RESPONSES.pmPnlByAddress);
         const orderBy = [{ field: 'total_pnl_usd', direction: 'DESC' }];
         await api.pmPnlByAddress({ address: '0x1234567890abcdef1234567890abcdef12345678', orderBy });
         const body = expectFetchCalledWith('/api/v1/prediction-market/pnl-by-address');
         expect(body.order_by).toEqual(orderBy);
-        expect(body.sort).toEqual(orderBy);
       });
     });
 

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -1957,53 +1957,67 @@ describe('NansenAPI', () => {
     });
 
     describe('order_by parameter', () => {
-      it('should pass order_by to pmOhlcv', async () => {
+      it('should send both order_by and sort for backward compat on pmOhlcv', async () => {
         setupMock(MOCK_RESPONSES.pmOhlcv);
-        await api.pmOhlcv({ marketId: '654412', orderBy: [{ field: 'volume_usd', direction: 'ASC' }] });
+        const orderBy = [{ field: 'volume_usd', direction: 'ASC' }];
+        await api.pmOhlcv({ marketId: '654412', orderBy });
         const body = expectFetchCalledWith('/api/v1/prediction-market/ohlcv');
-        expect(body.order_by).toEqual([{ field: 'volume_usd', direction: 'ASC' }]);
+        expect(body.order_by).toEqual(orderBy);
+        expect(body.sort).toEqual(orderBy);
       });
 
-      it('should fall back to sort for pmOhlcv', async () => {
+      it('should fall back to sort param for pmOhlcv when no orderBy', async () => {
         setupMock(MOCK_RESPONSES.pmOhlcv);
-        await api.pmOhlcv({ marketId: '654412', sort: [{ field: 'period_start', direction: 'DESC' }] });
+        const sort = [{ field: 'period_start', direction: 'DESC' }];
+        await api.pmOhlcv({ marketId: '654412', sort });
         const body = expectFetchCalledWith('/api/v1/prediction-market/ohlcv');
-        expect(body.order_by).toEqual([{ field: 'period_start', direction: 'DESC' }]);
+        expect(body.order_by).toEqual(sort);
+        expect(body.sort).toEqual(sort);
       });
 
-      it('should pass order_by to pmTopHolders', async () => {
+      it('should send both order_by and sort for backward compat on pmTopHolders', async () => {
         setupMock(MOCK_RESPONSES.pmTopHolders);
-        await api.pmTopHolders({ marketId: '654412', orderBy: [{ field: 'position_size', direction: 'ASC' }] });
+        const orderBy = [{ field: 'position_size', direction: 'ASC' }];
+        await api.pmTopHolders({ marketId: '654412', orderBy });
         const body = expectFetchCalledWith('/api/v1/prediction-market/top-holders');
-        expect(body.order_by).toEqual([{ field: 'position_size', direction: 'ASC' }]);
+        expect(body.order_by).toEqual(orderBy);
+        expect(body.sort).toEqual(orderBy);
       });
 
-      it('should pass order_by to pmTradesByMarket', async () => {
+      it('should send both order_by and sort on pmTradesByMarket', async () => {
         setupMock(MOCK_RESPONSES.pmTradesByMarket);
-        await api.pmTradesByMarket({ marketId: '654412', orderBy: [{ field: 'timestamp', direction: 'ASC' }] });
+        const orderBy = [{ field: 'timestamp', direction: 'ASC' }];
+        await api.pmTradesByMarket({ marketId: '654412', orderBy });
         const body = expectFetchCalledWith('/api/v1/prediction-market/trades-by-market');
-        expect(body.order_by).toEqual([{ field: 'timestamp', direction: 'ASC' }]);
+        expect(body.order_by).toEqual(orderBy);
+        expect(body.sort).toEqual(orderBy);
       });
 
-      it('should pass order_by to pmTradesByAddress', async () => {
+      it('should send both order_by and sort on pmTradesByAddress', async () => {
         setupMock(MOCK_RESPONSES.pmTradesByAddress);
-        await api.pmTradesByAddress({ address: '0x1234567890abcdef1234567890abcdef12345678', orderBy: [{ field: 'timestamp', direction: 'DESC' }] });
+        const orderBy = [{ field: 'timestamp', direction: 'DESC' }];
+        await api.pmTradesByAddress({ address: '0x1234567890abcdef1234567890abcdef12345678', orderBy });
         const body = expectFetchCalledWith('/api/v1/prediction-market/trades-by-address');
-        expect(body.order_by).toEqual([{ field: 'timestamp', direction: 'DESC' }]);
+        expect(body.order_by).toEqual(orderBy);
+        expect(body.sort).toEqual(orderBy);
       });
 
-      it('should pass order_by to pmPnlByMarket', async () => {
+      it('should send both order_by and sort on pmPnlByMarket', async () => {
         setupMock(MOCK_RESPONSES.pmPnlByMarket);
-        await api.pmPnlByMarket({ marketId: '654412', orderBy: [{ field: 'total_pnl_usd', direction: 'ASC' }] });
+        const orderBy = [{ field: 'total_pnl_usd', direction: 'ASC' }];
+        await api.pmPnlByMarket({ marketId: '654412', orderBy });
         const body = expectFetchCalledWith('/api/v1/prediction-market/pnl-by-market');
-        expect(body.order_by).toEqual([{ field: 'total_pnl_usd', direction: 'ASC' }]);
+        expect(body.order_by).toEqual(orderBy);
+        expect(body.sort).toEqual(orderBy);
       });
 
-      it('should pass order_by to pmPnlByAddress', async () => {
+      it('should send both order_by and sort on pmPnlByAddress', async () => {
         setupMock(MOCK_RESPONSES.pmPnlByAddress);
-        await api.pmPnlByAddress({ address: '0x1234567890abcdef1234567890abcdef12345678', orderBy: [{ field: 'total_pnl_usd', direction: 'DESC' }] });
+        const orderBy = [{ field: 'total_pnl_usd', direction: 'DESC' }];
+        await api.pmPnlByAddress({ address: '0x1234567890abcdef1234567890abcdef12345678', orderBy });
         const body = expectFetchCalledWith('/api/v1/prediction-market/pnl-by-address');
-        expect(body.order_by).toEqual([{ field: 'total_pnl_usd', direction: 'DESC' }]);
+        expect(body.order_by).toEqual(orderBy);
+        expect(body.sort).toEqual(orderBy);
       });
     });
 
@@ -2094,6 +2108,15 @@ describe('NansenAPI', () => {
         expect(body).not.toHaveProperty('max_volume_24hr');
         expect(body).not.toHaveProperty('tags');
         expect(body).not.toHaveProperty('neg_risk');
+      });
+
+      it('should pass 0 as a valid filter value (not sentinel)', async () => {
+        setupMock(MOCK_RESPONSES.pmMarketScreener);
+        await api.pmMarketScreener({ minLiquidity: 0, maxLiquidity: 0, minVolume24hr: 0 });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
+        expect(body.min_liquidity).toBe(0);
+        expect(body.max_liquidity).toBe(0);
+        expect(body.min_volume_24hr).toBe(0);
       });
     });
 

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -1793,13 +1793,14 @@ describe('NansenAPI', () => {
         setupMock(MOCK_RESPONSES.pmMarketScreener);
         const result = await api.pmMarketScreener({});
         const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
+        expect(body.sort_by).toBe('volume_24hr');
         expect(body.query).toBe('');
         expect(body.status).toBe('');
         expect(result.data).toBeInstanceOf(Array);
         expect(result.data[0]).toHaveProperty('question', 'Will X happen?');
       });
 
-      it('should pass sort_by as fallback when no order_by', async () => {
+      it('should pass sort_by, query, and status', async () => {
         setupMock(MOCK_RESPONSES.pmMarketScreener);
         await api.pmMarketScreener({ sortBy: 'liquidity', query: 'election', status: 'active' });
         const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
@@ -1814,13 +1815,14 @@ describe('NansenAPI', () => {
         setupMock(MOCK_RESPONSES.pmEventScreener);
         const result = await api.pmEventScreener({});
         const body = expectFetchCalledWith('/api/v1/prediction-market/event-screener');
+        expect(body.sort_by).toBe('volume_24hr');
         expect(body.query).toBe('');
         expect(body.status).toBe('');
         expect(result.data).toBeInstanceOf(Array);
         expect(result.data[0]).toHaveProperty('event_title', 'US Election');
       });
 
-      it('should pass sort_by as fallback when no order_by', async () => {
+      it('should pass sort_by, query, and status', async () => {
         setupMock(MOCK_RESPONSES.pmEventScreener);
         await api.pmEventScreener({ sortBy: 'open_interest', query: 'crypto', status: 'active' });
         const body = expectFetchCalledWith('/api/v1/prediction-market/event-screener');
@@ -2006,15 +2008,15 @@ describe('NansenAPI', () => {
     });
 
     describe('pmMarketScreener (filters)', () => {
-      it('should pass order_by to screener', async () => {
+      it('should pass order_by alongside sort_by', async () => {
         setupMock(MOCK_RESPONSES.pmMarketScreener);
         await api.pmMarketScreener({ orderBy: [{ field: 'liquidity', direction: 'ASC' }] });
         const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
         expect(body.order_by).toEqual([{ field: 'liquidity', direction: 'ASC' }]);
-        expect(body).not.toHaveProperty('sort_by');
+        expect(body.sort_by).toBe('volume_24hr');
       });
 
-      it('should fall back to sort_by when no order_by', async () => {
+      it('should send sort_by without order_by when no orderBy provided', async () => {
         setupMock(MOCK_RESPONSES.pmMarketScreener);
         await api.pmMarketScreener({ sortBy: 'open_interest' });
         const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
@@ -2096,12 +2098,12 @@ describe('NansenAPI', () => {
     });
 
     describe('pmEventScreener (filters)', () => {
-      it('should pass order_by to event screener', async () => {
+      it('should pass order_by alongside sort_by to event screener', async () => {
         setupMock(MOCK_RESPONSES.pmEventScreener);
         await api.pmEventScreener({ orderBy: [{ field: 'volume_24hr', direction: 'ASC' }] });
         const body = expectFetchCalledWith('/api/v1/prediction-market/event-screener');
         expect(body.order_by).toEqual([{ field: 'volume_24hr', direction: 'ASC' }]);
-        expect(body).not.toHaveProperty('sort_by');
+        expect(body.sort_by).toBe('volume_24hr');
       });
 
       it('should pass volume and liquidity filters', async () => {

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -1708,11 +1708,11 @@ describe('NansenAPI', () => {
         expect(result.data[0]).toHaveProperty('volume_usd', 12500);
       });
 
-      it('should pass sort parameter', async () => {
+      it('should pass sort as order_by (backward compat)', async () => {
         setupMock(MOCK_RESPONSES.pmOhlcv);
         await api.pmOhlcv({ marketId: '654412', sort: [{ field: 'period_start', direction: 'DESC' }] });
         const body = expectFetchCalledWith('/api/v1/prediction-market/ohlcv');
-        expect(body.sort).toEqual([{ field: 'period_start', direction: 'DESC' }]);
+        expect(body.order_by).toEqual([{ field: 'period_start', direction: 'DESC' }]);
       });
 
       it('should require marketId', async () => {
@@ -1793,14 +1793,13 @@ describe('NansenAPI', () => {
         setupMock(MOCK_RESPONSES.pmMarketScreener);
         const result = await api.pmMarketScreener({});
         const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
-        expect(body.sort_by).toBe('volume_24hr');
         expect(body.query).toBe('');
         expect(body.status).toBe('');
         expect(result.data).toBeInstanceOf(Array);
         expect(result.data[0]).toHaveProperty('question', 'Will X happen?');
       });
 
-      it('should pass sort_by, query, and status', async () => {
+      it('should pass sort_by as fallback when no order_by', async () => {
         setupMock(MOCK_RESPONSES.pmMarketScreener);
         await api.pmMarketScreener({ sortBy: 'liquidity', query: 'election', status: 'active' });
         const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
@@ -1815,14 +1814,13 @@ describe('NansenAPI', () => {
         setupMock(MOCK_RESPONSES.pmEventScreener);
         const result = await api.pmEventScreener({});
         const body = expectFetchCalledWith('/api/v1/prediction-market/event-screener');
-        expect(body.sort_by).toBe('volume_24hr');
         expect(body.query).toBe('');
         expect(body.status).toBe('');
         expect(result.data).toBeInstanceOf(Array);
         expect(result.data[0]).toHaveProperty('event_title', 'US Election');
       });
 
-      it('should pass sort_by, query, and status', async () => {
+      it('should pass sort_by as fallback when no order_by', async () => {
         setupMock(MOCK_RESPONSES.pmEventScreener);
         await api.pmEventScreener({ sortBy: 'open_interest', query: 'crypto', status: 'active' });
         const body = expectFetchCalledWith('/api/v1/prediction-market/event-screener');
@@ -1833,11 +1831,11 @@ describe('NansenAPI', () => {
     });
 
     describe('pmTopHolders (sort)', () => {
-      it('should pass sort parameter', async () => {
+      it('should pass sort as order_by (backward compat)', async () => {
         setupMock(MOCK_RESPONSES.pmTopHolders);
         await api.pmTopHolders({ marketId: '654412', sort: [{ field: 'position_size', direction: 'DESC' }] });
         const body = expectFetchCalledWith('/api/v1/prediction-market/top-holders');
-        expect(body.sort).toEqual([{ field: 'position_size', direction: 'DESC' }]);
+        expect(body.order_by).toEqual([{ field: 'position_size', direction: 'DESC' }]);
       });
 
       it('should pass pagination', async () => {
@@ -1956,56 +1954,72 @@ describe('NansenAPI', () => {
       });
     });
 
-    describe('sort_direction parameter', () => {
-      it('should pass sort_direction to pmOhlcv', async () => {
+    describe('order_by parameter', () => {
+      it('should pass order_by to pmOhlcv', async () => {
         setupMock(MOCK_RESPONSES.pmOhlcv);
-        await api.pmOhlcv({ marketId: '654412', sortDirection: 'asc' });
+        await api.pmOhlcv({ marketId: '654412', orderBy: [{ field: 'volume_usd', direction: 'ASC' }] });
         const body = expectFetchCalledWith('/api/v1/prediction-market/ohlcv');
-        expect(body.sort_direction).toBe('asc');
+        expect(body.order_by).toEqual([{ field: 'volume_usd', direction: 'ASC' }]);
       });
 
-      it('should pass sort_direction to pmTopHolders', async () => {
+      it('should fall back to sort for pmOhlcv', async () => {
+        setupMock(MOCK_RESPONSES.pmOhlcv);
+        await api.pmOhlcv({ marketId: '654412', sort: [{ field: 'period_start', direction: 'DESC' }] });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/ohlcv');
+        expect(body.order_by).toEqual([{ field: 'period_start', direction: 'DESC' }]);
+      });
+
+      it('should pass order_by to pmTopHolders', async () => {
         setupMock(MOCK_RESPONSES.pmTopHolders);
-        await api.pmTopHolders({ marketId: '654412', sortDirection: 'desc' });
+        await api.pmTopHolders({ marketId: '654412', orderBy: [{ field: 'position_size', direction: 'ASC' }] });
         const body = expectFetchCalledWith('/api/v1/prediction-market/top-holders');
-        expect(body.sort_direction).toBe('desc');
+        expect(body.order_by).toEqual([{ field: 'position_size', direction: 'ASC' }]);
       });
 
-      it('should pass sort_direction to pmTradesByMarket', async () => {
+      it('should pass order_by to pmTradesByMarket', async () => {
         setupMock(MOCK_RESPONSES.pmTradesByMarket);
-        await api.pmTradesByMarket({ marketId: '654412', sortDirection: 'asc' });
+        await api.pmTradesByMarket({ marketId: '654412', orderBy: [{ field: 'timestamp', direction: 'ASC' }] });
         const body = expectFetchCalledWith('/api/v1/prediction-market/trades-by-market');
-        expect(body.sort_direction).toBe('asc');
+        expect(body.order_by).toEqual([{ field: 'timestamp', direction: 'ASC' }]);
       });
 
-      it('should pass sort_direction to pmTradesByAddress', async () => {
+      it('should pass order_by to pmTradesByAddress', async () => {
         setupMock(MOCK_RESPONSES.pmTradesByAddress);
-        await api.pmTradesByAddress({ address: '0x1234567890abcdef1234567890abcdef12345678', sortDirection: 'desc' });
+        await api.pmTradesByAddress({ address: '0x1234567890abcdef1234567890abcdef12345678', orderBy: [{ field: 'timestamp', direction: 'DESC' }] });
         const body = expectFetchCalledWith('/api/v1/prediction-market/trades-by-address');
-        expect(body.sort_direction).toBe('desc');
+        expect(body.order_by).toEqual([{ field: 'timestamp', direction: 'DESC' }]);
       });
 
-      it('should pass sort_direction to pmPnlByMarket', async () => {
+      it('should pass order_by to pmPnlByMarket', async () => {
         setupMock(MOCK_RESPONSES.pmPnlByMarket);
-        await api.pmPnlByMarket({ marketId: '654412', sortDirection: 'asc' });
+        await api.pmPnlByMarket({ marketId: '654412', orderBy: [{ field: 'total_pnl_usd', direction: 'ASC' }] });
         const body = expectFetchCalledWith('/api/v1/prediction-market/pnl-by-market');
-        expect(body.sort_direction).toBe('asc');
+        expect(body.order_by).toEqual([{ field: 'total_pnl_usd', direction: 'ASC' }]);
       });
 
-      it('should pass sort_direction to pmPnlByAddress', async () => {
+      it('should pass order_by to pmPnlByAddress', async () => {
         setupMock(MOCK_RESPONSES.pmPnlByAddress);
-        await api.pmPnlByAddress({ address: '0x1234567890abcdef1234567890abcdef12345678', sortDirection: 'desc' });
+        await api.pmPnlByAddress({ address: '0x1234567890abcdef1234567890abcdef12345678', orderBy: [{ field: 'total_pnl_usd', direction: 'DESC' }] });
         const body = expectFetchCalledWith('/api/v1/prediction-market/pnl-by-address');
-        expect(body.sort_direction).toBe('desc');
+        expect(body.order_by).toEqual([{ field: 'total_pnl_usd', direction: 'DESC' }]);
       });
     });
 
     describe('pmMarketScreener (filters)', () => {
-      it('should pass sort_direction', async () => {
+      it('should pass order_by to screener', async () => {
         setupMock(MOCK_RESPONSES.pmMarketScreener);
-        await api.pmMarketScreener({ sortDirection: 'asc' });
+        await api.pmMarketScreener({ orderBy: [{ field: 'liquidity', direction: 'ASC' }] });
         const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
-        expect(body.sort_direction).toBe('asc');
+        expect(body.order_by).toEqual([{ field: 'liquidity', direction: 'ASC' }]);
+        expect(body).not.toHaveProperty('sort_by');
+      });
+
+      it('should fall back to sort_by when no order_by', async () => {
+        setupMock(MOCK_RESPONSES.pmMarketScreener);
+        await api.pmMarketScreener({ sortBy: 'open_interest' });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
+        expect(body.sort_by).toBe('open_interest');
+        expect(body).not.toHaveProperty('order_by');
       });
 
       it('should pass volume filters', async () => {
@@ -2082,11 +2096,12 @@ describe('NansenAPI', () => {
     });
 
     describe('pmEventScreener (filters)', () => {
-      it('should pass sort_direction', async () => {
+      it('should pass order_by to event screener', async () => {
         setupMock(MOCK_RESPONSES.pmEventScreener);
-        await api.pmEventScreener({ sortDirection: 'asc' });
+        await api.pmEventScreener({ orderBy: [{ field: 'volume_24hr', direction: 'ASC' }] });
         const body = expectFetchCalledWith('/api/v1/prediction-market/event-screener');
-        expect(body.sort_direction).toBe('asc');
+        expect(body.order_by).toEqual([{ field: 'volume_24hr', direction: 'ASC' }]);
+        expect(body).not.toHaveProperty('sort_by');
       });
 
       it('should pass volume and liquidity filters', async () => {

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -268,6 +268,19 @@ const MOCK_RESPONSES = {
     ],
     pagination: { page: 1, per_page: 100 }
   },
+  pmAddressSummary: {
+    address: '0x1234567890abcdef1234567890abcdef12345678',
+    first_seen: '2024-01-15T00:00:00Z',
+    wallet_age_days: 450,
+    realized_pnl_usd: 12500,
+    unrealized_pnl_usd: 3200,
+    total_pnl_usd: 15700,
+    markets_won: 8,
+    markets_traded: 15,
+    win_rate: 0.533,
+    p2p_tokens_sent: 5000,
+    p2p_tokens_received: 3000
+  },
   // Smart Alert endpoints
   alertsList: [
     { id: 'alert-1', name: 'ETH SM Flows', type: 'sm-token-flows', isEnabled: true }
@@ -1913,6 +1926,195 @@ describe('NansenAPI', () => {
         await api.pmCategories({ pagination: { page: 1, per_page: 10 } });
         const body = expectFetchCalledWith('/api/v1/prediction-market/categories');
         expect(body.pagination).toEqual({ page: 1, per_page: 10 });
+      });
+    });
+
+    describe('pmAddressSummary', () => {
+      it('should fetch address summary with correct endpoint', async () => {
+        setupMock(MOCK_RESPONSES.pmAddressSummary);
+        const result = await api.pmAddressSummary({ address: '0x1234567890abcdef1234567890abcdef12345678' });
+        expectFetchCalledWith('/api/v1/prediction-market/address-summary', { address: '0x1234567890abcdef1234567890abcdef12345678' });
+        expect(result).toHaveProperty('total_pnl_usd', 15700);
+        expect(result).toHaveProperty('win_rate', 0.533);
+        expect(result).toHaveProperty('markets_traded', 15);
+      });
+
+      it('should validate address format', async () => {
+        try {
+          await api.pmAddressSummary({ address: 'invalid' });
+        } catch (e) {
+          expect(e.code).toBe(ErrorCode.INVALID_ADDRESS);
+        }
+      });
+
+      it('should require address', async () => {
+        try {
+          await api.pmAddressSummary({});
+        } catch (e) {
+          expect(e.code).toBe(ErrorCode.MISSING_PARAM);
+        }
+      });
+    });
+
+    describe('sort_direction parameter', () => {
+      it('should pass sort_direction to pmOhlcv', async () => {
+        setupMock(MOCK_RESPONSES.pmOhlcv);
+        await api.pmOhlcv({ marketId: '654412', sortDirection: 'asc' });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/ohlcv');
+        expect(body.sort_direction).toBe('asc');
+      });
+
+      it('should pass sort_direction to pmTopHolders', async () => {
+        setupMock(MOCK_RESPONSES.pmTopHolders);
+        await api.pmTopHolders({ marketId: '654412', sortDirection: 'desc' });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/top-holders');
+        expect(body.sort_direction).toBe('desc');
+      });
+
+      it('should pass sort_direction to pmTradesByMarket', async () => {
+        setupMock(MOCK_RESPONSES.pmTradesByMarket);
+        await api.pmTradesByMarket({ marketId: '654412', sortDirection: 'asc' });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/trades-by-market');
+        expect(body.sort_direction).toBe('asc');
+      });
+
+      it('should pass sort_direction to pmTradesByAddress', async () => {
+        setupMock(MOCK_RESPONSES.pmTradesByAddress);
+        await api.pmTradesByAddress({ address: '0x1234567890abcdef1234567890abcdef12345678', sortDirection: 'desc' });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/trades-by-address');
+        expect(body.sort_direction).toBe('desc');
+      });
+
+      it('should pass sort_direction to pmPnlByMarket', async () => {
+        setupMock(MOCK_RESPONSES.pmPnlByMarket);
+        await api.pmPnlByMarket({ marketId: '654412', sortDirection: 'asc' });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/pnl-by-market');
+        expect(body.sort_direction).toBe('asc');
+      });
+
+      it('should pass sort_direction to pmPnlByAddress', async () => {
+        setupMock(MOCK_RESPONSES.pmPnlByAddress);
+        await api.pmPnlByAddress({ address: '0x1234567890abcdef1234567890abcdef12345678', sortDirection: 'desc' });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/pnl-by-address');
+        expect(body.sort_direction).toBe('desc');
+      });
+    });
+
+    describe('pmMarketScreener (filters)', () => {
+      it('should pass sort_direction', async () => {
+        setupMock(MOCK_RESPONSES.pmMarketScreener);
+        await api.pmMarketScreener({ sortDirection: 'asc' });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
+        expect(body.sort_direction).toBe('asc');
+      });
+
+      it('should pass volume filters', async () => {
+        setupMock(MOCK_RESPONSES.pmMarketScreener);
+        await api.pmMarketScreener({ minVolume24hr: 1000, maxVolume24hr: 50000 });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
+        expect(body.min_volume_24hr).toBe(1000);
+        expect(body.max_volume_24hr).toBe(50000);
+      });
+
+      it('should pass liquidity filters', async () => {
+        setupMock(MOCK_RESPONSES.pmMarketScreener);
+        await api.pmMarketScreener({ minLiquidity: 5000, maxLiquidity: 100000 });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
+        expect(body.min_liquidity).toBe(5000);
+        expect(body.max_liquidity).toBe(100000);
+      });
+
+      it('should pass open interest filters', async () => {
+        setupMock(MOCK_RESPONSES.pmMarketScreener);
+        await api.pmMarketScreener({ minOpenInterest: 10000, maxOpenInterest: 500000 });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
+        expect(body.min_open_interest).toBe(10000);
+        expect(body.max_open_interest).toBe(500000);
+      });
+
+      it('should pass unique traders filters', async () => {
+        setupMock(MOCK_RESPONSES.pmMarketScreener);
+        await api.pmMarketScreener({ minUniqueTraders24h: 10, maxUniqueTraders24h: 500 });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
+        expect(body.min_unique_traders_24h).toBe(10);
+        expect(body.max_unique_traders_24h).toBe(500);
+      });
+
+      it('should pass neg_risk boolean', async () => {
+        setupMock(MOCK_RESPONSES.pmMarketScreener);
+        await api.pmMarketScreener({ negRisk: true });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
+        expect(body.neg_risk).toBe(true);
+      });
+
+      it('should pass tags as array', async () => {
+        setupMock(MOCK_RESPONSES.pmMarketScreener);
+        await api.pmMarketScreener({ tags: ['crypto', 'sports'] });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
+        expect(body.tags).toEqual(['crypto', 'sports']);
+      });
+
+      it('should pass price filters', async () => {
+        setupMock(MOCK_RESPONSES.pmMarketScreener);
+        await api.pmMarketScreener({ minPrice: 0.1, maxPrice: 0.9 });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
+        expect(body.min_price).toBe(0.1);
+        expect(body.max_price).toBe(0.9);
+      });
+
+      it('should pass date filters', async () => {
+        setupMock(MOCK_RESPONSES.pmMarketScreener);
+        await api.pmMarketScreener({ endDateBefore: '2025-12-31', endDateAfter: '2025-01-01' });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
+        expect(body.end_date_before).toBe('2025-12-31');
+        expect(body.end_date_after).toBe('2025-01-01');
+      });
+
+      it('should not include filters when not provided', async () => {
+        setupMock(MOCK_RESPONSES.pmMarketScreener);
+        await api.pmMarketScreener({});
+        const body = expectFetchCalledWith('/api/v1/prediction-market/market-screener');
+        expect(body).not.toHaveProperty('min_volume_24hr');
+        expect(body).not.toHaveProperty('max_volume_24hr');
+        expect(body).not.toHaveProperty('tags');
+        expect(body).not.toHaveProperty('neg_risk');
+      });
+    });
+
+    describe('pmEventScreener (filters)', () => {
+      it('should pass sort_direction', async () => {
+        setupMock(MOCK_RESPONSES.pmEventScreener);
+        await api.pmEventScreener({ sortDirection: 'asc' });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/event-screener');
+        expect(body.sort_direction).toBe('asc');
+      });
+
+      it('should pass volume and liquidity filters', async () => {
+        setupMock(MOCK_RESPONSES.pmEventScreener);
+        await api.pmEventScreener({ minVolume24hr: 1000, maxVolume24hr: 50000, minLiquidity: 5000, maxLiquidity: 100000 });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/event-screener');
+        expect(body.min_volume_24hr).toBe(1000);
+        expect(body.max_volume_24hr).toBe(50000);
+        expect(body.min_liquidity).toBe(5000);
+        expect(body.max_liquidity).toBe(100000);
+      });
+
+      it('should pass unique traders and open interest filters', async () => {
+        setupMock(MOCK_RESPONSES.pmEventScreener);
+        await api.pmEventScreener({ minUniqueTraders24h: 10, maxUniqueTraders24h: 500, minOpenInterest: 1000, maxOpenInterest: 100000 });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/event-screener');
+        expect(body.min_unique_traders_24h).toBe(10);
+        expect(body.max_unique_traders_24h).toBe(500);
+        expect(body.min_open_interest).toBe(1000);
+        expect(body.max_open_interest).toBe(100000);
+      });
+
+      it('should pass neg_risk and tags', async () => {
+        setupMock(MOCK_RESPONSES.pmEventScreener);
+        await api.pmEventScreener({ negRisk: false, tags: ['politics'] });
+        const body = expectFetchCalledWith('/api/v1/prediction-market/event-screener');
+        expect(body.neg_risk).toBe(false);
+        expect(body.tags).toEqual(['politics']);
       });
     });
   });

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -123,6 +123,7 @@ describe('CLI Smoke Tests', () => {
     expect(stdout).toContain('ohlcv');
     expect(stdout).toContain('market-screener');
     expect(stdout).toContain('categories');
+    expect(stdout).toContain('address-summary');
   });
 
   it('should route top-level pm alias to prediction-market', () => {
@@ -130,6 +131,7 @@ describe('CLI Smoke Tests', () => {
     expect(stdout).toContain('ohlcv');
     expect(stdout).toContain('market-screener');
     expect(stdout).toContain('categories');
+    expect(stdout).toContain('address-summary');
   });
 
   it('should error on pm ohlcv without --market-id', () => {
@@ -150,6 +152,22 @@ describe('CLI Smoke Tests', () => {
 
   it('should error on pm trades-by-address with invalid address', () => {
     const { stdout, stderr, exitCode } = runCLI('research pm trades-by-address --address notanaddress');
+    expect(exitCode).not.toBe(0);
+    const output = stdout || stderr;
+    const json = JSON.parse(output.split('\n').find(l => l.startsWith('{')));
+    expect(json.code).toBe('INVALID_ADDRESS');
+  });
+
+  it('should error on pm address-summary without --address', () => {
+    const { stdout, stderr, exitCode } = runCLI('research pm address-summary');
+    expect(exitCode).not.toBe(0);
+    const output = stdout || stderr;
+    const json = JSON.parse(output.split('\n').find(l => l.startsWith('{')));
+    expect(json.code).toBe('MISSING_PARAM');
+  });
+
+  it('should error on pm address-summary with invalid address', () => {
+    const { stdout, stderr, exitCode } = runCLI('research pm address-summary --address notanaddress');
     expect(exitCode).not.toBe(0);
     const output = stdout || stderr;
     const json = JSON.parse(output.split('\n').find(l => l.startsWith('{')));

--- a/src/api.js
+++ b/src/api.js
@@ -1230,12 +1230,11 @@ export class NansenAPI {
   // ============= Prediction Market Endpoints =============
 
   async pmOhlcv(params = {}) {
-    const { marketId, sort, sortDirection, pagination } = params;
+    const { marketId, orderBy, sort, pagination } = params;
     if (!marketId) throw new NansenError('market_id is required. Run: nansen research pm market-screener --query "your search"', ErrorCode.MISSING_PARAM);
     return this.request('/api/v1/prediction-market/ohlcv', {
       market_id: marketId,
-      sort,
-      sort_direction: sortDirection,
+      order_by: orderBy || sort,
       pagination
     });
   }
@@ -1250,47 +1249,49 @@ export class NansenAPI {
   }
 
   async pmTopHolders(params = {}) {
-    const { marketId, sort, sortDirection, pagination } = params;
+    const { marketId, orderBy, sort, pagination } = params;
     if (!marketId) throw new NansenError('market_id is required. Run: nansen research pm market-screener --query "your search"', ErrorCode.MISSING_PARAM);
     return this.request('/api/v1/prediction-market/top-holders', {
       market_id: marketId,
-      sort,
-      sort_direction: sortDirection,
+      order_by: orderBy || sort,
       pagination
     });
   }
 
   async pmTradesByMarket(params = {}) {
-    const { marketId, sortDirection, pagination } = params;
+    const { marketId, orderBy, pagination } = params;
     if (!marketId) throw new NansenError('market_id is required. Run: nansen research pm market-screener --query "your search"', ErrorCode.MISSING_PARAM);
     return this.request('/api/v1/prediction-market/trades-by-market', {
       market_id: marketId,
-      sort_direction: sortDirection,
+      order_by: orderBy,
       pagination
     });
   }
 
   async pmTradesByAddress(params = {}) {
-    const { address, sortDirection, pagination } = params;
+    const { address, orderBy, pagination } = params;
     // Polymarket runs exclusively on Polygon
     const validation = validateAddress(address, 'polygon');
     if (!validation.valid) throw new NansenError(validation.error, validation.code);
     return this.request('/api/v1/prediction-market/trades-by-address', {
       address,
-      sort_direction: sortDirection,
+      order_by: orderBy,
       pagination
     });
   }
 
   async pmMarketScreener(params = {}) {
-    const { sortBy = 'volume_24hr', sortDirection, query = '', status = '', tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination } = params;
+    const { orderBy, sortBy, query = '', status = '', tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination } = params;
     const body = {
-      sort_by: sortBy,
-      sort_direction: sortDirection,
       query,
       status,
       pagination
     };
+    if (orderBy) {
+      body.order_by = orderBy;
+    } else if (sortBy) {
+      body.sort_by = sortBy;
+    }
     if (tags && tags.length) body.tags = tags;
     if (minLiquidity != null) body.min_liquidity = minLiquidity;
     if (maxLiquidity != null) body.max_liquidity = maxLiquidity;
@@ -1309,14 +1310,17 @@ export class NansenAPI {
   }
 
   async pmEventScreener(params = {}) {
-    const { sortBy = 'volume_24hr', sortDirection, query = '', status = '', tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination } = params;
+    const { orderBy, sortBy, query = '', status = '', tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination } = params;
     const body = {
-      sort_by: sortBy,
-      sort_direction: sortDirection,
       query,
       status,
       pagination
     };
+    if (orderBy) {
+      body.order_by = orderBy;
+    } else if (sortBy) {
+      body.sort_by = sortBy;
+    }
     if (tags && tags.length) body.tags = tags;
     if (minLiquidity != null) body.min_liquidity = minLiquidity;
     if (maxLiquidity != null) body.max_liquidity = maxLiquidity;
@@ -1333,23 +1337,23 @@ export class NansenAPI {
   }
 
   async pmPnlByMarket(params = {}) {
-    const { marketId, sortDirection, pagination } = params;
+    const { marketId, orderBy, pagination } = params;
     if (!marketId) throw new NansenError('market_id is required. Run: nansen research pm market-screener --query "your search"', ErrorCode.MISSING_PARAM);
     return this.request('/api/v1/prediction-market/pnl-by-market', {
       market_id: marketId,
-      sort_direction: sortDirection,
+      order_by: orderBy,
       pagination
     });
   }
 
   async pmPnlByAddress(params = {}) {
-    const { address, sortDirection, pagination } = params;
+    const { address, orderBy, pagination } = params;
     // Polymarket runs exclusively on Polygon
     const validation = validateAddress(address, 'polygon');
     if (!validation.valid) throw new NansenError(validation.error, validation.code);
     return this.request('/api/v1/prediction-market/pnl-by-address', {
       address,
-      sort_direction: sortDirection,
+      order_by: orderBy,
       pagination
     });
   }

--- a/src/api.js
+++ b/src/api.js
@@ -1230,11 +1230,12 @@ export class NansenAPI {
   // ============= Prediction Market Endpoints =============
 
   async pmOhlcv(params = {}) {
-    const { marketId, sort, pagination } = params;
+    const { marketId, sort, sortDirection, pagination } = params;
     if (!marketId) throw new NansenError('market_id is required. Run: nansen research pm market-screener --query "your search"', ErrorCode.MISSING_PARAM);
     return this.request('/api/v1/prediction-market/ohlcv', {
       market_id: marketId,
       sort,
+      sort_direction: sortDirection,
       pagination
     });
   }
@@ -1249,71 +1250,102 @@ export class NansenAPI {
   }
 
   async pmTopHolders(params = {}) {
-    const { marketId, sort, pagination } = params;
+    const { marketId, sort, sortDirection, pagination } = params;
     if (!marketId) throw new NansenError('market_id is required. Run: nansen research pm market-screener --query "your search"', ErrorCode.MISSING_PARAM);
     return this.request('/api/v1/prediction-market/top-holders', {
       market_id: marketId,
       sort,
+      sort_direction: sortDirection,
       pagination
     });
   }
 
   async pmTradesByMarket(params = {}) {
-    const { marketId, pagination } = params;
+    const { marketId, sortDirection, pagination } = params;
     if (!marketId) throw new NansenError('market_id is required. Run: nansen research pm market-screener --query "your search"', ErrorCode.MISSING_PARAM);
     return this.request('/api/v1/prediction-market/trades-by-market', {
       market_id: marketId,
+      sort_direction: sortDirection,
       pagination
     });
   }
 
   async pmTradesByAddress(params = {}) {
-    const { address, pagination } = params;
+    const { address, sortDirection, pagination } = params;
     // Polymarket runs exclusively on Polygon
     const validation = validateAddress(address, 'polygon');
     if (!validation.valid) throw new NansenError(validation.error, validation.code);
     return this.request('/api/v1/prediction-market/trades-by-address', {
       address,
+      sort_direction: sortDirection,
       pagination
     });
   }
 
   async pmMarketScreener(params = {}) {
-    const { sortBy = 'volume_24hr', query = '', status = '', pagination } = params;
-    return this.request('/api/v1/prediction-market/market-screener', {
+    const { sortBy = 'volume_24hr', sortDirection, query = '', status = '', tags, minLiquidity, maxLiquidity, maxUniqueTraders24h, minVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination } = params;
+    const body = {
       sort_by: sortBy,
+      sort_direction: sortDirection,
       query,
       status,
       pagination
-    });
+    };
+    if (tags && tags.length) body.tags = tags;
+    if (minLiquidity != null) body.min_liquidity = minLiquidity;
+    if (maxLiquidity != null) body.max_liquidity = maxLiquidity;
+    if (maxUniqueTraders24h != null) body.max_unique_traders_24h = maxUniqueTraders24h;
+    if (minVolume24hr != null) body.min_volume_24hr = minVolume24hr;
+    if (negRisk != null) body.neg_risk = negRisk;
+    if (minOpenInterest != null) body.min_open_interest = minOpenInterest;
+    if (maxOpenInterest != null) body.max_open_interest = maxOpenInterest;
+    if (endDateBefore) body.end_date_before = endDateBefore;
+    if (endDateAfter) body.end_date_after = endDateAfter;
+    if (minPrice != null) body.min_price = minPrice;
+    if (maxPrice != null) body.max_price = maxPrice;
+    return this.request('/api/v1/prediction-market/market-screener', body);
   }
 
   async pmEventScreener(params = {}) {
-    const { sortBy = 'volume_24hr', query = '', status = '', pagination } = params;
-    return this.request('/api/v1/prediction-market/event-screener', {
+    const { sortBy = 'volume_24hr', sortDirection, query = '', status = '', tags, minLiquidity, maxLiquidity, maxUniqueTraders24h, minVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination } = params;
+    const body = {
       sort_by: sortBy,
+      sort_direction: sortDirection,
       query,
       status,
       pagination
-    });
+    };
+    if (tags && tags.length) body.tags = tags;
+    if (minLiquidity != null) body.min_liquidity = minLiquidity;
+    if (maxLiquidity != null) body.max_liquidity = maxLiquidity;
+    if (maxUniqueTraders24h != null) body.max_unique_traders_24h = maxUniqueTraders24h;
+    if (minVolume24hr != null) body.min_volume_24hr = minVolume24hr;
+    if (negRisk != null) body.neg_risk = negRisk;
+    if (minOpenInterest != null) body.min_open_interest = minOpenInterest;
+    if (maxOpenInterest != null) body.max_open_interest = maxOpenInterest;
+    if (endDateBefore) body.end_date_before = endDateBefore;
+    if (endDateAfter) body.end_date_after = endDateAfter;
+    return this.request('/api/v1/prediction-market/event-screener', body);
   }
 
   async pmPnlByMarket(params = {}) {
-    const { marketId, pagination } = params;
+    const { marketId, sortDirection, pagination } = params;
     if (!marketId) throw new NansenError('market_id is required. Run: nansen research pm market-screener --query "your search"', ErrorCode.MISSING_PARAM);
     return this.request('/api/v1/prediction-market/pnl-by-market', {
       market_id: marketId,
+      sort_direction: sortDirection,
       pagination
     });
   }
 
   async pmPnlByAddress(params = {}) {
-    const { address, pagination } = params;
+    const { address, sortDirection, pagination } = params;
     // Polymarket runs exclusively on Polygon
     const validation = validateAddress(address, 'polygon');
     if (!validation.valid) throw new NansenError(validation.error, validation.code);
     return this.request('/api/v1/prediction-market/pnl-by-address', {
       address,
+      sort_direction: sortDirection,
       pagination
     });
   }
@@ -1330,6 +1362,17 @@ export class NansenAPI {
   async pmCategories(params = {}) {
     const { pagination } = params;
     return this.request('/api/v1/prediction-market/categories', {
+      pagination
+    });
+  }
+
+  async pmAddressSummary(params = {}) {
+    const { address, pagination } = params;
+    // Polymarket runs exclusively on Polygon
+    const validation = validateAddress(address, 'polygon');
+    if (!validation.valid) throw new NansenError(validation.error, validation.code);
+    return this.request('/api/v1/prediction-market/address-summary', {
+      address,
       pagination
     });
   }

--- a/src/api.js
+++ b/src/api.js
@@ -1232,11 +1232,9 @@ export class NansenAPI {
   async pmOhlcv(params = {}) {
     const { marketId, orderBy, sort, pagination } = params;
     if (!marketId) throw new NansenError('market_id is required. Run: nansen research pm market-screener --query "your search"', ErrorCode.MISSING_PARAM);
-    const effectiveSort = orderBy || sort;
     return this.request('/api/v1/prediction-market/ohlcv', {
       market_id: marketId,
-      order_by: effectiveSort,
-      sort: effectiveSort,
+      order_by: orderBy || sort,
       pagination
     });
   }
@@ -1253,11 +1251,9 @@ export class NansenAPI {
   async pmTopHolders(params = {}) {
     const { marketId, orderBy, sort, pagination } = params;
     if (!marketId) throw new NansenError('market_id is required. Run: nansen research pm market-screener --query "your search"', ErrorCode.MISSING_PARAM);
-    const effectiveSort = orderBy || sort;
     return this.request('/api/v1/prediction-market/top-holders', {
       market_id: marketId,
-      order_by: effectiveSort,
-      sort: effectiveSort,
+      order_by: orderBy || sort,
       pagination
     });
   }
@@ -1268,7 +1264,6 @@ export class NansenAPI {
     return this.request('/api/v1/prediction-market/trades-by-market', {
       market_id: marketId,
       order_by: orderBy,
-      sort: orderBy,
       pagination
     });
   }
@@ -1281,7 +1276,6 @@ export class NansenAPI {
     return this.request('/api/v1/prediction-market/trades-by-address', {
       address,
       order_by: orderBy,
-      sort: orderBy,
       pagination
     });
   }
@@ -1342,7 +1336,6 @@ export class NansenAPI {
     return this.request('/api/v1/prediction-market/pnl-by-market', {
       market_id: marketId,
       order_by: orderBy,
-      sort: orderBy,
       pagination
     });
   }
@@ -1355,7 +1348,6 @@ export class NansenAPI {
     return this.request('/api/v1/prediction-market/pnl-by-address', {
       address,
       order_by: orderBy,
-      sort: orderBy,
       pagination
     });
   }

--- a/src/api.js
+++ b/src/api.js
@@ -1283,7 +1283,7 @@ export class NansenAPI {
   }
 
   async pmMarketScreener(params = {}) {
-    const { sortBy = 'volume_24hr', sortDirection, query = '', status = '', tags, minLiquidity, maxLiquidity, maxUniqueTraders24h, minVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination } = params;
+    const { sortBy = 'volume_24hr', sortDirection, query = '', status = '', tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination } = params;
     const body = {
       sort_by: sortBy,
       sort_direction: sortDirection,
@@ -1294,8 +1294,10 @@ export class NansenAPI {
     if (tags && tags.length) body.tags = tags;
     if (minLiquidity != null) body.min_liquidity = minLiquidity;
     if (maxLiquidity != null) body.max_liquidity = maxLiquidity;
+    if (minUniqueTraders24h != null) body.min_unique_traders_24h = minUniqueTraders24h;
     if (maxUniqueTraders24h != null) body.max_unique_traders_24h = maxUniqueTraders24h;
     if (minVolume24hr != null) body.min_volume_24hr = minVolume24hr;
+    if (maxVolume24hr != null) body.max_volume_24hr = maxVolume24hr;
     if (negRisk != null) body.neg_risk = negRisk;
     if (minOpenInterest != null) body.min_open_interest = minOpenInterest;
     if (maxOpenInterest != null) body.max_open_interest = maxOpenInterest;
@@ -1307,7 +1309,7 @@ export class NansenAPI {
   }
 
   async pmEventScreener(params = {}) {
-    const { sortBy = 'volume_24hr', sortDirection, query = '', status = '', tags, minLiquidity, maxLiquidity, maxUniqueTraders24h, minVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination } = params;
+    const { sortBy = 'volume_24hr', sortDirection, query = '', status = '', tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination } = params;
     const body = {
       sort_by: sortBy,
       sort_direction: sortDirection,
@@ -1318,8 +1320,10 @@ export class NansenAPI {
     if (tags && tags.length) body.tags = tags;
     if (minLiquidity != null) body.min_liquidity = minLiquidity;
     if (maxLiquidity != null) body.max_liquidity = maxLiquidity;
+    if (minUniqueTraders24h != null) body.min_unique_traders_24h = minUniqueTraders24h;
     if (maxUniqueTraders24h != null) body.max_unique_traders_24h = maxUniqueTraders24h;
     if (minVolume24hr != null) body.min_volume_24hr = minVolume24hr;
+    if (maxVolume24hr != null) body.max_volume_24hr = maxVolume24hr;
     if (negRisk != null) body.neg_risk = negRisk;
     if (minOpenInterest != null) body.min_open_interest = minOpenInterest;
     if (maxOpenInterest != null) body.max_open_interest = maxOpenInterest;

--- a/src/api.js
+++ b/src/api.js
@@ -1232,9 +1232,11 @@ export class NansenAPI {
   async pmOhlcv(params = {}) {
     const { marketId, orderBy, sort, pagination } = params;
     if (!marketId) throw new NansenError('market_id is required. Run: nansen research pm market-screener --query "your search"', ErrorCode.MISSING_PARAM);
+    const effectiveSort = orderBy || sort;
     return this.request('/api/v1/prediction-market/ohlcv', {
       market_id: marketId,
-      order_by: orderBy || sort,
+      order_by: effectiveSort,
+      sort: effectiveSort,
       pagination
     });
   }
@@ -1251,9 +1253,11 @@ export class NansenAPI {
   async pmTopHolders(params = {}) {
     const { marketId, orderBy, sort, pagination } = params;
     if (!marketId) throw new NansenError('market_id is required. Run: nansen research pm market-screener --query "your search"', ErrorCode.MISSING_PARAM);
+    const effectiveSort = orderBy || sort;
     return this.request('/api/v1/prediction-market/top-holders', {
       market_id: marketId,
-      order_by: orderBy || sort,
+      order_by: effectiveSort,
+      sort: effectiveSort,
       pagination
     });
   }
@@ -1264,6 +1268,7 @@ export class NansenAPI {
     return this.request('/api/v1/prediction-market/trades-by-market', {
       market_id: marketId,
       order_by: orderBy,
+      sort: orderBy,
       pagination
     });
   }
@@ -1276,22 +1281,20 @@ export class NansenAPI {
     return this.request('/api/v1/prediction-market/trades-by-address', {
       address,
       order_by: orderBy,
+      sort: orderBy,
       pagination
     });
   }
 
   async pmMarketScreener(params = {}) {
-    const { orderBy, sortBy, query = '', status = '', tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination } = params;
+    const { orderBy, sortBy = 'volume_24hr', query = '', status = '', tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination } = params;
     const body = {
+      sort_by: sortBy,
       query,
       status,
       pagination
     };
-    if (orderBy) {
-      body.order_by = orderBy;
-    } else if (sortBy) {
-      body.sort_by = sortBy;
-    }
+    if (orderBy) body.order_by = orderBy;
     if (tags && tags.length) body.tags = tags;
     if (minLiquidity != null) body.min_liquidity = minLiquidity;
     if (maxLiquidity != null) body.max_liquidity = maxLiquidity;
@@ -1310,17 +1313,14 @@ export class NansenAPI {
   }
 
   async pmEventScreener(params = {}) {
-    const { orderBy, sortBy, query = '', status = '', tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination } = params;
+    const { orderBy, sortBy = 'volume_24hr', query = '', status = '', tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination } = params;
     const body = {
+      sort_by: sortBy,
       query,
       status,
       pagination
     };
-    if (orderBy) {
-      body.order_by = orderBy;
-    } else if (sortBy) {
-      body.sort_by = sortBy;
-    }
+    if (orderBy) body.order_by = orderBy;
     if (tags && tags.length) body.tags = tags;
     if (minLiquidity != null) body.min_liquidity = minLiquidity;
     if (maxLiquidity != null) body.max_liquidity = maxLiquidity;
@@ -1342,6 +1342,7 @@ export class NansenAPI {
     return this.request('/api/v1/prediction-market/pnl-by-market', {
       market_id: marketId,
       order_by: orderBy,
+      sort: orderBy,
       pagination
     });
   }
@@ -1354,6 +1355,7 @@ export class NansenAPI {
     return this.request('/api/v1/prediction-market/pnl-by-address', {
       address,
       order_by: orderBy,
+      sort: orderBy,
       pagination
     });
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1415,8 +1415,10 @@ export function buildCommands(deps = {}) {
       const tags = options.tags ? options.tags.split(',').map(t => t.trim()) : undefined;
       const minLiquidity = options['min-liquidity'] != null ? Number(options['min-liquidity']) : undefined;
       const maxLiquidity = options['max-liquidity'] != null ? Number(options['max-liquidity']) : undefined;
+      const minUniqueTraders24h = options['min-unique-traders-24h'] != null ? Number(options['min-unique-traders-24h']) : undefined;
       const maxUniqueTraders24h = options['max-unique-traders-24h'] != null ? Number(options['max-unique-traders-24h']) : undefined;
       const minVolume24hr = options['min-volume-24hr'] != null ? Number(options['min-volume-24hr']) : undefined;
+      const maxVolume24hr = options['max-volume-24hr'] != null ? Number(options['max-volume-24hr']) : undefined;
       const negRisk = options['neg-risk'] != null ? options['neg-risk'] === 'true' : undefined;
       const minOpenInterest = options['min-open-interest'] != null ? Number(options['min-open-interest']) : undefined;
       const maxOpenInterest = options['max-open-interest'] != null ? Number(options['max-open-interest']) : undefined;
@@ -1431,8 +1433,8 @@ export function buildCommands(deps = {}) {
         'top-holders': () => apiInstance.pmTopHolders({ marketId, sort, sortDirection, pagination }),
         'trades-by-market': () => apiInstance.pmTradesByMarket({ marketId, sortDirection, pagination }),
         'trades-by-address': () => apiInstance.pmTradesByAddress({ address, sortDirection, pagination }),
-        'market-screener': () => apiInstance.pmMarketScreener({ sortBy, sortDirection, query, status, tags, minLiquidity, maxLiquidity, maxUniqueTraders24h, minVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination }),
-        'event-screener': () => apiInstance.pmEventScreener({ sortBy, sortDirection, query, status, tags, minLiquidity, maxLiquidity, maxUniqueTraders24h, minVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination }),
+        'market-screener': () => apiInstance.pmMarketScreener({ sortBy, sortDirection, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination }),
+        'event-screener': () => apiInstance.pmEventScreener({ sortBy, sortDirection, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination }),
         'pnl-by-market': () => apiInstance.pmPnlByMarket({ marketId, sortDirection, pagination }),
         'pnl-by-address': () => apiInstance.pmPnlByAddress({ address, sortDirection, pagination }),
         'position-detail': () => apiInstance.pmPositionDetail({ marketId, pagination }),

--- a/src/cli.js
+++ b/src/cli.js
@@ -1407,7 +1407,7 @@ export function buildCommands(deps = {}) {
       const sortBy = options['sort-by'];
       const query = options.query;
       const status = options.status;
-      const sort = parseSort(options.sort);
+      const orderBy = parseSort(options.sort, options['order-by']);
       const pagination = buildPagination(options);
 
       // Screener-specific filter options
@@ -1427,15 +1427,15 @@ export function buildCommands(deps = {}) {
       const maxPrice = options['max-price'] != null ? Number(options['max-price']) : undefined;
 
       const handlers = {
-        'ohlcv': () => apiInstance.pmOhlcv({ marketId, orderBy: sort, pagination }),
+        'ohlcv': () => apiInstance.pmOhlcv({ marketId, orderBy, pagination }),
         'orderbook': () => apiInstance.pmOrderbook({ marketId, pagination }),
-        'top-holders': () => apiInstance.pmTopHolders({ marketId, orderBy: sort, pagination }),
-        'trades-by-market': () => apiInstance.pmTradesByMarket({ marketId, orderBy: sort, pagination }),
-        'trades-by-address': () => apiInstance.pmTradesByAddress({ address, orderBy: sort, pagination }),
-        'market-screener': () => apiInstance.pmMarketScreener({ orderBy: sort, sortBy, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination }),
-        'event-screener': () => apiInstance.pmEventScreener({ orderBy: sort, sortBy, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination }),
-        'pnl-by-market': () => apiInstance.pmPnlByMarket({ marketId, orderBy: sort, pagination }),
-        'pnl-by-address': () => apiInstance.pmPnlByAddress({ address, orderBy: sort, pagination }),
+        'top-holders': () => apiInstance.pmTopHolders({ marketId, orderBy, pagination }),
+        'trades-by-market': () => apiInstance.pmTradesByMarket({ marketId, orderBy, pagination }),
+        'trades-by-address': () => apiInstance.pmTradesByAddress({ address, orderBy, pagination }),
+        'market-screener': () => apiInstance.pmMarketScreener({ orderBy, sortBy, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination }),
+        'event-screener': () => apiInstance.pmEventScreener({ orderBy, sortBy, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination }),
+        'pnl-by-market': () => apiInstance.pmPnlByMarket({ marketId, orderBy, pagination }),
+        'pnl-by-address': () => apiInstance.pmPnlByAddress({ address, orderBy, pagination }),
         'position-detail': () => apiInstance.pmPositionDetail({ marketId, pagination }),
         'categories': () => apiInstance.pmCategories({ pagination }),
         'address-summary': () => apiInstance.pmAddressSummary({ address, pagination }),

--- a/src/cli.js
+++ b/src/cli.js
@@ -1405,16 +1405,10 @@ export function buildCommands(deps = {}) {
       const marketId = options['market-id'];
       const address = options.address;
       const sortBy = options['sort-by'];
-      const sortDirection = options['sort-direction'];
       const query = options.query;
       const status = options.status;
       const sort = parseSort(options.sort);
       const pagination = buildPagination(options);
-
-      // Build order_by for screeners from --sort-by + --sort-direction
-      const screenerOrderBy = (sortBy || sortDirection)
-        ? [{ field: sortBy || 'volume_24hr', direction: (sortDirection || 'desc').toUpperCase() }]
-        : undefined;
 
       // Screener-specific filter options
       const tags = options.tags ? options.tags.split(',').map(t => t.trim()) : undefined;
@@ -1438,8 +1432,8 @@ export function buildCommands(deps = {}) {
         'top-holders': () => apiInstance.pmTopHolders({ marketId, orderBy: sort, pagination }),
         'trades-by-market': () => apiInstance.pmTradesByMarket({ marketId, orderBy: sort, pagination }),
         'trades-by-address': () => apiInstance.pmTradesByAddress({ address, orderBy: sort, pagination }),
-        'market-screener': () => apiInstance.pmMarketScreener({ orderBy: screenerOrderBy, sortBy, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination }),
-        'event-screener': () => apiInstance.pmEventScreener({ orderBy: screenerOrderBy, sortBy, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination }),
+        'market-screener': () => apiInstance.pmMarketScreener({ orderBy: sort, sortBy, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination }),
+        'event-screener': () => apiInstance.pmEventScreener({ orderBy: sort, sortBy, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination }),
         'pnl-by-market': () => apiInstance.pmPnlByMarket({ marketId, orderBy: sort, pagination }),
         'pnl-by-address': () => apiInstance.pmPnlByAddress({ address, orderBy: sort, pagination }),
         'position-detail': () => apiInstance.pmPositionDetail({ marketId, pagination }),

--- a/src/cli.js
+++ b/src/cli.js
@@ -1405,25 +1405,41 @@ export function buildCommands(deps = {}) {
       const marketId = options['market-id'];
       const address = options.address;
       const sortBy = options['sort-by'];
+      const sortDirection = options['sort-direction'];
       const query = options.query;
       const status = options.status;
       const sort = parseSort(options.sort);
       const pagination = buildPagination(options);
 
+      // Screener-specific filter options
+      const tags = options.tags ? options.tags.split(',').map(t => t.trim()) : undefined;
+      const minLiquidity = options['min-liquidity'] != null ? Number(options['min-liquidity']) : undefined;
+      const maxLiquidity = options['max-liquidity'] != null ? Number(options['max-liquidity']) : undefined;
+      const maxUniqueTraders24h = options['max-unique-traders-24h'] != null ? Number(options['max-unique-traders-24h']) : undefined;
+      const minVolume24hr = options['min-volume-24hr'] != null ? Number(options['min-volume-24hr']) : undefined;
+      const negRisk = options['neg-risk'] != null ? options['neg-risk'] === 'true' : undefined;
+      const minOpenInterest = options['min-open-interest'] != null ? Number(options['min-open-interest']) : undefined;
+      const maxOpenInterest = options['max-open-interest'] != null ? Number(options['max-open-interest']) : undefined;
+      const endDateBefore = options['end-date-before'];
+      const endDateAfter = options['end-date-after'];
+      const minPrice = options['min-price'] != null ? Number(options['min-price']) : undefined;
+      const maxPrice = options['max-price'] != null ? Number(options['max-price']) : undefined;
+
       const handlers = {
-        'ohlcv': () => apiInstance.pmOhlcv({ marketId, sort, pagination }),
+        'ohlcv': () => apiInstance.pmOhlcv({ marketId, sort, sortDirection, pagination }),
         'orderbook': () => apiInstance.pmOrderbook({ marketId, pagination }),
-        'top-holders': () => apiInstance.pmTopHolders({ marketId, sort, pagination }),
-        'trades-by-market': () => apiInstance.pmTradesByMarket({ marketId, pagination }),
-        'trades-by-address': () => apiInstance.pmTradesByAddress({ address, pagination }),
-        'market-screener': () => apiInstance.pmMarketScreener({ sortBy, query, status, pagination }),
-        'event-screener': () => apiInstance.pmEventScreener({ sortBy, query, status, pagination }),
-        'pnl-by-market': () => apiInstance.pmPnlByMarket({ marketId, pagination }),
-        'pnl-by-address': () => apiInstance.pmPnlByAddress({ address, pagination }),
+        'top-holders': () => apiInstance.pmTopHolders({ marketId, sort, sortDirection, pagination }),
+        'trades-by-market': () => apiInstance.pmTradesByMarket({ marketId, sortDirection, pagination }),
+        'trades-by-address': () => apiInstance.pmTradesByAddress({ address, sortDirection, pagination }),
+        'market-screener': () => apiInstance.pmMarketScreener({ sortBy, sortDirection, query, status, tags, minLiquidity, maxLiquidity, maxUniqueTraders24h, minVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination }),
+        'event-screener': () => apiInstance.pmEventScreener({ sortBy, sortDirection, query, status, tags, minLiquidity, maxLiquidity, maxUniqueTraders24h, minVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination }),
+        'pnl-by-market': () => apiInstance.pmPnlByMarket({ marketId, sortDirection, pagination }),
+        'pnl-by-address': () => apiInstance.pmPnlByAddress({ address, sortDirection, pagination }),
         'position-detail': () => apiInstance.pmPositionDetail({ marketId, pagination }),
         'categories': () => apiInstance.pmCategories({ pagination }),
+        'address-summary': () => apiInstance.pmAddressSummary({ address, pagination }),
         'help': () => ({
-          commands: ['ohlcv', 'orderbook', 'top-holders', 'trades-by-market', 'trades-by-address', 'market-screener', 'event-screener', 'pnl-by-market', 'pnl-by-address', 'position-detail', 'categories'],
+          commands: ['ohlcv', 'orderbook', 'top-holders', 'trades-by-market', 'trades-by-address', 'market-screener', 'event-screener', 'pnl-by-market', 'pnl-by-address', 'position-detail', 'categories', 'address-summary'],
           description: 'Polymarket prediction market analytics',
           example: 'nansen research pm market-screener --sort-by volume_24hr --limit 20'
         })

--- a/src/cli.js
+++ b/src/cli.js
@@ -1411,6 +1411,11 @@ export function buildCommands(deps = {}) {
       const sort = parseSort(options.sort);
       const pagination = buildPagination(options);
 
+      // Build order_by for screeners from --sort-by + --sort-direction
+      const screenerOrderBy = (sortBy || sortDirection)
+        ? [{ field: sortBy || 'volume_24hr', direction: (sortDirection || 'desc').toUpperCase() }]
+        : undefined;
+
       // Screener-specific filter options
       const tags = options.tags ? options.tags.split(',').map(t => t.trim()) : undefined;
       const minLiquidity = options['min-liquidity'] != null ? Number(options['min-liquidity']) : undefined;
@@ -1428,15 +1433,15 @@ export function buildCommands(deps = {}) {
       const maxPrice = options['max-price'] != null ? Number(options['max-price']) : undefined;
 
       const handlers = {
-        'ohlcv': () => apiInstance.pmOhlcv({ marketId, sort, sortDirection, pagination }),
+        'ohlcv': () => apiInstance.pmOhlcv({ marketId, orderBy: sort, pagination }),
         'orderbook': () => apiInstance.pmOrderbook({ marketId, pagination }),
-        'top-holders': () => apiInstance.pmTopHolders({ marketId, sort, sortDirection, pagination }),
-        'trades-by-market': () => apiInstance.pmTradesByMarket({ marketId, sortDirection, pagination }),
-        'trades-by-address': () => apiInstance.pmTradesByAddress({ address, sortDirection, pagination }),
-        'market-screener': () => apiInstance.pmMarketScreener({ sortBy, sortDirection, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination }),
-        'event-screener': () => apiInstance.pmEventScreener({ sortBy, sortDirection, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination }),
-        'pnl-by-market': () => apiInstance.pmPnlByMarket({ marketId, sortDirection, pagination }),
-        'pnl-by-address': () => apiInstance.pmPnlByAddress({ address, sortDirection, pagination }),
+        'top-holders': () => apiInstance.pmTopHolders({ marketId, orderBy: sort, pagination }),
+        'trades-by-market': () => apiInstance.pmTradesByMarket({ marketId, orderBy: sort, pagination }),
+        'trades-by-address': () => apiInstance.pmTradesByAddress({ address, orderBy: sort, pagination }),
+        'market-screener': () => apiInstance.pmMarketScreener({ orderBy: screenerOrderBy, sortBy, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, minPrice, maxPrice, pagination }),
+        'event-screener': () => apiInstance.pmEventScreener({ orderBy: screenerOrderBy, sortBy, query, status, tags, minLiquidity, maxLiquidity, minUniqueTraders24h, maxUniqueTraders24h, minVolume24hr, maxVolume24hr, negRisk, minOpenInterest, maxOpenInterest, endDateBefore, endDateAfter, pagination }),
+        'pnl-by-market': () => apiInstance.pmPnlByMarket({ marketId, orderBy: sort, pagination }),
+        'pnl-by-address': () => apiInstance.pmPnlByAddress({ address, orderBy: sort, pagination }),
         'position-detail': () => apiInstance.pmPositionDetail({ marketId, pagination }),
         'categories': () => apiInstance.pmCategories({ pagination }),
         'address-summary': () => apiInstance.pmAddressSummary({ address, pagination }),

--- a/src/schema.json
+++ b/src/schema.json
@@ -554,8 +554,7 @@
               "options": {
                 "market-id": {
                   "required": true
-                },
-                "sort-direction": {}
+                }
               }
             },
             "orderbook": {
@@ -573,8 +572,7 @@
               "options": {
                 "market-id": {
                   "required": true
-                },
-                "sort-direction": {}
+                }
               }
             },
             "trades-by-market": {
@@ -583,8 +581,7 @@
               "options": {
                 "market-id": {
                   "required": true
-                },
-                "sort-direction": {}
+                }
               }
             },
             "market-screener": {
@@ -592,7 +589,8 @@
               "description": "Get Prediction Market Screener",
               "options": {
                 "query": { "default": "" },
-                "sort-direction": { "default": "desc" },
+                "sort-by": { "description": "Sort field (default: volume_24hr). Use with --sort-direction." },
+                "sort-direction": { "description": "Sort direction: asc or desc (default: desc). Combines with --sort-by into order_by." },
                 "tags": {},
                 "min-liquidity": {},
                 "max-liquidity": {},
@@ -614,7 +612,8 @@
               "description": "Get Prediction Market Event Screener",
               "options": {
                 "query": { "default": "" },
-                "sort-direction": { "default": "desc" },
+                "sort-by": { "description": "Sort field (default: volume_24hr). Use with --sort-direction." },
+                "sort-direction": { "description": "Sort direction: asc or desc (default: desc). Combines with --sort-by into order_by." },
                 "tags": {},
                 "min-liquidity": {},
                 "max-liquidity": {},
@@ -635,8 +634,7 @@
               "options": {
                 "market-id": {
                   "required": true
-                },
-                "sort-direction": {}
+                }
               }
             },
             "pnl-by-address": {
@@ -645,8 +643,7 @@
               "options": {
                 "address": {
                   "required": true
-                },
-                "sort-direction": {}
+                }
               }
             },
             "position-detail": {
@@ -664,8 +661,7 @@
               "options": {
                 "address": {
                   "required": true
-                },
-                "sort-direction": {}
+                }
               }
             },
             "categories": {

--- a/src/schema.json
+++ b/src/schema.json
@@ -554,7 +554,8 @@
               "options": {
                 "market-id": {
                   "required": true
-                }
+                },
+                "sort-direction": {}
               }
             },
             "orderbook": {
@@ -572,7 +573,8 @@
               "options": {
                 "market-id": {
                   "required": true
-                }
+                },
+                "sort-direction": {}
               }
             },
             "trades-by-market": {
@@ -581,7 +583,8 @@
               "options": {
                 "market-id": {
                   "required": true
-                }
+                },
+                "sort-direction": {}
               }
             },
             "market-screener": {
@@ -593,8 +596,10 @@
                 "tags": {},
                 "min-liquidity": {},
                 "max-liquidity": {},
+                "min-unique-traders-24h": {},
                 "max-unique-traders-24h": {},
                 "min-volume-24hr": {},
+                "max-volume-24hr": {},
                 "neg-risk": {},
                 "min-open-interest": {},
                 "max-open-interest": {},
@@ -613,8 +618,10 @@
                 "tags": {},
                 "min-liquidity": {},
                 "max-liquidity": {},
+                "min-unique-traders-24h": {},
                 "max-unique-traders-24h": {},
                 "min-volume-24hr": {},
+                "max-volume-24hr": {},
                 "neg-risk": {},
                 "min-open-interest": {},
                 "max-open-interest": {},
@@ -628,7 +635,8 @@
               "options": {
                 "market-id": {
                   "required": true
-                }
+                },
+                "sort-direction": {}
               }
             },
             "pnl-by-address": {
@@ -637,7 +645,8 @@
               "options": {
                 "address": {
                   "required": true
-                }
+                },
+                "sort-direction": {}
               }
             },
             "position-detail": {
@@ -655,7 +664,8 @@
               "options": {
                 "address": {
                   "required": true
-                }
+                },
+                "sort-direction": {}
               }
             },
             "categories": {

--- a/src/schema.json
+++ b/src/schema.json
@@ -589,8 +589,7 @@
               "description": "Get Prediction Market Screener",
               "options": {
                 "query": { "default": "" },
-                "sort-by": { "description": "Sort field (default: volume_24hr). Use with --sort-direction." },
-                "sort-direction": { "description": "Sort direction: asc or desc (default: desc). Combines with --sort-by into order_by." },
+                "sort-by": { "description": "Deprecated: use --sort field:dir instead" },
                 "tags": {},
                 "min-liquidity": {},
                 "max-liquidity": {},
@@ -612,8 +611,7 @@
               "description": "Get Prediction Market Event Screener",
               "options": {
                 "query": { "default": "" },
-                "sort-by": { "description": "Sort field (default: volume_24hr). Use with --sort-direction." },
-                "sort-direction": { "description": "Sort direction: asc or desc (default: desc). Combines with --sort-by into order_by." },
+                "sort-by": { "description": "Deprecated: use --sort field:dir instead" },
                 "tags": {},
                 "min-liquidity": {},
                 "max-liquidity": {},

--- a/src/schema.json
+++ b/src/schema.json
@@ -588,18 +588,38 @@
               "endpoint": "/api/v1/prediction-market/market-screener",
               "description": "Get Prediction Market Screener",
               "options": {
-                "query": {
-                  "default": ""
-                }
+                "query": { "default": "" },
+                "sort-direction": { "default": "desc" },
+                "tags": {},
+                "min-liquidity": {},
+                "max-liquidity": {},
+                "max-unique-traders-24h": {},
+                "min-volume-24hr": {},
+                "neg-risk": {},
+                "min-open-interest": {},
+                "max-open-interest": {},
+                "end-date-before": {},
+                "end-date-after": {},
+                "min-price": {},
+                "max-price": {}
               }
             },
             "event-screener": {
               "endpoint": "/api/v1/prediction-market/event-screener",
               "description": "Get Prediction Market Event Screener",
               "options": {
-                "query": {
-                  "default": ""
-                }
+                "query": { "default": "" },
+                "sort-direction": { "default": "desc" },
+                "tags": {},
+                "min-liquidity": {},
+                "max-liquidity": {},
+                "max-unique-traders-24h": {},
+                "min-volume-24hr": {},
+                "neg-risk": {},
+                "min-open-interest": {},
+                "max-open-interest": {},
+                "end-date-before": {},
+                "end-date-after": {}
               }
             },
             "pnl-by-market": {
@@ -641,6 +661,15 @@
             "categories": {
               "endpoint": "/api/v1/prediction-market/categories",
               "description": "Get Prediction Market Categories"
+            },
+            "address-summary": {
+              "endpoint": "/api/v1/prediction-market/address-summary",
+              "description": "Get wallet-level PnL summary for a Polymarket address",
+              "options": {
+                "address": {
+                  "required": true
+                }
+              }
             }
           },
           "description": "Polymarket prediction market analytics"


### PR DESCRIPTION
## Summary

Adds v2 API params to the CLI for prediction market endpoints (SIG-6603).

### Changes

**Sorting** — all sortable PM endpoints now use `order_by` (matching API PR #1076):
- Supports `--sort field:dir` and `--order-by` (JSON), same as every other CLI endpoint
- `--sort-by` kept on screeners as convenience (maps to `sort_by`, accepted by both old and new API)

**Non-screener endpoints** (ohlcv, top-holders, trades-by-market, trades-by-address, pnl-by-market, pnl-by-address):
- Send `order_by` only (new API). Old `sort` param removed since old API rejects `order_by` with `extra="forbid"` regardless.

**Market screener + event screener** — advanced filters:
- `--tags` (comma-separated, e.g. `--tags Crypto,Bitcoin`)
- `--min-liquidity` / `--max-liquidity`
- `--min-unique-traders-24h` / `--max-unique-traders-24h`
- `--min-volume-24hr` / `--max-volume-24hr`
- `--neg-risk` (`true`/`false`)
- `--min-open-interest` / `--max-open-interest`
- `--end-date-before` / `--end-date-after` (ISO 8601)
- `--min-price` / `--max-price` (market screener only)

**New subcommand** — `address-summary`:
```bash
nansen research pm address-summary --address 0x94f1...
```
Returns wallet-level PnL summary: realized/unrealized PnL, win rate, wallet age, P2P stats.

### Deployment order

API PR #1076 deploys first. The new CLI only ever hits the new API.
- Old API has `extra="forbid"` on all PM endpoints — sending `order_by` would 422 regardless, so no backward compat shim is possible or needed.
- `--sort-by` on screeners is the one exception: it sends `sort_by` which both old and new API accept. Not a breaking change.

### Smoke-tested against production API

| Command | Result |
|---------|--------|
| `pm market-screener` (no new flags) | ✅ Works |
| `pm market-screener --sort-by liquidity` | ✅ Works (`sort_by` accepted) |
| `pm ohlcv --market-id X` (no `--sort`) | ✅ Works (`order_by` is undefined) |
| `pm ohlcv --sort volume_usd:asc` | ❌ 422 (expected — old API rejects `order_by`) |
| `pm address-summary --address X` | ❌ 404 (expected — endpoint doesn't exist yet) |

### Depends on
- [nansen-api PR #1076](https://github.com/nansen-ai/nansen-api/pull/1076) — API v2 endpoints (deploy first)
- [nansen-prediction-markets PR #110](https://github.com/nansen-ai/nansen-prediction-markets/pull/110) — v2 dbt models

Linear: [SIG-6603](https://linear.app/nansen/issue/SIG-6603/add-advanced-filtering-to-prediction-market-endpoints)

## Test plan
- [x] 1309/1309 unit tests pass (23 test files)
- [x] Lint clean
- [x] `order_by` on all 6 non-screener endpoints + both screeners
- [x] `sort` fallback to `order_by` on ohlcv/top-holders (backward compat for programmatic callers)
- [x] Screener `sort_by` always present alongside `order_by`
- [x] All screener filter params: volume, liquidity, OI, traders, neg_risk, tags, price, date
- [x] Numeric filter `0` passes through (not treated as sentinel)
- [x] `address-summary` in help output, missing/invalid address validation
- [x] Changeset added (`minor`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)