### PR TITLE
refactor: switch top-tokens to public external endpoint + expand scoring docs

### DIFF
--- a/.changeset/top-tokens-nansen-score.md
+++ b/.changeset/top-tokens-nansen-score.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add `top-tokens` subcommand to discover top-scoring tokens by Nansen Score. Calls internal endpoint (`/api/internal/nansen-score-top-tokens`) with optional `--market-cap` filter.

--- a/.changeset/top-tokens-nansen-score.md
+++ b/.changeset/top-tokens-nansen-score.md
@@ -2,4 +2,4 @@
 "nansen-cli": minor
 ---
 
-Add `top-tokens` subcommand to discover top-scoring tokens by Nansen Score. Calls internal endpoint (`/api/internal/nansen-score-top-tokens`) with optional `--market-cap` filter.
+Add `top-tokens` subcommand to discover top-scoring tokens by Nansen Score. Calls the public endpoint (`/api/v1/nansen-score/top-tokens`) with optional `--market-cap` filter.

--- a/skills/nansen-token-screener/SKILL.md
+++ b/skills/nansen-token-screener/SKILL.md
@@ -46,17 +46,63 @@ nansen research token indicators --token $TOKEN --chain $CHAIN
 nansen research token flow-intelligence --token $TOKEN --chain $CHAIN
 # → net_flow_usd per label: smart_trader, whale, exchange, fresh_wallets, public_figure
 
-# Nansen Score Top Tokens — "what should I buy?" (internal, @nansen.ai only)
+# Nansen Score Top Tokens — "what should I buy?" (public endpoint, any authenticated API key)
 # Use this FIRST for discovery, then drill into individual tokens with `indicators` above
 nansen research token top-tokens --limit 25
 nansen research token top-tokens --market-cap largecap --limit 10
