### PR TITLE
feat: add top-tokens subcommand for Nansen Score discovery

### DIFF
--- a/.changeset/top-tokens-nansen-score.md
+++ b/.changeset/top-tokens-nansen-score.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add `top-tokens` subcommand to discover top-scoring tokens by Nansen Score. Calls internal endpoint (`/api/internal/nansen-score-top-tokens`) with optional `--market-cap` filter.

--- a/skills/nansen-token-screener/SKILL.md
+++ b/skills/nansen-token-screener/SKILL.md
@@ -45,10 +45,18 @@ nansen research token indicators --token $TOKEN --chain $CHAIN
 # Flow intelligence — only use for promising tokens from screener/indicators above
 nansen research token flow-intelligence --token $TOKEN --chain $CHAIN
 # → net_flow_usd per label: smart_trader, whale, exchange, fresh_wallets, public_figure
+
+# Nansen Score Top Tokens — "what should I buy?" (internal, @nansen.ai only)
+# Use this FIRST for discovery, then drill into individual tokens with `indicators` above
+nansen research token top-tokens --limit 25
+nansen research token top-tokens --market-cap largecap --limit 10
+# → token_symbol, chain, performance_score, risk_score, plus per-indicator contribution fields
 ```
 
 Screener timeframes: `5m`, `10m`, `1h`, `6h`, `24h`, `7d`, `30d`
 
 Indicators: score is "bullish"/"bearish"/"neutral". signal_percentile > 70 = historically significant. Some tokens return empty indicators — not an error.
+
+Top tokens: performance_score >= 15 means buy candidate. risk_score > 0 means safer. Use `--market-cap` to filter by lowcap/midcap/largecap. Then use `indicators` on individual tokens for the full breakdown.
 
 Flow intelligence is credit-heavy. Use it to confirm SM conviction on tokens that already look promising from screener + indicators, not as a first pass on every token.

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -160,6 +160,19 @@ const MOCK_RESPONSES = {
       { indicator_type: 'price-momentum', score: 'bullish', signal: 0.75, signal_percentile: 85.5, last_trigger_on: '2025-01-10' }
     ]
   },
+  topTokens: {
+    tokens: [
+      {
+        token_address: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+        token_symbol: 'AAVE',
+        chain: 'ethereum',
+        performance_score: 72.5,
+        risk_score: 35.2,
+        price_momentum_performance: 0.85,
+        liquidity_risk: 0.15
+      }
+    ]
+  },
   tokenOhlcv: {
     candles: [
       { timestamp: '2025-01-15T00:00:00Z', open: 1.5, high: 1.8, low: 1.4, close: 1.7, volume: 1000000 }
@@ -1080,6 +1093,38 @@ describe('NansenAPI', () => {
 
         expect(result.risk_indicators).toBeInstanceOf(Array);
         expect(result.reward_indicators).toBeInstanceOf(Array);
+      });
+    });
+
+    describe('topTokens', () => {
+      it('should fetch top tokens with correct endpoint and body', async () => {
+        setupMock(MOCK_RESPONSES.topTokens);
+        const result = await api.topTokens({ limit: 10 });
+        const body = expectFetchCalledWith('/api/internal/nansen-score-top-tokens');
+        if (body) {
+          expect(body.limit).toBe(10);
+          expect(body.marketCapGroup).toBeUndefined();
+        }
+        expect(result.tokens).toBeInstanceOf(Array);
+      });
+
+      it('should pass marketCapGroup when provided', async () => {
+        setupMock(MOCK_RESPONSES.topTokens);
+        await api.topTokens({ marketCapGroup: 'largecap', limit: 5 });
+        const body = expectFetchCalledWith('/api/internal/nansen-score-top-tokens');
+        if (body) {
+          expect(body.marketCapGroup).toBe('largecap');
+          expect(body.limit).toBe(5);
+        }
+      });
+
+      it('should default limit to 25', async () => {
+        setupMock(MOCK_RESPONSES.topTokens);
+        await api.topTokens({});
+        const body = expectFetchCalledWith('/api/internal/nansen-score-top-tokens');
+        if (body) {
+          expect(body.limit).toBe(25);
+        }
       });
     });
 

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -116,6 +116,7 @@ describe('CLI Smoke Tests', () => {
     const { stdout } = runCLI('research token help');
     expect(stdout).toContain('screener');
     expect(stdout).toContain('ohlcv');
+    expect(stdout).toContain('top-tokens');
   });
 
   it('should route research prediction-market commands', () => {

--- a/src/__tests__/coverage.test.js
+++ b/src/__tests__/coverage.test.js
@@ -46,6 +46,7 @@ const DOCUMENTED_ENDPOINTS = {
     { name: 'perp-trades', method: 'tokenPerpTrades', endpoint: '/api/v1/tgm/perp-trades' },
     { name: 'perp-positions', method: 'tokenPerpPositions', endpoint: '/api/v1/tgm/perp-positions' },
     { name: 'perp-pnl-leaderboard', method: 'tokenPerpPnlLeaderboard', endpoint: '/api/v1/tgm/perp-pnl-leaderboard' },
+    { name: 'top-tokens', method: 'topTokens', endpoint: '/api/internal/nansen-score-top-tokens' },
   ],
   composite: [
     { name: 'batch-profile', fn: batchProfile, endpoint: 'composite' },

--- a/src/api.js
+++ b/src/api.js
@@ -1203,6 +1203,13 @@ export class NansenAPI {
     });
   }
 
+  async topTokens(params = {}) {
+    const { marketCapGroup, limit = 25 } = params;
+    const body = { limit };
+    if (marketCapGroup) body.marketCapGroup = marketCapGroup;
+    return this.request('/api/internal/nansen-score-top-tokens', body);
+  }
+
   // ============= Perp Endpoints =============
 
   async perpScreener(params = {}) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1276,8 +1276,13 @@ export function buildCommands(deps = {}) {
           const withLabels = resolveBooleanOption(options, flags, 'premium-labels');
           return apiInstance.tokenPerpPnlLeaderboard({ tokenSymbol, filters, orderBy, pagination, days, withLabels });
         },
+        'top-tokens': () => {
+          const marketCapGroup = options['market-cap'] || options['market-cap-group'];
+          const limit = options.limit ? parseInt(options.limit) : undefined;
+          return apiInstance.topTokens({ marketCapGroup, limit });
+        },
         'help': () => ({
-          commands: ['info', 'ohlcv', 'screener', 'holders', 'flows', 'dex-trades', 'pnl', 'who-bought-sold', 'flow-intelligence', 'transfers', 'jup-dca', 'perp-trades', 'perp-positions', 'perp-pnl-leaderboard'],
+          commands: ['info', 'ohlcv', 'screener', 'holders', 'flows', 'dex-trades', 'pnl', 'who-bought-sold', 'flow-intelligence', 'transfers', 'jup-dca', 'perp-trades', 'perp-positions', 'perp-pnl-leaderboard', 'top-tokens'],
           description: 'Token God Mode endpoints',
           example: 'nansen token screener --chain solana --timeframe 24h --smart-money --include-stablecoins false'
         })

--- a/src/schema.json
+++ b/src/schema.json
@@ -500,6 +500,19 @@
                   "default": true
                 }
               }
+            },
+            "top-tokens": {
+              "endpoint": "/api/internal/nansen-score-top-tokens",
+              "description": "Top tokens ranked by Nansen Score (internal, requires @nansen.ai account)",
+              "options": {
+                "market-cap": {
+                  "description": "Filter by market cap group",
+                  "enum": ["lowcap", "midcap", "largecap"]
+                },
+                "limit": {
+                  "default": 25
+                }
+              }
             }
           },
           "description": "Token God Mode - deep analytics for any token"


### PR DESCRIPTION
## Summary
- Add `nansen research token top-tokens` subcommand that calls `POST /api/internal/nansen-score-top-tokens`
- Supports `--market-cap` filter (lowcap/midcap/largecap) and `--limit`
- Fills the discovery gap: users can now find top-scoring tokens, then drill into individual indicators

## Test plan
- [x] All 1323 existing tests pass
- [x] 3 new unit tests for `topTokens()` API method (endpoint, marketCapGroup passthrough, default limit)
- [x] CLI integration test asserts `top-tokens` in help output
- [x] Coverage test updated
- [x] Schema validated via `nansen schema token`