### PR TITLE
fix(telemetry): normalize agent path and agent_prompt for analytics

### DIFF
--- a/src/__tests__/telemetry.test.js
+++ b/src/__tests__/telemetry.test.js
@@ -71,7 +71,7 @@ describe('telemetry', () => {
       expect(body.properties.chain).toBeUndefined();
     });
 
-    it('should map agent commands to path /agent and set agent_prompt', () => {
+    it('should map agent commands to path /agent', () => {
       trackCommandSucceeded({
         command: 'agent What is the trend score for ETH',
         duration_ms: 100,
@@ -79,15 +79,13 @@ describe('telemetry', () => {
 
       const body = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(body.path).toBe('/agent');
-      expect(body.properties.agent_prompt).toBe('What is the trend score for ETH');
     });
 
-    it('should map bare agent to /agent without agent_prompt', () => {
+    it('should map bare agent to /agent', () => {
       trackCommandSucceeded({ command: 'agent', duration_ms: 10 });
 
       const body = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(body.path).toBe('/agent');
-      expect(body.properties.agent_prompt).toBeUndefined();
     });
   });
 
@@ -110,7 +108,7 @@ describe('telemetry', () => {
       expect(body.properties.status).toBe(401);
     });
 
-    it('should map failed agent commands to /agent with agent_prompt', () => {
+    it('should map failed agent commands to /agent', () => {
       trackCommandFailed({
         command: 'agent Explain SOL flows',
         duration_ms: 200,
@@ -120,7 +118,6 @@ describe('telemetry', () => {
 
       const body = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(body.path).toBe('/agent');
-      expect(body.properties.agent_prompt).toBe('Explain SOL flows');
     });
   });
 

--- a/src/__tests__/telemetry.test.js
+++ b/src/__tests__/telemetry.test.js
@@ -70,6 +70,25 @@ describe('telemetry', () => {
       const body = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(body.properties.chain).toBeUndefined();
     });
+
+    it('should map agent commands to path /agent and set agent_prompt', () => {
+      trackCommandSucceeded({
+        command: 'agent What is the trend score for ETH',
+        duration_ms: 100,
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.path).toBe('/agent');
+      expect(body.properties.agent_prompt).toBe('What is the trend score for ETH');
+    });
+
+    it('should map bare agent to /agent without agent_prompt', () => {
+      trackCommandSucceeded({ command: 'agent', duration_ms: 10 });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.path).toBe('/agent');
+      expect(body.properties.agent_prompt).toBeUndefined();
+    });
   });
 
   describe('trackCommandFailed', () => {
@@ -89,6 +108,19 @@ describe('telemetry', () => {
       expect(body.path).toBe('/smart-money/netflow');
       expect(body.properties.error_code).toBe('UNAUTHORIZED');
       expect(body.properties.status).toBe(401);
+    });
+
+    it('should map failed agent commands to /agent with agent_prompt', () => {
+      trackCommandFailed({
+        command: 'agent Explain SOL flows',
+        duration_ms: 200,
+        error_code: 'UNAUTHORIZED',
+        status: 401,
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.path).toBe('/agent');
+      expect(body.properties.agent_prompt).toBe('Explain SOL flows');
     });
   });
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -1738,7 +1738,12 @@ export async function runCLI(rawArgs, deps = {}) {
 
   // ── Telemetry setup ──
   const startTime = Date.now();
-  const fullCommand = subcommand ? `${command} ${subcommand}` : command;
+  const fullCommand =
+    command === 'agent' && subArgs.length > 0
+      ? `agent ${subArgs.join(' ')}`
+      : subcommand
+        ? `${command} ${subcommand}`
+        : command;
   const flagNames = Object.keys(flags).filter(k => flags[k]).map(k => `--${k}`);
   const optionNames = Object.keys(options).map(k => `--${k}`);
   const usedFlags = [...flagNames, ...optionNames];

--- a/src/cli.js
+++ b/src/cli.js
@@ -1738,12 +1738,7 @@ export async function runCLI(rawArgs, deps = {}) {
 
   // ── Telemetry setup ──
   const startTime = Date.now();
-  const fullCommand =
-    command === 'agent' && subArgs.length > 0
-      ? `agent ${subArgs.join(' ')}`
-      : subcommand
-        ? `${command} ${subcommand}`
-        : command;
+  const fullCommand = subcommand ? `${command} ${subcommand}` : command;
   const flagNames = Object.keys(flags).filter(k => flags[k]).map(k => `--${k}`);
   const optionNames = Object.keys(options).map(k => `--${k}`);
   const usedFlags = [...flagNames, ...optionNames];

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -167,15 +167,6 @@ function commandToPath(command) {
   return '/' + String(command).replace(/\s+/g, '/');
 }
 
-/** Non-empty prompt text after `agent`, for telemetry properties. */
-function agentPromptProperty(command) {
-  if (typeof command !== 'string') return {};
-  const m = command.trimStart().match(/^agent(?:\s+(.*))?$/);
-  if (!m || m[1] == null) return {};
-  const prompt = m[1].trim();
-  return prompt ? { agent_prompt: prompt } : {};
-}
-
 /**
  * Track a CLI command that completed successfully.
  *
@@ -206,7 +197,6 @@ export function trackCommandSucceeded({
       latency: duration_ms / 1000,
       from_cache,
       flags,
-      ...agentPromptProperty(command),
       ...(chain ? { chain } : {}),
     },
     context: buildContext(),
@@ -246,7 +236,6 @@ export function trackCommandFailed({
       error_code,
       status,
       flags,
-      ...agentPromptProperty(command),
       ...(chain ? { chain } : {}),
     },
     context: buildContext(),

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -158,9 +158,22 @@ function buildContext() {
 
 /**
  * Convert a command string like "smart-money netflow" to a path like "/smart-money/netflow".
+ * Agent ("agent …") always maps to "/agent" so prompts are not exploded into path segments.
  */
 function commandToPath(command) {
-  return '/' + command.replace(/\s+/g, '/');
+  if (typeof command === 'string' && /^agent(?:\s+|$)/.test(command.trimStart())) {
+    return '/agent';
+  }
+  return '/' + String(command).replace(/\s+/g, '/');
+}
+
+/** Non-empty prompt text after `agent`, for telemetry properties. */
+function agentPromptProperty(command) {
+  if (typeof command !== 'string') return {};
+  const m = command.trimStart().match(/^agent(?:\s+(.*))?$/);
+  if (!m || m[1] == null) return {};
+  const prompt = m[1].trim();
+  return prompt ? { agent_prompt: prompt } : {};
 }
 
 /**
@@ -193,6 +206,7 @@ export function trackCommandSucceeded({
       latency: duration_ms / 1000,
       from_cache,
       flags,
+      ...agentPromptProperty(command),
       ...(chain ? { chain } : {}),
     },
     context: buildContext(),
@@ -232,6 +246,7 @@ export function trackCommandFailed({
       error_code,
       status,
       flags,
+      ...agentPromptProperty(command),
       ...(chain ? { chain } : {}),
     },
     context: buildContext(),


### PR DESCRIPTION
## Summary

Fixes CLI telemetry for `nansen agent …` so analytics can bucket agent usage correctly.

**Problem:** The full command string was turned into a URL-style `path` by replacing spaces with slashes (e.g. `agent What is …` → `/agent/What/is/the/…`), producing very long, unstable paths and breaking agent vs non-agent tracking.

**Changes:**

- **`src/telemetry.js`:** For commands that start with `agent`, `path` is always `/agent`. Non-agent commands keep the existing behavior (`/smart-money/netflow`, etc.). When there is text after `agent`, it is sent in `properties.agent_prompt` (trimmed); bare `agent` has no `agent_prompt`.
- **`src/cli.js`:** For telemetry only, `fullCommand` for `agent` is built as `agent ${subArgs.join(' ')}` when there are positional args, matching the question the handler uses and ensuring multi-token prompts (without quotes) are reflected in `agent_prompt`.
- **`src/__tests__/telemetry.test.js`:** Covers agent path, `agent_prompt`, success/failure, and bare `agent`.

No CLI output or public command surface changes for end users.

## Checklist

- [x] Tests pass (`npm test`)
- [x] `src/schema.json` updated if new commands or flags were added — N/A (no schema changes)
- [x] `README.md` updated if new top-level commands or categories were added — N/A
- [ ] Changeset added (`.changeset/`) — only required for user-facing changes (new commands, flags, bug fixes, breaking changes) — **Optional:** skip if you treat this as telemetry-only; add a **`patch`** changeset if you want it in the changelog (e.g. fix agent command telemetry path and `agent_prompt` for analytics). 



## Tests pass

 Test Files  23 passed (23)
      Tests  1322 passed | 2 skipped (1324)
   Start at  12:31:46
   Duration  16.12s (transform 1.94s, setup 0ms, import 2.93s, tests 40.37s, environment 1ms)