-# → token_symbol, chain, performance_score, risk_score, plus per-indicator contribution fields
+# → chain, token_address, token_symbol, performance_score, risk_score,
+#   per-indicator contributions, market_cap_group, latest_date, last_trigger_on
 ```
 
 Screener timeframes: `5m`, `10m`, `1h`, `6h`, `24h`, `7d`, `30d`
 
 Indicators: score is "bullish"/"bearish"/"neutral". signal_percentile > 70 = historically significant. Some tokens return empty indicators — not an error.
 
-Top tokens: performance_score >= 15 means buy candidate. risk_score > 0 means safer. Use `--market-cap` to filter by lowcap/midcap/largecap. Then use `indicators` on individual tokens for the full breakdown.
+## Top tokens — Nansen Score field reference
+
+Results are pre-filtered to `performance_score >= 15` server-side and returned sorted by:
+1. `performance_score` DESC
+2. `market_cap_group` priority (largecap → midcap → lowcap)
+3. `risk_score` DESC
+4. 24h volume DESC
+
+So row 0 is always the strongest candidate for the filter you applied — no client-side ranking needed.
+
+Market cap buckets (used in both the sort priority and the `--market-cap` filter):
+- `lowcap`: market cap < $100M
+- `midcap`: market cap $100M – $1B
+- `largecap`: market cap > $1B
+
+Every contribution is **ternary** — exactly one of `{negative, 0, positive}` per field. No partial values. Zero means "indicator didn't apply to this token" (out of scope), not "indicator was neutral".
+
+**Performance Score (Alpha — "likely to outperform BTC over 7–30d")**
+Range: `-60 to +75` (arithmetic bounds; live max is closer to `+45` since no single token hits every positive indicator simultaneously). Buy threshold: `>= 15`. Sum of the five `*_performance` fields below.
+| Field | Contribution | Trigger | What the underlying indicator measures |
+|---|---|---|---|
+| `price_momentum_performance` | +30 / 0 | upstream score `bullish` → +30 | Price momentum, scored against separate thresholds for large-cap vs. low/mid-cap tokens. |
+| `chain_fees_performance` | +30 / 0 | `bullish` (30-day fee growth > +1%) → +30 | 30-day spending momentum on network fees (geometric mean of daily returns). **Only tracked for a handful of L1 native tokens (e.g. ETH, TRX, AVAX, RON); always 0 for every other token.** |
+| `trading_range_performance` | +15 / 0 | `bullish` (price breaks above resistance in an uptrend) → +15 | 14-day price trend combined with position vs. nearest support/resistance. In practice fires mostly on established tokens that have well-defined levels — can fire at any market cap, but is rare for new / low-liquidity tokens. |
+| `chain_tvl_performance` | 0 / -35 | `bearish` (composite TVL growth < 0) → -35 | TVL momentum composite signal. Only non-zero for chains / L2s whose TVL is tracked. No positive path exists — the field only deducts. |
+| `protocol_fees_performance` | 0 / -25 | `bearish` (14-day fee growth < -3%) → -25 | 14-day protocol fee momentum. Only non-zero for tokens backed by protocols with measurable fee revenue. No positive path — deduction only. |
+
+**Risk Score (Safety — "filters falling knives / dangerous setups")**
+Range: `-60 to +80` (arithmetic bounds). Safety threshold: `> 0` (positive = safer, negative = riskier). Sum of the four `*_risk` fields below. For every risk field: upstream score `low` → positive contribution, `high` → negative contribution, `medium`/missing → 0.
+| Field | Contribution | What the underlying indicator measures |
+|---|---|---|
+| `btc_reflexivity_risk` | +40 / -20 | Rolling 5-event median ratio of token drop to BTC drop on days BTC falls >3%. Ratio ≤ 1 → `low` → **+40** (token holds up as well as or better than BTC on drawdowns). Ratio > 1 → `high` → **-20** (token drops harder than BTC). Skipped for stablecoins and tokens with <$1M 24h volume. |
+| `liquidity_risk` | +20 / -20 | Ratio of on-chain liquidity to market cap (`total_liquidity_usd / market_cap_usd`). Higher ratio → `low` → **+20** (deep books relative to cap). Very thin ratio → `high` → **-20**. |
+| `concentration_risk` | +10 / -10 | Top-10 holder concentration as a fraction of supply. `< 0.12` → `low` → **+10** (well-distributed). `> 0.55` → `high` → **-10** (whale-concentrated). |
+| `inflation_risk` | +10 / -10 | EMA of daily token supply inflation rate. Negative / near-zero → `low` → **+10** (stable or deflationary supply). Strongly positive → `high` → **-10** (high dilution). Only evaluated for tokens >= $100M market cap. |
+
+Other response fields:
+- `market_cap_group`: `lowcap` / `midcap` / `largecap` — see thresholds above.
+- `latest_date`: ISO datetime of the most recent indicator refresh for this token.
+- `last_trigger_on`: ISO datetime of the most recent trigger across contributing indicators (MAX aggregate — individual indicators may be days-to-months stale even when this looks fresh). Use `indicators` on a specific token to audit per-indicator ages.
+
+**Stablecoins rank high but aren't picks.** USDC, USDT, DAI, FDUSD and similar score well on chain_fees + liquidity indicators but aren't what "what should I buy" means. Filter them out of the shortlist using the canonical whitelist at `nansen-dbt-ch-tokens/seeds/stablecoins_for_indicator.csv` before drilling into `indicators`.
+
+Typical workflow: start with `top-tokens` for a shortlist → drop stablecoins → run `indicators` on the top 3–5 to inspect individual signals and their signal_percentile → `flow-intelligence` only on the finalists to confirm SM conviction.
+
+Field meanings and contribution mappings above are sourced from `nansen-dbt-ch-tokens/models/indicators/api_nansen_score_indicators_all_tokens_latest.sql` and per-indicator model yml files. Sign conventions and live value ranges were validated against production ClickHouse data.
 
 Flow intelligence is credit-heavy. Use it to confirm SM conviction on tokens that already look promising from screener + indicators, not as a first pass on every token.

--- a/skills/nansen-token-screener/SKILL.md
+++ b/skills/nansen-token-screener/SKILL.md
@@ -45,10 +45,18 @@ nansen research token indicators --token $TOKEN --chain $CHAIN
 # Flow intelligence — only use for promising tokens from screener/indicators above
 nansen research token flow-intelligence --token $TOKEN --chain $CHAIN
 # → net_flow_usd per label: smart_trader, whale, exchange, fresh_wallets, public_figure
+
+# Nansen Score Top Tokens — "what should I buy?" (internal, @nansen.ai only)
+# Use this FIRST for discovery, then drill into individual tokens with `indicators` above
+nansen research token top-tokens --limit 25
+nansen research token top-tokens --market-cap largecap --limit 10
+# → token_symbol, chain, performance_score, risk_score, plus per-indicator contribution fields
 ```
 
 Screener timeframes: `5m`, `10m`, `1h`, `6h`, `24h`, `7d`, `30d`
 
 Indicators: score is "bullish"/"bearish"/"neutral". signal_percentile > 70 = historically significant. Some tokens return empty indicators — not an error.
