### PR TITLE
fix(trading): disable Relay aggregator for cross-chain quotes until CLI tracks aggregator per-quote

### DIFF
--- a/src/trading.js
+++ b/src/trading.js
@@ -1167,6 +1167,11 @@ CROSS-CHAIN NOTES (when using --to-chain):
         };
         if (isCrossChain) {
           params.toChainIndex = toChainConfig.index;
+          // Disable Relay until CLI can track per-quote aggregator and pass it
+          // to getBridgeStatus(). Without this, a Relay-selected quote would be
+          // polled via LiFi's status API, returning wrong/not-found status and
+          // breaking `trade wait`. Remove once CLI sends aggregator to getBridgeStatus.
+          params.disabledAggregators = 'relay';
           if (toWallet) {
             params.toWalletAddress = toWallet;
             log(`  Destination wallet: ${toWallet}`);


### PR DESCRIPTION
## Problem

After superapp PR [#12959](https://github.com/nansen-ai/superapp/pull/12959) merges (Relay cross-chain aggregator), the trading backend will fan out cross-chain quotes to both LiFi and Relay. The CLI may then receive a Relay-selected quote as the best option for Base↔Solana.

The CLI bypasses the backend `/execute` endpoint, so:
1. The Redis aggregator hint (`trading:bridge-aggregator:${txHash}`) is never populated.
2. `getBridgeStatus()` in `src/trading.js:214` sends no `aggregator` param → backend defaults to LiFi's status API.
3. Polling a Relay txHash via LiFi's status endpoint returns wrong/not-found status → breaks `trade wait`.

## Fix

Add `params.disabledAggregators = 'relay'` in the cross-chain branch of the quote command (line ~1169, after `params.toChainIndex = toChainConfig.index`).

This keeps cross-chain routing on LiFi (current behavior) and is a no-op for older superapp deployments (backend ignores unknown params).

## Follow-up required

Remove this once the CLI is updated to:
- Track the selected aggregator per quote
- Pass `aggregator` param to `getBridgeStatus()`