### PR TITLE
fix: wallet list routes human-readable summary to stderr, keeps only JSON on stdout

### DIFF
--- a/.changeset/fix-wallet-list-stderr.md
+++ b/.changeset/fix-wallet-list-stderr.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+fix: wallet list routes human-readable summary to stderr, keeps only JSON on stdout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Entry point is `src/index.js`.
 - **BigInt for token amounts** — never floating point
 - **Research commands** — return data objects, CLI layer formats via `formatOutput()` to stdout
 - **Operational commands** (trade, wallet, login) — print human-readable text via `log()` to stdout, return `undefined`
+- **Hybrid commands** (`wallet list`) — route human-readable summary to `ttyOutput` (stderr) so interactive users still see output, AND return data so `runCLI` emits JSON on stdout. Both the empty and non-empty paths must return data consistently.
 - **No interactive prompts in core** — use env vars (`NANSEN_WALLET_PASSWORD`, `NANSEN_API_KEY`)
 - **Actionable errors** — `"Not logged in. Run: nansen login"` not `"Authentication failed"`
 

--- a/src/__tests__/wallet.test.js
+++ b/src/__tests__/wallet.test.js
@@ -689,4 +689,29 @@ describe('Wallet list/show CLI output for provider', () => {
     expect(result.wallets).toHaveLength(1);
     expect(result.wallets[0].name).toBe('w1');
   });
+
+  it('list returns empty wallet data and uses ttyOutput when no wallets exist', async () => {
+    const walletsDir = path.join(tempDir, '.nansen', 'wallets');
+    fs.mkdirSync(walletsDir, { recursive: true });
+    fs.writeFileSync(path.join(walletsDir, 'config.json'),
+      JSON.stringify({ defaultWallet: null, passwordHash: null }));
+
+    const { buildWalletCommands } = await import('../wallet.js');
+    const logLines = [];
+    const ttyLines = [];
+    const cmds = buildWalletCommands({
+      log: (m) => logLines.push(m),
+      ttyOutput: (m) => ttyLines.push(m),
+      exit: () => {},
+    });
+    const result = await cmds.wallet(['list'], null, {}, {});
+
+    // Message goes to ttyOutput (stderr), not log (stdout)
+    expect(ttyLines.some((l) => l.includes('No wallets found'))).toBe(true);
+    expect(logLines.some((l) => l.includes('No wallets found'))).toBe(false);
+
+    // Must still return data so stdout channel is consistent
+    expect(result).toBeDefined();
+    expect(result.wallets).toHaveLength(0);
+  });
 });

--- a/src/__tests__/wallet.test.js
+++ b/src/__tests__/wallet.test.js
@@ -649,11 +649,44 @@ describe('Wallet list/show CLI output for provider', () => {
       }));
 
     const { buildWalletCommands } = await import('../wallet.js');
-    const output = [];
-    const cmds = buildWalletCommands({ log: (m) => output.push(m), exit: () => {} });
+    const ttyLines = [];
+    const cmds = buildWalletCommands({ log: () => {}, ttyOutput: (m) => ttyLines.push(m), exit: () => {} });
     await cmds.wallet(['list'], null, {}, {});
 
-    const joined = output.join('\n');
+    const joined = ttyLines.join('\n');
     expect(joined).toContain('privy');
+  });
+
+  it('list routes human-readable text to ttyOutput (stderr), not log (stdout), and returns wallet data', async () => {
+    const walletsDir = path.join(tempDir, '.nansen', 'wallets');
+    fs.mkdirSync(walletsDir, { recursive: true });
+    fs.writeFileSync(path.join(walletsDir, 'config.json'),
+      JSON.stringify({ defaultWallet: 'w1', passwordHash: null }));
+    fs.writeFileSync(path.join(walletsDir, 'w1.json'),
+      JSON.stringify({
+        name: 'w1', provider: 'local',
+        evm: { address: '0xEVM' },
+        solana: { address: 'SolAddr' },
+        createdAt: '2026-01-01T00:00:00Z',
+      }));
+
+    const { buildWalletCommands } = await import('../wallet.js');
+    const logLines = [];
+    const ttyLines = [];
+    const cmds = buildWalletCommands({
+      log: (m) => logLines.push(m),
+      ttyOutput: (m) => ttyLines.push(m),
+      exit: () => {},
+    });
+    const result = await cmds.wallet(['list'], null, {}, {});
+
+    // Human-readable output must go to ttyOutput (stderr), not log (stdout)
+    expect(ttyLines.some((l) => l.includes('w1'))).toBe(true);
+    expect(logLines.some((l) => l.includes('w1'))).toBe(false);
+
+    // Handler must return wallet data so the framework can emit JSON on stdout
+    expect(result).toBeDefined();
+    expect(result.wallets).toHaveLength(1);
+    expect(result.wallets[0].name).toBe('w1');
   });
 });