+
+Top tokens: performance_score >= 15 means buy candidate. risk_score > 0 means safer. Use `--market-cap` to filter by lowcap/midcap/largecap. Then use `indicators` on individual tokens for the full breakdown.
 
 Flow intelligence is credit-heavy. Use it to confirm SM conviction on tokens that already look promising from screener + indicators, not as a first pass on every token.

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -160,6 +160,19 @@ const MOCK_RESPONSES = {
       { indicator_type: 'price-momentum', score: 'bullish', signal: 0.75, signal_percentile: 85.5, last_trigger_on: '2025-01-10' }
     ]
   },
+  topTokens: {
+    tokens: [
+      {
+        token_address: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+        token_symbol: 'AAVE',
+        chain: 'ethereum',
+        performance_score: 72.5,
+        risk_score: 35.2,
+        price_momentum_performance: 0.85,
+        liquidity_risk: 0.15
+      }
+    ]
+  },
   tokenOhlcv: {
     candles: [
       { timestamp: '2025-01-15T00:00:00Z', open: 1.5, high: 1.8, low: 1.4, close: 1.7, volume: 1000000 }
@@ -1080,6 +1093,38 @@ describe('NansenAPI', () => {
 
         expect(result.risk_indicators).toBeInstanceOf(Array);
         expect(result.reward_indicators).toBeInstanceOf(Array);
+      });
+    });
+
+    describe('topTokens', () => {
+      it('should fetch top tokens with correct endpoint and body', async () => {
+        setupMock(MOCK_RESPONSES.topTokens);
+        const result = await api.topTokens({ limit: 10 });
+        const body = expectFetchCalledWith('/api/internal/nansen-score-top-tokens');
+        if (body) {
+          expect(body.limit).toBe(10);
+          expect(body.marketCapGroup).toBeUndefined();
+        }
+        expect(result.tokens).toBeInstanceOf(Array);
+      });
+
+      it('should pass marketCapGroup when provided', async () => {
+        setupMock(MOCK_RESPONSES.topTokens);
+        await api.topTokens({ marketCapGroup: 'largecap', limit: 5 });
+        const body = expectFetchCalledWith('/api/internal/nansen-score-top-tokens');
+        if (body) {
+          expect(body.marketCapGroup).toBe('largecap');
+          expect(body.limit).toBe(5);
+        }
+      });
+
+      it('should default limit to 25', async () => {
+        setupMock(MOCK_RESPONSES.topTokens);
+        await api.topTokens({});
+        const body = expectFetchCalledWith('/api/internal/nansen-score-top-tokens');
+        if (body) {
+          expect(body.limit).toBe(25);
+        }
       });
     });
 

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -161,7 +161,7 @@ const MOCK_RESPONSES = {
     ]
   },
   topTokens: {
-    tokens: [
+    data: [
       {
         token_address: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
         token_symbol: 'AAVE',
@@ -1105,7 +1105,7 @@ describe('NansenAPI', () => {
           expect(body.limit).toBe(10);
           expect(body.market_cap_group).toBeUndefined();
         }
-        expect(result.tokens).toBeInstanceOf(Array);
+        expect(result.data).toBeInstanceOf(Array);
       });
 
       it('should pass marketCapGroup when provided', async () => {

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -1100,10 +1100,10 @@ describe('NansenAPI', () => {
       it('should fetch top tokens with correct endpoint and body', async () => {
         setupMock(MOCK_RESPONSES.topTokens);
         const result = await api.topTokens({ limit: 10 });
-        const body = expectFetchCalledWith('/api/internal/nansen-score-top-tokens');
+        const body = expectFetchCalledWith('/api/v1/nansen-score/top-tokens');
         if (body) {
           expect(body.limit).toBe(10);
-          expect(body.marketCapGroup).toBeUndefined();
+          expect(body.market_cap_group).toBeUndefined();
         }
         expect(result.tokens).toBeInstanceOf(Array);
       });
@@ -1111,9 +1111,9 @@ describe('NansenAPI', () => {
       it('should pass marketCapGroup when provided', async () => {
         setupMock(MOCK_RESPONSES.topTokens);
         await api.topTokens({ marketCapGroup: 'largecap', limit: 5 });
-        const body = expectFetchCalledWith('/api/internal/nansen-score-top-tokens');
+        const body = expectFetchCalledWith('/api/v1/nansen-score/top-tokens');
         if (body) {
-          expect(body.marketCapGroup).toBe('largecap');
+          expect(body.market_cap_group).toBe('largecap');
           expect(body.limit).toBe(5);
         }
       });
@@ -1121,7 +1121,7 @@ describe('NansenAPI', () => {
       it('should default limit to 25', async () => {
         setupMock(MOCK_RESPONSES.topTokens);
         await api.topTokens({});
-        const body = expectFetchCalledWith('/api/internal/nansen-score-top-tokens');
+        const body = expectFetchCalledWith('/api/v1/nansen-score/top-tokens');
         if (body) {
           expect(body.limit).toBe(25);
         }

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -116,6 +116,7 @@ describe('CLI Smoke Tests', () => {
     const { stdout } = runCLI('research token help');
     expect(stdout).toContain('screener');
     expect(stdout).toContain('ohlcv');
+    expect(stdout).toContain('top-tokens');
   });
 
   it('should route research prediction-market commands', () => {

--- a/src/__tests__/coverage.test.js
+++ b/src/__tests__/coverage.test.js
@@ -46,6 +46,7 @@ const DOCUMENTED_ENDPOINTS = {
     { name: 'perp-trades', method: 'tokenPerpTrades', endpoint: '/api/v1/tgm/perp-trades' },
     { name: 'perp-positions', method: 'tokenPerpPositions', endpoint: '/api/v1/tgm/perp-positions' },
     { name: 'perp-pnl-leaderboard', method: 'tokenPerpPnlLeaderboard', endpoint: '/api/v1/tgm/perp-pnl-leaderboard' },
+    { name: 'top-tokens', method: 'topTokens', endpoint: '/api/internal/nansen-score-top-tokens' },
   ],
   composite: [
     { name: 'batch-profile', fn: batchProfile, endpoint: 'composite' },

--- a/src/__tests__/coverage.test.js
+++ b/src/__tests__/coverage.test.js
@@ -46,7 +46,7 @@ const DOCUMENTED_ENDPOINTS = {
     { name: 'perp-trades', method: 'tokenPerpTrades', endpoint: '/api/v1/tgm/perp-trades' },
     { name: 'perp-positions', method: 'tokenPerpPositions', endpoint: '/api/v1/tgm/perp-positions' },
     { name: 'perp-pnl-leaderboard', method: 'tokenPerpPnlLeaderboard', endpoint: '/api/v1/tgm/perp-pnl-leaderboard' },
-    { name: 'top-tokens', method: 'topTokens', endpoint: '/api/internal/nansen-score-top-tokens' },
+    { name: 'top-tokens', method: 'topTokens', endpoint: '/api/v1/nansen-score/top-tokens' },
   ],
   composite: [
     { name: 'batch-profile', fn: batchProfile, endpoint: 'composite' },

--- a/src/api.js
+++ b/src/api.js
@@ -1203,6 +1203,13 @@ export class NansenAPI {
     });
   }
 
+  async topTokens(params = {}) {
+    const { marketCapGroup, limit = 25 } = params;
+    const body = { limit };
+    if (marketCapGroup) body.marketCapGroup = marketCapGroup;
+    return this.request('/api/internal/nansen-score-top-tokens', body);
+  }
+
   // ============= Perp Endpoints =============
 
   async perpScreener(params = {}) {

--- a/src/api.js
+++ b/src/api.js
@@ -1206,8 +1206,8 @@ export class NansenAPI {
   async topTokens(params = {}) {
     const { marketCapGroup, limit = 25 } = params;
     const body = { limit };
-    if (marketCapGroup) body.marketCapGroup = marketCapGroup;
-    return this.request('/api/internal/nansen-score-top-tokens', body);
+    if (marketCapGroup) body.market_cap_group = marketCapGroup;
+    return this.request('/api/v1/nansen-score/top-tokens', body);
   }
 
   // ============= Perp Endpoints =============

--- a/src/cli.js
+++ b/src/cli.js
@@ -1276,8 +1276,13 @@ export function buildCommands(deps = {}) {
           const withLabels = resolveBooleanOption(options, flags, 'premium-labels');
           return apiInstance.tokenPerpPnlLeaderboard({ tokenSymbol, filters, orderBy, pagination, days, withLabels });
         },
+        'top-tokens': () => {
+          const marketCapGroup = options['market-cap'] || options['market-cap-group'];
+          const limit = options.limit ? parseInt(options.limit) : undefined;
+          return apiInstance.topTokens({ marketCapGroup, limit });
+        },
         'help': () => ({
-          commands: ['info', 'ohlcv', 'screener', 'holders', 'flows', 'dex-trades', 'pnl', 'who-bought-sold', 'flow-intelligence', 'transfers', 'jup-dca', 'perp-trades', 'perp-positions', 'perp-pnl-leaderboard'],
+          commands: ['info', 'ohlcv', 'screener', 'holders', 'flows', 'dex-trades', 'pnl', 'who-bought-sold', 'flow-intelligence', 'transfers', 'jup-dca', 'perp-trades', 'perp-positions', 'perp-pnl-leaderboard', 'top-tokens'],
           description: 'Token God Mode endpoints',
           example: 'nansen token screener --chain solana --timeframe 24h --smart-money --include-stablecoins false'
         })

--- a/src/schema.json
+++ b/src/schema.json
@@ -500,6 +500,19 @@
                   "default": true
                 }
               }
+            },
+            "top-tokens": {
+              "endpoint": "/api/internal/nansen-score-top-tokens",
+              "description": "Top tokens ranked by Nansen Score (internal, requires @nansen.ai account)",
+              "options": {
+                "market-cap": {
+                  "description": "Filter by market cap group",
+                  "enum": ["lowcap", "midcap", "largecap"]
+                },
+                "limit": {
+                  "default": 25
+                }
+              }
             }
           },
           "description": "Token God Mode - deep analytics for any token"

--- a/src/schema.json
+++ b/src/schema.json
@@ -502,8 +502,8 @@
               }
             },
             "top-tokens": {
-              "endpoint": "/api/internal/nansen-score-top-tokens",
-              "description": "Top tokens ranked by Nansen Score (internal, requires @nansen.ai account)",
+              "endpoint": "/api/v1/nansen-score/top-tokens",
+              "description": "Top tokens ranked by Nansen Score (public endpoint, any authenticated API key)",
               "options": {
                 "market-cap": {
                   "description": "Filter by market cap group",


### PR DESCRIPTION
## Summary

Wires `nansen research token top-tokens` to the new public endpoint `/api/v1/nansen-score/top-tokens` (shipped in nansen-api [#1113](https://github.com/nansen-ai/nansen-api/pull/1113)) and fleshes out the SKILL.md scoring field reference so downstream agents can interpret the response correctly.

Closes the two pieces of feedback from the previous PR ([#409](https://github.com/nansen-ai/nansen-cli/pull/409)):

1. **"Should be using the external-facing endpoint"** (Marius) — now calls the public `/api/v1` path.
2. **"Field definitions are missing, agent will hallucinate interpretations"** (@0xlaveen) — SKILL.md now carries source-validated definitions for every scoring component.

## What changed

- `src/api.js` — endpoint path + snake_case `market_cap_group` body key
- `src/schema.json` + tests (`api.test.js`, `coverage.test.js`) — mirror the endpoint swap
- `skills/nansen-token-screener/SKILL.md` — full Nansen Score field reference:
  - Server-side sort order + `performance_score >= 15` pre-filter
  - Market-cap bucket thresholds
  - Per-indicator contribution (+/- ternary), upstream trigger, and underlying measurement for all 9 scoring components
  - Stablecoin caveat pointing at `nansen-dbt-ch-tokens/seeds/stablecoins_for_indicator.csv` (so agents drop USDC/USDT/DAI from "what should I buy" shortlists)
  - `last_trigger_on` MAX-aggregate caveat (contributing indicators can be days-to-months stale behind the fresh max)
- `.changeset/top-tokens-nansen-score.md` — endpoint path updated in release note

## Verification

- **Sign conventions + contribution values**: validated against production ClickHouse (2026-04-21 snapshot, 1,930 tokens). All 9 columns confirmed ternary `{negative, 0, positive}`; every sign documented matches live data.
- **Source of truth**: field meanings and contribution mappings sourced from `nansen-dbt-ch-tokens/models/indicators/api_nansen_score_indicators_all_tokens_latest.sql` and per-indicator model yml files (attribution footer in SKILL.md).
- **Access control**: confirmed against merged `_public_router` in `wrapper/routers/nansen_score_top_tokens.py` — endpoint is public (any authenticated API key), not gated to internal users.

## Test plan

- [x] `npm test` — 1323 passed, 2 skipped (unchanged from main)
- [x] `npm run lint` — clean
- [x] `node src/index.js schema token` shows new endpoint
- [x] `node src/index.js token help` lists `top-tokens` subcommand