### PR TITLE
fix: opt out of Relay aggregator for cross-chain quotes

### DIFF
--- a/src/trading.js
+++ b/src/trading.js
@@ -1167,6 +1167,10 @@ CROSS-CHAIN NOTES (when using --to-chain):
         };
         if (isCrossChain) {
           params.toChainIndex = toChainConfig.index;
+          // Opt out of Relay aggregator: CLI bypasses backend /execute so the
+          // Redis aggregator hint is never set, and /bridge/status defaults to
+          // LiFi — polling a Relay txHash there returns NOT_FOUND.
+          params.disabledAggregators = 'relay';
           if (toWallet) {
             params.toWalletAddress = toWallet;
             log(`  Destination wallet: ${toWallet}`);


### PR DESCRIPTION
## Problem

After superapp PR #12959 merges, the trading backend fans out cross-chain quotes to both LiFi and Relay, and may select Relay as best quote for Base↔Solana.

The CLI bypasses the backend `/execute` endpoint, so the Redis aggregator hint (`trading:bridge-aggregator:${txHash}`) is never populated. `getBridgeStatus()` in `src/trading.js` sends no `aggregator` param, so the backend defaults to LiFi. Polling a Relay txHash via LiFi's status endpoint returns `NOT_FOUND`, breaking `trade wait` with infinite polling / wrong status.

## Fix

In the cross-chain branch of quote params construction, add:

```js
params.disabledAggregators = 'relay';
```

This keeps cross-chain quotes on LiFi (current behaviour). It is a no-op against older superapp deployments that don't recognise the param (unknown query params are silently ignored by the Hono handler).

## Compatibility

- ✅ Safe against older superapp backends — unknown params ignored
- ✅ No execution-path changes — signing and submission unchanged

## Follow-up (separate PR, not blocking)

Track `response.quotes[0].aggregator` on the quote response, pass it to `getBridgeStatus()` as `aggregator=<name>`, then remove the `disabledAggregators` opt-out so the CLI benefits from Relay's faster Base↔Solana bridging (~2–3s vs 30s–5min for LiFi).