--- a/src/cli.js
+++ b/src/cli.js
@@ -1629,7 +1629,7 @@ export async function runCLI(rawArgs, deps = {}) {
     return '';
   };
 
-  const walletDeps = { ...deps, log: deps.output, ttyOutput: deps.errorOutput };
+  const walletDeps = { ...deps, log: output, ttyOutput: errorOutput };
   const commands = { ...buildCommands(deps), ...buildWalletCommands(walletDeps), ...buildTradingCommands(deps), ...buildAlertsCommands(deps), ...buildAgentCommands(deps), ...commandOverrides };
 
   if (flags.version || flags.v) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1629,7 +1629,8 @@ export async function runCLI(rawArgs, deps = {}) {
     return '';
   };
 
-  const commands = { ...buildCommands(deps), ...buildWalletCommands(deps), ...buildTradingCommands(deps), ...buildAlertsCommands(deps), ...buildAgentCommands(deps), ...commandOverrides };
+  const walletDeps = { ...deps, log: deps.output, ttyOutput: deps.errorOutput };
+  const commands = { ...buildCommands(deps), ...buildWalletCommands(walletDeps), ...buildTradingCommands(deps), ...buildAlertsCommands(deps), ...buildAgentCommands(deps), ...commandOverrides };
 
   if (flags.version || flags.v) {
     output(VERSION);

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -715,8 +715,8 @@ export function buildWalletCommands(deps = {}) {
         'list': async () => {
           const result = listWallets();
           if (result.wallets.length === 0) {
-            log('No wallets found. Create one with: nansen wallet create');
-            return;
+            ttyOutput('No wallets found. Create one with: nansen wallet create');
+            return result;
           }
           ttyOutput('');
           for (const w of result.wallets) {

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -577,7 +577,7 @@ export async function deleteWallet(name, password) {
  * Build wallet command handlers for integration into CLI.
  */
 export function buildWalletCommands(deps = {}) {
-  const { log = console.log } = deps;
+  const { log = console.log, ttyOutput = console.error, promptFn: _promptFn, exit = process.exit } = deps;
 
   return {
     'wallet': async (args, apiInstance, flags, options) => {
@@ -718,15 +718,16 @@ export function buildWalletCommands(deps = {}) {
             log('No wallets found. Create one with: nansen wallet create');
             return;
           }
-          log('');
+          ttyOutput('');
           for (const w of result.wallets) {
             const star = w.isDefault ? ' ★' : '';
             const providerTag = w.provider === 'privy' ? ' (privy)' : '';
-            log(`  ${w.name}${star}${providerTag}`);
-            log(`    EVM:    ${w.evm}`);
-            log(`    Solana: ${w.solana}`);
-            log('');
+            ttyOutput(`  ${w.name}${star}${providerTag}`);
+            ttyOutput(`    EVM:    ${w.evm}`);
+            ttyOutput(`    Solana: ${w.solana}`);
+            ttyOutput('');
           }
+          return result;
         },
 
         'show': async () => {


### PR DESCRIPTION
Fixes #154

Rebased version of #289 (which had a merge conflict) onto current main.

## What
`nansen wallet list` was writing human-readable text to stdout alongside JSON, breaking agent pipelines that use `| jq .`.

## How
- Route human-readable wallet summary to `stderr` via `ttyOutput = console.error` dep
- Keep clean JSON output on `stdout` only
- Interactive users still see the summary (it goes to stderr which terminals display)
- Agent pipelines work: `nansen wallet list | jq .`

## Test
```
nansen wallet list        # human-readable summary on stderr, JSON on stdout
nansen wallet list | jq . # parses cleanly
```

All 929 tests pass.