### PR TITLE
fix: dogfood cleanup

### DIFF
--- a/.changeset/add-alerts-command.md
+++ b/.changeset/add-alerts-command.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add nansen alerts command for managing smart alerts (list, create, update, toggle, delete)

--- a/.changeset/add-alerts-command.md
+++ b/.changeset/add-alerts-command.md
@@ -2,4 +2,10 @@
 "nansen-cli": minor
 ---
 
-Add nansen alerts command for managing smart alerts (list, create, update, toggle, delete)
+Add `nansen alerts` command for managing smart alerts (list, create, update, toggle, delete).
+
+Supports three alert types: `sm-token-flows`, `common-token-transfer`, and `smart-contract-call`.
+Named flags (`--inflow-1h-min`, `--chains`, `--telegram`, etc.) let you build alerts without raw JSON;
+a `--data` escape hatch is available for full config overrides.
+
+Also adds a `nansen-alerts` skill for agent integration.

--- a/.changeset/alerts-list-table-view.md
+++ b/.changeset/alerts-list-table-view.md
@@ -1,5 +1,0 @@
----
-"nansen-cli": patch
----
-
-Add human-readable table view for alerts list --table

--- a/.changeset/alerts-list-table-view.md
+++ b/.changeset/alerts-list-table-view.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Add human-readable table view for alerts list --table

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Run `nansen schema --pretty` for the full subcommand and field reference.
 
 **Reduce token burn with `--fields`:**
 ```bash
-nansen research smart-money netflow --chain solana --fields token_symbol,net_flow_usd --limit 10
+nansen research smart-money netflow --chain solana --fields token_symbol,net_flow_24h_usd --limit 10
 ```
 
 **Use `--stream` for large results** — outputs NDJSON instead of buffering a giant array.

--- a/skills/nansen-alerts/SKILL.md
+++ b/skills/nansen-alerts/SKILL.md
@@ -242,17 +242,11 @@ Track smart contract call events when the system detects contract interactions m
     ],
     "smartContract": [
       { "type": "address|entity|label|custom-label", "value": "Uniswap V3" }
-    ],
-    "tokenIn": [
-      { "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "chain": "ethereum" }
-    ],
-    "tokenOut": []
+    ]
   },
   "exclusion": {
     "caller": [],
-    "smartContract": [],
-    "tokenIn": [],
-    "tokenOut": []
+    "smartContract": []
   }
 }
 ```
@@ -263,8 +257,7 @@ Track smart contract call events when the system detects contract interactions m
 - `signatureHash`: Function signature hashes to monitor (e.g., `0x095ea7b3` for `approve`). Empty array tracks all function calls.
 - `inclusion.caller`: Caller addresses/entities/labels to track. Empty array tracks all callers.
 - `inclusion.smartContract`: Contract addresses/entities/labels to monitor. Empty array tracks all contracts.
-- `inclusion.tokenIn` / `tokenOut`: Input/output tokens involved in the call.
-- `exclusion`: Callers/contracts/tokens to ignore.
+- `exclusion`: Callers/contracts to exclude.
 
 **Example:**
 ```bash

--- a/skills/nansen-alerts/SKILL.md
+++ b/skills/nansen-alerts/SKILL.md
@@ -23,7 +23,7 @@ CRUD management for smart alerts. Alerts are internal-only (requires Nansen inte
 ## List
 
 ```bash
-nansen alerts list --pretty
+nansen alerts list --table
 ```
 
 ## Create
@@ -299,5 +299,5 @@ Multiple channels can be combined: `--telegram 123 --slack https://...`
 ## Notes
 
 - Alert endpoints are internal-only. Non-internal users receive 404.
-- `--channels` and `--data` accept JSON strings.
+- `--data` accepts a JSON string.
 - `list` returns an array directly.

--- a/skills/nansen-alerts/SKILL.md
+++ b/skills/nansen-alerts/SKILL.md
@@ -35,29 +35,29 @@ nansen alerts create --name "ETH SM Flows" --type sm-token-flows --time-window 1
 ## Update
 
 ```bash
-nansen alerts update --id <alert-id> --name "New Name" --pretty
+nansen alerts update <alert-id> --name "New Name" --pretty
 ```
 
-All create options are optional for update (only `--id` is required).
+All create options are optional for update (only `<alert-id>` is required as first positional arg).
 
 ## Toggle
 
 ```bash
-nansen alerts toggle --id <alert-id> --enabled
-nansen alerts toggle --id <alert-id> --disabled
+nansen alerts toggle <alert-id> --enabled
+nansen alerts toggle <alert-id> --disabled
 ```
 
 ## Delete
 
 ```bash
-nansen alerts delete --id <alert-id>
+nansen alerts delete <alert-id>
 ```
 
 ## Options Reference
 
 | Flag | Create | Update | Toggle | Delete |
 |------|--------|--------|--------|--------|
-| `--id` | | required | required | required |
+| `<id>` (positional) | | required | required | required |
 | `--name` | required | optional | | |
 | `--type` | required | optional | | |
 | `--time-window` | required | optional | | |
@@ -72,8 +72,217 @@ nansen alerts delete --id <alert-id>
 
 ## Alert Types
 
-- `sm-token-flows` — Smart money token flow alerts
-- `common-token-transfer` — Common token transfer alerts
+Three alert types are supported, each with a different `--data` schema:
+
+### 1. `sm-token-flows` — Smart Money Token Flows
+
+Track Smart Money aggregated inflow/outflow over time windows. At least one time window threshold must be specified.
+
+**Required fields:**
+- `--name`: Alert title
+- `--type sm-token-flows`
+- `--time-window 1h` (fixed for this type)
+- At least one channel (`--telegram`, `--slack`, or `--discord`)
+
+**Data schema:**
+```json
+{
+  "chains": ["ethereum", "solana", "base", ...],
+  "inflow_1h": { "min": 5000000, "max": null },
+  "inflow_1d": { "min": null, "max": null },
+  "inflow_7d": { "min": null, "max": null },
+  "outflow_1h": { "min": null, "max": null },
+  "outflow_1d": { "min": null, "max": null },
+  "outflow_7d": { "min": null, "max": null },
+  "netflow_1h": { "min": null, "max": null },
+  "netflow_1d": { "min": null, "max": null },
+  "netflow_7d": { "min": null, "max": null },
+  "inclusion": {
+    "tokens": [
+      { "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "chain": "ethereum" }
+    ],
+    "tokenSectors": ["DeFi", "Gaming"],
+    "marketCap": { "min": 1000000, "max": 100000000 },
+    "fdv": { "min": null, "max": null }
+  },
+  "exclusion": {
+    "tokens": [],
+    "tokenSectors": ["Meme"]
+  }
+}
+```
+
+**Field descriptions:**
+- `chains`: Array of chain names. Use `["all"]` if not specified.
+- `inflow_*` / `outflow_*` / `netflow_*`: USD thresholds for time windows (1h, 1d, 7d). Use `inflow` to track smart money buying/receiving, `outflow` for selling/sending. Min/max must be positive numbers.
+- `inclusion.tokens`: Specific tokens to monitor. Empty array tracks all tokens.
+- `inclusion.tokenSectors`: Token sectors to monitor. Empty array tracks all sectors.
+- `inclusion.marketCap` / `fdv`: Market cap / FDV range filters (USD).
+- `exclusion`: Tokens/sectors to ignore.
+
+**Example:**
+```bash
+nansen alerts create \
+  --name "Smart Money ETH Buying Alert" \
+  --type sm-token-flows \
+  --time-window 1h \
+  --chains ethereum \
+  --telegram 5238612255 \
+  --description 'Alert when smart money inflow exceeds $5M in 1 hour for ETH' \
+  --data '{
+    "chains": ["ethereum"],
+    "inflow_1h": {"min": 5000000},
+    "inclusion": {
+      "tokens": [{"address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "chain": "ethereum"}]
+    }
+  }'
+```
+
+### 2. `common-token-transfer` — Token Transfer Events
+
+Track real-time token transfer events on the blockchain. Triggers when transfers match your specified criteria.
+
+**Required fields:**
+- `--name`: Alert title
+- `--type common-token-transfer`
+- `--time-window realtime` (fixed for this type)
+- At least one channel
+
+**Data schema:**
+```json
+{
+  "subjects": [
+    { "type": "address|entity|label|custom-label", "value": "0x..." }
+  ],
+  "chains": ["ethereum", "solana", ...],
+  "events": ["buy", "sell", "swap", "send", "receive"],
+  "counterparties": [
+    { "type": "address|entity|label|custom-label", "value": "CEX" }
+  ],
+  "usdValue": { "min": 1000000, "max": null },
+  "tokenAmount": { "min": 100, "max": null },
+  "inclusion": {
+    "tokens": [
+      { "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "chain": "ethereum" }
+    ],
+    "tokenSectors": ["DeFi"],
+    "tokenAge": { "min": 7, "max": 365 },
+    "marketCap": { "min": 1000000, "max": null }
+  },
+  "exclusion": {
+    "tokens": [],
+    "tokenSectors": [],
+    "tokenAge": { "min": null, "max": null }
+  }
+}
+```
+
+**Field descriptions:**
+- `subjects`: The addresses/entities/labels to track. Empty array tracks all addresses. Required if `counterparties` is specified.
+- `chains`: Blockchain networks to monitor.
+- `events`: Transaction types to track:
+  - `buy`: Token swapped from native/stablecoin to other token
+  - `sell`: Token swapped to native/stablecoin
+  - `swap`: Any token-to-token swap
+  - `send`: Outgoing transfer
+  - `receive`: Incoming transfer
+  - Empty array tracks all events
+- `counterparties`: Secondary targets (e.g., CEX, specific wallets). Can only be set when `subjects` is specified. Prefer using `subjects` with opposite event direction.
+- `usdValue` / `tokenAmount`: Value/quantity thresholds. Empty object `{}` tracks all values.
+- `inclusion.tokens`: Specific tokens to monitor. Empty array tracks all tokens.
+- `inclusion.tokenAge`: Token age range in days.
+- `inclusion.marketCap`: Market cap range (USD).
+- `exclusion`: Filters to exclude from alerts.
+
+**Important notes:**
+- The `buy` event for counterparties = `sell` event for subjects
+- The `send` event for counterparties = `receive` event for subjects
+- To track "any addresses sending to CEX", use `subjects` with `receive` event, NOT `counterparties` with `send` event
+
+**Example:**
+```bash
+nansen alerts create \
+  --name "Large USDC Transfers Alert" \
+  --type common-token-transfer \
+  --time-window realtime \
+  --chains ethereum \
+  --telegram 123456789 \
+  --description 'Alert when USDC transfers exceed $1M on Ethereum mainnet' \
+  --data '{
+    "chains": ["ethereum"],
+    "events": ["send", "receive"],
+    "inclusion": {
+      "tokens": [
+        {"address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "chain": "ethereum"}
+      ]
+    },
+    "usdValue": {"min": 1000000}
+  }'
+```
+
+### 3. `smart-contract-call` — Smart Contract Interactions
+
+Track smart contract call events when the system detects contract interactions matching your criteria.
+
+**Required fields:**
+- `--name`: Alert title
+- `--type smart-contract-call`
+- `--time-window realtime` (fixed for this type)
+- At least one channel
+
+**Data schema:**
+```json
+{
+  "chains": ["ethereum", "base", ...],
+  "usdValue": { "min": 100000, "max": null },
+  "signatureHash": ["0x095ea7b3", "0xa9059cbb"],
+  "inclusion": {
+    "caller": [
+      { "type": "address|entity|label|custom-label", "value": "0x..." }
+    ],
+    "smartContract": [
+      { "type": "address|entity|label|custom-label", "value": "Uniswap V3" }
+    ],
+    "tokenIn": [
+      { "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "chain": "ethereum" }
+    ],
+    "tokenOut": []
+  },
+  "exclusion": {
+    "caller": [],
+    "smartContract": [],
+    "tokenIn": [],
+    "tokenOut": []
+  }
+}
+```
+
+**Field descriptions:**
+- `chains`: Blockchain networks to monitor.
+- `usdValue`: USD value threshold for contract calls. Empty object `{}` tracks all values.
+- `signatureHash`: Function signature hashes to monitor (e.g., `0x095ea7b3` for `approve`). Empty array tracks all function calls.
+- `inclusion.caller`: Caller addresses/entities/labels to track. Empty array tracks all callers.
+- `inclusion.smartContract`: Contract addresses/entities/labels to monitor. Empty array tracks all contracts.
+- `inclusion.tokenIn` / `tokenOut`: Input/output tokens involved in the call.
+- `exclusion`: Callers/contracts/tokens to ignore.
+
+**Example:**
+```bash
+nansen alerts create \
+  --name "Uniswap V3 Large Swaps" \
+  --type smart-contract-call \
+  --time-window realtime \
+  --chains ethereum \
+  --telegram 123456789 \
+  --description 'Alert on large swaps through Uniswap V3' \
+  --data '{
+    "chains": ["ethereum"],
+    "usdValue": {"min": 1000000},
+    "inclusion": {
+      "smartContract": [{"type": "entity", "value": "Uniswap V3"}]
+    }
+  }'
+```
 
 ## Channels
 

--- a/skills/nansen-alerts/SKILL.md
+++ b/skills/nansen-alerts/SKILL.md
@@ -20,37 +20,14 @@ allowed-tools: Bash(nansen:*)
 
 CRUD management for smart alerts. Alerts are internal-only (requires Nansen internal API key).
 
-## List
+## Quick Reference
 
 ```bash
 nansen alerts list --table
-```
-
-## Create
-
-```bash
-nansen alerts create --name "ETH SM Flows" --type sm-token-flows --time-window 1h --chains ethereum --telegram 5238612255 --data '{"events":["sm-token-flows"],"inclusion":{"tokens":[{"chain":"ethereum","address":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"}]},"exclusion":{},"inflow_1h":{"min":100000},"inflow_1d":{},"inflow_7d":{},"outflow_1h":{},"outflow_1d":{},"outflow_7d":{}}' --pretty
-```
-
-## Update
-
-```bash
-nansen alerts update <alert-id> --name "New Name" --pretty
-```
-
-All create options are optional for update (only `<alert-id>` is required as first positional arg).
-
-## Toggle
-
-```bash
-nansen alerts toggle <alert-id> --enabled
-nansen alerts toggle <alert-id> --disabled
-```
-
-## Delete
-
-```bash
-nansen alerts delete <alert-id>
+nansen alerts create --name <name> --type <type> --chains <chains> --telegram <chatId>
+nansen alerts update <id> [--name <name>] [--chains <chains>]
+nansen alerts toggle <id> --enabled|--disabled
+nansen alerts delete <id>
 ```
 
 ## Options Reference
@@ -60,237 +37,100 @@ nansen alerts delete <alert-id>
 | `<id>` (positional) | | required | required | required |
 | `--name` | required | optional | | |
 | `--type` | required | optional | | |
-| `--time-window` | required | optional | | |
 | `--chains` | recommended | optional | | |
 | `--telegram` | chat ID | optional | | |
 | `--slack` | webhook URL | optional | | |
 | `--discord` | webhook URL | optional | | |
-| `--data` | optional (JSON) | optional (JSON) | | |
 | `--description` | optional | optional | | |
 | `--enabled` | | flag | flag | |
 | `--disabled` | flag | flag | flag | |
+| `--data` | optional (JSON escape hatch) | optional | | |
 
 ## Alert Types
 
-Three alert types are supported, each with a different `--data` schema:
-
 ### 1. `sm-token-flows` — Smart Money Token Flows
 
-Track Smart Money aggregated inflow/outflow over time windows. At least one time window threshold must be specified.
+Track aggregated SM inflow/outflow. At least one flow threshold should be specified.
 
-**Required fields:**
-- `--name`: Alert title
-- `--type sm-token-flows`
-- `--time-window 1h` (fixed for this type)
-- At least one channel (`--telegram`, `--slack`, or `--discord`)
-
-**Data schema:**
-```json
-{
-  "chains": ["ethereum", "solana", "base", ...],
-  "inflow_1h": { "min": 5000000, "max": null },
-  "inflow_1d": { "min": null, "max": null },
-  "inflow_7d": { "min": null, "max": null },
-  "outflow_1h": { "min": null, "max": null },
-  "outflow_1d": { "min": null, "max": null },
-  "outflow_7d": { "min": null, "max": null },
-  "netflow_1h": { "min": null, "max": null },
-  "netflow_1d": { "min": null, "max": null },
-  "netflow_7d": { "min": null, "max": null },
-  "inclusion": {
-    "tokens": [
-      { "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "chain": "ethereum" }
-    ],
-    "tokenSectors": ["DeFi", "Gaming"],
-    "marketCap": { "min": 1000000, "max": 100000000 },
-    "fdv": { "min": null, "max": null }
-  },
-  "exclusion": {
-    "tokens": [],
-    "tokenSectors": ["Meme"]
-  }
-}
-```
-
-**Field descriptions:**
-- `chains`: Array of chain names. Use `["all"]` if not specified.
-- `inflow_*` / `outflow_*` / `netflow_*`: USD thresholds for time windows (1h, 1d, 7d). Use `inflow` to track smart money buying/receiving, `outflow` for selling/sending. Min/max must be positive numbers.
-- `inclusion.tokens`: Specific tokens to monitor. Empty array tracks all tokens.
-- `inclusion.tokenSectors`: Token sectors to monitor. Empty array tracks all sectors.
-- `inclusion.marketCap` / `fdv`: Market cap / FDV range filters (USD).
-- `exclusion`: Tokens/sectors to ignore.
+**Type-specific flags:**
+- `--inflow-1h-min/max`, `--inflow-1d-min/max`, `--inflow-7d-min/max` (USD thresholds)
+- `--outflow-1h-min/max`, `--outflow-1d-min/max`, `--outflow-7d-min/max`
+- `--netflow-1h-min/max`, `--netflow-1d-min/max`, `--netflow-7d-min/max`
+- `--token <address:chain>` (repeatable) — include specific tokens
+- `--exclude-token <address:chain>` (repeatable)
+- `--token-sector <name>` / `--exclude-token-sector <name>` (repeatable)
+- `--token-age-max <days>`
+- `--market-cap-min/max <usd>`, `--fdv-min/max <usd>`
 
 **Example:**
 ```bash
 nansen alerts create \
-  --name "Smart Money ETH Buying Alert" \
+  --name 'SM ETH Inflow >5M' \
   --type sm-token-flows \
-  --time-window 1h \
   --chains ethereum \
   --telegram 5238612255 \
-  --description 'Alert when smart money inflow exceeds $5M in 1 hour for ETH' \
-  --data '{
-    "chains": ["ethereum"],
-    "inflow_1h": {"min": 5000000},
-    "inclusion": {
-      "tokens": [{"address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "chain": "ethereum"}]
-    }
-  }'
+  --inflow-1h-min 5000000 \
+  --token 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2:ethereum
 ```
 
 ### 2. `common-token-transfer` — Token Transfer Events
 
-Track real-time token transfer events on the blockchain. Triggers when transfers match your specified criteria.
+Track real-time transfer events matching specified criteria.
 
-**Required fields:**
-- `--name`: Alert title
-- `--type common-token-transfer`
-- `--time-window realtime` (fixed for this type)
-- At least one channel
+**Subject types:** `address`, `entity`, `label`, `custom-label`
+Format: `--subject type:value` (e.g. `--subject label:"Centralized Exchange"`)
 
-**Data schema:**
-```json
-{
-  "subjects": [
-    { "type": "address|entity|label|custom-label", "value": "0x..." }
-  ],
-  "chains": ["ethereum", "solana", ...],
-  "events": ["buy", "sell", "swap", "send", "receive"],
-  "counterparties": [
-    { "type": "address|entity|label|custom-label", "value": "CEX" }
-  ],
-  "usdValue": { "min": 1000000, "max": null },
-  "tokenAmount": { "min": 100, "max": null },
-  "inclusion": {
-    "tokens": [
-      { "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "chain": "ethereum" }
-    ],
-    "tokenSectors": ["DeFi"],
-    "tokenAge": { "min": 7, "max": 365 },
-    "marketCap": { "min": 1000000, "max": null }
-  },
-  "exclusion": {
-    "tokens": [],
-    "tokenSectors": [],
-    "tokenAge": { "min": null, "max": null }
-  }
-}
-```
+**Type-specific flags:**
+- `--events <buy,sell,swap,send,receive>` (comma-separated)
+- `--usd-min/max <usd>`, `--token-amount-min/max <n>`
+- `--subject <type:value>` (repeatable) — addresses/entities/labels to track
+- `--counterparty <type:value>` (repeatable) — requires `--subject`
+- `--token <address:chain>` / `--exclude-token <address:chain>` (repeatable)
+- `--token-sector <name>` / `--exclude-token-sector <name>` (repeatable)
+- `--token-age-min/max <days>`, `--market-cap-min/max <usd>`
+- `--exclude-from <type:value>` / `--exclude-to <type:value>` (repeatable)
 
-**Field descriptions:**
-- `subjects`: The addresses/entities/labels to track. Empty array tracks all addresses. Required if `counterparties` is specified.
-- `chains`: Blockchain networks to monitor.
-- `events`: Transaction types to track:
-  - `buy`: Token swapped from native/stablecoin to other token
-  - `sell`: Token swapped to native/stablecoin
-  - `swap`: Any token-to-token swap
-  - `send`: Outgoing transfer
-  - `receive`: Incoming transfer
-  - Empty array tracks all events
-- `counterparties`: Secondary targets (e.g., CEX, specific wallets). Can only be set when `subjects` is specified. Prefer using `subjects` with opposite event direction.
-- `usdValue` / `tokenAmount`: Value/quantity thresholds. Empty object `{}` tracks all values.
-- `inclusion.tokens`: Specific tokens to monitor. Empty array tracks all tokens.
-- `inclusion.tokenAge`: Token age range in days.
-- `inclusion.marketCap`: Market cap range (USD).
-- `exclusion`: Filters to exclude from alerts.
-
-**Important notes:**
-- The `buy` event for counterparties = `sell` event for subjects
-- The `send` event for counterparties = `receive` event for subjects
-- To track "any addresses sending to CEX", use `subjects` with `receive` event, NOT `counterparties` with `send` event
+**Event direction notes:**
+- `buy` for counterparties = `sell` for subjects
+- `send` for counterparties = `receive` for subjects
+- To track "any address sending to CEX": use `--subject` with `receive`, not `--counterparty` with `send`
 
 **Example:**
 ```bash
 nansen alerts create \
-  --name "Large USDC Transfers Alert" \
+  --name 'Large USDC Transfers' \
   --type common-token-transfer \
-  --time-window realtime \
   --chains ethereum \
   --telegram 123456789 \
-  --description 'Alert when USDC transfers exceed $1M on Ethereum mainnet' \
-  --data '{
-    "chains": ["ethereum"],
-    "events": ["send", "receive"],
-    "inclusion": {
-      "tokens": [
-        {"address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "chain": "ethereum"}
-      ]
-    },
-    "usdValue": {"min": 1000000}
-  }'
+  --events send,receive \
+  --usd-min 1000000 \
+  --token 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48:ethereum
 ```
 
 ### 3. `smart-contract-call` — Smart Contract Interactions
 
-Track smart contract call events when the system detects contract interactions matching your criteria.
+Track contract calls matching specified criteria.
 
-**Required fields:**
-- `--name`: Alert title
-- `--type smart-contract-call`
-- `--time-window realtime` (fixed for this type)
-- At least one channel
-
-**Data schema:**
-```json
-{
-  "chains": ["ethereum", "base", ...],
-  "usdValue": { "min": 100000, "max": null },
-  "signatureHash": ["0x095ea7b3", "0xa9059cbb"],
-  "inclusion": {
-    "caller": [
-      { "type": "address|entity|label|custom-label", "value": "0x..." }
-    ],
-    "smartContract": [
-      { "type": "address|entity|label|custom-label", "value": "Uniswap V3" }
-    ]
-  },
-  "exclusion": {
-    "caller": [],
-    "smartContract": []
-  }
-}
-```
-
-**Field descriptions:**
-- `chains`: Blockchain networks to monitor.
-- `usdValue`: USD value threshold for contract calls. Empty object `{}` tracks all values.
-- `signatureHash`: Function signature hashes to monitor (e.g., `0x095ea7b3` for `approve`). Empty array tracks all function calls.
-- `inclusion.caller`: Caller addresses/entities/labels to track. Empty array tracks all callers.
-- `inclusion.smartContract`: Contract addresses/entities/labels to monitor. Empty array tracks all contracts.
-- `exclusion`: Callers/contracts to exclude.
+**Type-specific flags:**
+- `--usd-min/max <usd>`
+- `--signature-hash <hash>` (repeatable, e.g. `0x095ea7b3` for `approve`)
+- `--caller <type:value>` / `--exclude-caller <type:value>` (repeatable)
+- `--contract <type:value>` / `--exclude-contract <type:value>` (repeatable)
 
 **Example:**
 ```bash
 nansen alerts create \
-  --name "Uniswap V3 Large Swaps" \
+  --name 'Uniswap V3 Large Swaps' \
   --type smart-contract-call \
-  --time-window realtime \
   --chains ethereum \
   --telegram 123456789 \
-  --description 'Alert on large swaps through Uniswap V3' \
-  --data '{
-    "chains": ["ethereum"],
-    "usdValue": {"min": 1000000},
-    "inclusion": {
-      "smartContract": [{"type": "entity", "value": "Uniswap V3"}]
-    }
-  }'
+  --usd-min 1000000 \
+  --contract entity:"Uniswap V3"
 ```
-
-## Channels
-
-Shorthand flags (preferred):
-```bash
---telegram 123456
---slack https://hooks.slack.com/services/...
---discord https://discord.com/api/webhooks/...
-```
-
-Multiple channels can be combined: `--telegram 123 --slack https://...`
-
 
 ## Notes
 
+- Chain aliases: Hyperliquid = `hyperevm`, BSC = `bnb`.
+- Multiple channels can be combined: `--telegram 123 --slack https://...`
+- `--data '<json>'` merges raw JSON on top of named flags (escape hatch for fields without named flags).
 - Alert endpoints are internal-only. Non-internal users receive 404.
-- `--data` accepts a JSON string.
-- `list` returns an array directly.

--- a/skills/nansen-alerts/SKILL.md
+++ b/skills/nansen-alerts/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: nansen-alerts
+description: Manage smart alerts — list, create, update, toggle, delete. Use when setting up or managing token flow alerts, smart money alerts, or notification rules.
+metadata:
+  openclaw:
+    requires:
+      env:
+        - NANSEN_API_KEY
+      bins:
+        - nansen
+    primaryEnv: NANSEN_API_KEY
+    install:
+      - kind: node
+        package: nansen-cli
+        bins: [nansen]
+allowed-tools: Bash(nansen:*)
+---
+
+# Smart Alerts
+
+CRUD management for smart alerts. Alerts are internal-only (requires Nansen internal API key).
+
+## List
+
+```bash
+nansen alerts list --pretty
+```
+
+## Create
+
+```bash
+nansen alerts create --name "ETH SM Flows" --type sm-token-flows --time-window 1h --chains ethereum --telegram 5238612255 --data '{"events":["sm-token-flows"],"inclusion":{"tokens":[{"chain":"ethereum","address":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"}]},"exclusion":{},"inflow_1h":{"min":100000},"inflow_1d":{},"inflow_7d":{},"outflow_1h":{},"outflow_1d":{},"outflow_7d":{}}' --pretty
+```
+
+## Update
+
+```bash
+nansen alerts update --id <alert-id> --name "New Name" --pretty
+```
+
+All create options are optional for update (only `--id` is required).
+
+## Toggle
+
+```bash
+nansen alerts toggle --id <alert-id> --enabled
+nansen alerts toggle --id <alert-id> --disabled
+```
+
+## Delete
+
+```bash
+nansen alerts delete --id <alert-id>
+```
+
+## Options Reference
+
+| Flag | Create | Update | Toggle | Delete |
+|------|--------|--------|--------|--------|
+| `--id` | | required | required | required |
+| `--name` | required | optional | | |
+| `--type` | required | optional | | |
+| `--time-window` | required | optional | | |
+| `--chains` | recommended | optional | | |
+| `--telegram` | chat ID | optional | | |
+| `--slack` | webhook URL | optional | | |
+| `--discord` | webhook URL | optional | | |
+| `--data` | optional (JSON) | optional (JSON) | | |
+| `--description` | optional | optional | | |
+| `--enabled` | | flag | flag | |
+| `--disabled` | flag | flag | flag | |
+
+## Alert Types
+
+- `sm-token-flows` — Smart money token flow alerts
+- `common-token-transfer` — Common token transfer alerts
+
+## Channels
+
+Shorthand flags (preferred):
+```bash
+--telegram 123456
+--slack https://hooks.slack.com/services/...
+--discord https://discord.com/api/webhooks/...
+```
+
+Multiple channels can be combined: `--telegram 123 --slack https://...`
+
+
+## Notes
+
+- Alert endpoints are internal-only. Non-internal users receive 404.
+- `--channels` and `--data` accept JSON strings.
+- `list` returns an array directly.

--- a/skills/nansen-alerts/SKILL.md
+++ b/skills/nansen-alerts/SKILL.md
@@ -36,7 +36,7 @@ nansen alerts delete <id>
 |------|--------|--------|--------|--------|
 | `<id>` (positional) | | required | required | required |
 | `--name` | required | optional | | |
-| `--type` | required | optional | | |
+| `--type` | required | required with type-specific flags | | |
 | `--chains` | recommended | optional | | |
 | `--telegram` | chat ID | optional | | |
 | `--slack` | webhook URL | optional | | |

--- a/skills/nansen-profiler/SKILL.md
+++ b/skills/nansen-profiler/SKILL.md
@@ -27,7 +27,7 @@ All commands: `nansen research profiler <sub> [options]`
 ```bash
 nansen research profiler balance --address <addr> --chain ethereum
 nansen research profiler labels --address <addr> --chain ethereum
-nansen research profiler search --query "Vitalik"
+nansen research search --query "Vitalik"
 ```
 
 ## PnL

--- a/skills/nansen-token/SKILL.md
+++ b/skills/nansen-token/SKILL.md
@@ -75,7 +75,7 @@ nansen research token who-bought-sold --token <addr> --chain solana
 
 ```bash
 nansen research token dex-trades --token <addr> --chain solana --limit 20
-nansen research token pnl --token <addr> --chain solana --sort total_pnl_usd:desc
+nansen research token pnl --token <addr> --chain solana --sort pnl_usd_total:desc
 nansen research token transfers --token <addr> --chain solana --enrich
 ```
 
@@ -100,7 +100,7 @@ nansen research token jup-dca --token <addr>
 | `--timeframe` | Screener or OHLCV interval |
 | `--smart-money` | Filter to SM wallets only (screener, holders) |
 | `--days` | Lookback period (default 30) |
-| `--sort` | Sort field:direction (e.g. `total_pnl_usd:desc`) |
+| `--sort` | Sort field:direction (e.g. `pnl_usd_total:desc`) |
 | `--enrich` | Add Nansen labels to transfer addresses |
 | `--fields` | Select specific fields |
 | `--table` | Human-readable table output |

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -1738,9 +1738,9 @@ describe('NansenAPI', () => {
   // =================== Error Handling ===================
 
   describe('Error Handling', () => {
-    it('should throw with message from API error response', async () => {
+    it('should throw with original message for 401 when API key exists', async () => {
       if (LIVE_TEST) return;
-      
+
       const errorResponse = {
         ok: false,
         status: 401,
@@ -1748,10 +1748,27 @@ describe('NansenAPI', () => {
         json: async () => ({ error: 'Unauthorized', message: 'Invalid API key' })
       };
       errorResponse.headers.get = () => null;
-      
+
       mockFetch.mockResolvedValueOnce(errorResponse);
 
       await expect(api.smartMoneyNetflow({})).rejects.toThrow('Invalid API key');
+    });
+
+    it('should show login guidance for 401 when no API key', async () => {
+      if (LIVE_TEST) return;
+
+      const apiNoKey = new NansenAPI(null, 'https://api.nansen.ai');
+      const errorResponse = {
+        ok: false,
+        status: 401,
+        headers: new Map(),
+        json: async () => ({ error: 'Unauthorized', message: 'Invalid API key' })
+      };
+      errorResponse.headers.get = () => null;
+
+      mockFetch.mockResolvedValueOnce(errorResponse);
+
+      await expect(apiNoKey.smartMoneyNetflow({})).rejects.toThrow('Not logged in. Run: nansen login');
     });
 
     it('should throw on network errors after retries', async () => {

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -2647,6 +2647,12 @@ describe('NansenAPI', () => {
       expect(result[0]).toHaveProperty('id', 'alert-1');
     });
 
+    it('alertsList should append filter params as query string', async () => {
+      setupMock(MOCK_RESPONSES.alertsList);
+      await api.alertsList({ type: 'sm-token-flows', isEnabled: true, limit: 10 });
+      expectFetchCalledWith('/api/v1/smart-alert/list?type=sm-token-flows&isEnabled=true&limit=10', {}, 'GET');
+    });
+
     it('alertsCreate should POST /api/v1/smart-alert', async () => {
       setupMock(MOCK_RESPONSES.alertsCreate);
       const params = { name: 'Test', type: 'sm-token-flows', timeWindow: '1h', channels: [], data: {} };

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -2675,6 +2675,12 @@ describe('NansenAPI', () => {
       expectFetchCalledWith('/api/v1/smart-alert/alert-1', {}, 'DELETE');
       expect(result).toHaveProperty('success', true);
     });
+
+    it('alertsDelete should encode special characters in alert ID', async () => {
+      setupMock(MOCK_RESPONSES.alertsDelete);
+      await api.alertsDelete('alert/with/slashes');
+      expectFetchCalledWith('/api/v1/smart-alert/alert%2Fwith%2Fslashes', {}, 'DELETE');
+    });
   });
 
   // =================== Supported Chains ===================

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -258,7 +258,15 @@ const MOCK_RESPONSES = {
       { category: 'Politics', active_markets: 50, total_volume: 5000000, total_volume_24hr: 100000 }
     ],
     pagination: { page: 1, per_page: 100 }
-  }
+  },
+  // Smart Alert endpoints
+  alertsList: [
+    { id: 'alert-1', name: 'ETH SM Flows', type: 'sm-token-flows', isEnabled: true }
+  ],
+  alertsCreate: { id: 'alert-2', name: 'New Alert', type: 'sm-token-flows', isEnabled: true },
+  alertsUpdate: { id: 'alert-1', name: 'Updated Alert', isEnabled: true },
+  alertsToggle: { id: 'alert-1', isEnabled: false },
+  alertsDelete: { success: true }
 };
 
 describe('NansenAPI', () => {
@@ -305,28 +313,32 @@ describe('NansenAPI', () => {
    * @param {string} expectedEndpoint - Expected API endpoint path
    * @param {object} expectedBodyContains - Object with keys/values that must be in the body
    */
-  function expectFetchCalledWith(expectedEndpoint, expectedBodyContains = {}) {
+  function expectFetchCalledWith(expectedEndpoint, expectedBodyContains = {}, expectedMethod = 'POST') {
     if (LIVE_TEST) return;
-    
+
     expect(mockFetch).toHaveBeenCalled();
     const [url, options] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
-    
+
     // Verify URL
     expect(url).toBe(`https://api.nansen.ai${expectedEndpoint}`);
-    
+
     // Verify method and headers
-    expect(options.method).toBe('POST');
+    expect(options.method).toBe(expectedMethod);
     expect(options.headers['Content-Type']).toBe('application/json');
     expect(options.headers['X-Client-Type']).toBe('nansen-cli');
     expect(options.headers['X-Client-Version']).toMatch(/^\d+\.\d+\.\d+/);
     expect(options.headers['apikey']).toBe('test-api-key');
-    
-    // Verify body contains expected fields
+
+    // Verify body contains expected fields (skip for GET/DELETE)
+    if (expectedMethod === 'GET' || expectedMethod === 'DELETE') {
+      expect(options.body).toBeUndefined();
+      return;
+    }
     const body = JSON.parse(options.body);
     for (const [key, value] of Object.entries(expectedBodyContains)) {
       expect(body[key]).toEqual(value);
     }
-    
+
     return body;
   }
 
@@ -2604,6 +2616,47 @@ describe('NansenAPI', () => {
       expect(thrownError.details?.paymentRequirements).toBeUndefined();
 
       vi.doUnmock('../walletconnect-x402.js');
+    });
+  });
+
+  // =================== Smart Alert Endpoints ===================
+
+  describe('Smart Alerts', () => {
+    it('alertsList should GET /api/v1/smart-alert/list', async () => {
+      setupMock(MOCK_RESPONSES.alertsList);
+      const result = await api.alertsList();
+      expectFetchCalledWith('/api/v1/smart-alert/list', {}, 'GET');
+      expect(result).toBeInstanceOf(Array);
+      expect(result[0]).toHaveProperty('id', 'alert-1');
+    });
+
+    it('alertsCreate should POST /api/v1/smart-alert', async () => {
+      setupMock(MOCK_RESPONSES.alertsCreate);
+      const params = { name: 'Test', type: 'sm-token-flows', timeWindow: '1h', channels: [], data: {} };
+      const result = await api.alertsCreate(params);
+      expectFetchCalledWith('/api/v1/smart-alert', { name: 'Test', type: 'sm-token-flows' });
+      expect(result).toHaveProperty('id', 'alert-2');
+    });
+
+    it('alertsUpdate should PATCH /api/v1/smart-alert', async () => {
+      setupMock(MOCK_RESPONSES.alertsUpdate);
+      const result = await api.alertsUpdate({ id: 'alert-1', name: 'Updated Alert' });
+      expectFetchCalledWith('/api/v1/smart-alert', { id: 'alert-1', name: 'Updated Alert' }, 'PATCH');
+      expect(result).toHaveProperty('name', 'Updated Alert');
+    });
+
+    it('alertsToggle should PATCH /api/v1/smart-alert/toggle', async () => {
+      setupMock(MOCK_RESPONSES.alertsToggle);
+      const result = await api.alertsToggle({ id: 'alert-1', isEnabled: false });
+      expectFetchCalledWith('/api/v1/smart-alert/toggle', { id: 'alert-1', isEnabled: false }, 'PATCH');
+      expect(result).toHaveProperty('isEnabled', false);
+    });
+
+    it('alertsDelete should DELETE /api/v1/smart-alert/:id', async () => {
+      setupMock(MOCK_RESPONSES.alertsDelete);
+      const result = await api.alertsDelete('alert-1');
+      expectFetchCalledWith('/api/v1/smart-alert/alert-1', {}, 'DELETE');
+      expect(result).toHaveProperty('success', true);
     });
   });
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -9,6 +9,7 @@ import {
   parseArgs,
   formatValue,
   formatTable,
+  formatAlertsTable,
   formatOutput,
   formatError,
   formatStream,
@@ -176,6 +177,46 @@ describe('formatTable', () => {
     const header = lines[0];
     // token_symbol should come before zebra (priority field)
     expect(header.indexOf('token_symbol')).toBeLessThan(header.indexOf('zebra'));
+  });
+});
+
+describe('formatAlertsTable', () => {
+  it('should return "No alerts" for empty array', () => {
+    expect(formatAlertsTable([])).toBe('No alerts');
+  });
+
+  it('should format alerts as table with NAME, TYPE, ENABLED, CHANNELS columns', () => {
+    const alerts = [
+      { id: 'a1', name: 'ETH Whale Alert', type: 'sm-token-flows', isEnabled: true, channels: [{ type: 'telegram' }] },
+      { id: 'a2', name: 'USDC Transfer Alert', type: 'common-token-transfer', isEnabled: false, channels: [{ type: 'slack' }, { type: 'discord' }] }
+    ];
+    const result = formatAlertsTable(alerts);
+    expect(result).toContain('NAME');
+    expect(result).toContain('TYPE');
+    expect(result).toContain('ENABLED');
+    expect(result).toContain('CHANNELS');
+    expect(result).toContain('ETH Whale Alert');
+    expect(result).toContain('sm-token-flows');
+    expect(result).toContain('✓');
+    expect(result).toContain('telegram');
+    expect(result).toContain('slack, discord');
+  });
+
+  it('should handle alerts with no channels', () => {
+    const alerts = [
+      { id: 'a1', name: 'Test Alert', type: 'sm-token-flows', isEnabled: true, channels: [] }
+    ];
+    const result = formatAlertsTable(alerts);
+    expect(result).toContain('Test Alert');
+    expect(result).not.toContain('undefined');
+  });
+
+  it('should truncate long names', () => {
+    const alerts = [
+      { id: 'a1', name: 'A very long alert name that exceeds the column width and should be truncated', type: 'sm-token-flows', isEnabled: true, channels: [] }
+    ];
+    const result = formatAlertsTable(alerts);
+    expect(result).toContain('…');
   });
 });
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -185,16 +185,19 @@ describe('formatAlertsTable', () => {
     expect(formatAlertsTable([])).toBe('No alerts');
   });
 
-  it('should format alerts as table with NAME, TYPE, ENABLED, CHANNELS columns', () => {
+  it('should format alerts as table with ID, NAME, TYPE, ENABLED, CHANNELS columns', () => {
     const alerts = [
       { id: 'a1', name: 'ETH Whale Alert', type: 'sm-token-flows', isEnabled: true, channels: [{ type: 'telegram' }] },
       { id: 'a2', name: 'USDC Transfer Alert', type: 'common-token-transfer', isEnabled: false, channels: [{ type: 'slack' }, { type: 'discord' }] }
     ];
     const result = formatAlertsTable(alerts);
+    expect(result).toContain('ID');
     expect(result).toContain('NAME');
     expect(result).toContain('TYPE');
     expect(result).toContain('ENABLED');
     expect(result).toContain('CHANNELS');
+    expect(result).toContain('a1');
+    expect(result).toContain('a2');
     expect(result).toContain('ETH Whale Alert');
     expect(result).toContain('sm-token-flows');
     expect(result).toContain('✓');
@@ -218,6 +221,14 @@ describe('formatAlertsTable', () => {
     ];
     const result = formatAlertsTable(alerts);
     expect(result).toContain('…');
+  });
+
+  it('should show full ID without truncation', () => {
+    const alerts = [
+      { id: 'very-long-alert-id-that-should-not-be-truncated', name: 'Test', type: 'sm-token-flows', isEnabled: true, channels: [] }
+    ];
+    const result = formatAlertsTable(alerts);
+    expect(result).toContain('very-long-alert-id-that-should-not-be-truncated');
   });
 });
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -198,6 +198,7 @@ describe('formatAlertsTable', () => {
     expect(result).toContain('ETH Whale Alert');
     expect(result).toContain('sm-token-flows');
     expect(result).toContain('✓');
+    expect(result).toContain('✗');
     expect(result).toContain('telegram');
     expect(result).toContain('slack, discord');
   });

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -9,7 +9,6 @@ import {
   parseArgs,
   formatValue,
   formatTable,
-  formatAlertsTable,
   formatOutput,
   formatError,
   formatStream,
@@ -30,6 +29,7 @@ import {
   parseAddressList
 } from '../cli.js';
 import {
+  formatAlertsTable,
   buildAlertData,
   buildSmTokenFlowsData,
   buildCommonTokenTransferData,
@@ -560,64 +560,6 @@ describe('buildCommonTokenTransferData new inclusion/exclusion flags', () => {
     const result = buildCommonTokenTransferData({ 'exclude-token': '0xbad:ethereum', 'exclude-from': 'label:Bot' });
     expect(result.exclusion.tokens).toEqual([{ address: '0xbad', chain: 'ethereum' }]);
     expect(result.exclusion.fromTargets).toEqual([{ type: 'label', value: 'Bot' }]);
-  });
-});
-
-describe('alerts list client-side filtering', () => {
-  const mockAlerts = [
-    { id: '1', type: 'sm-token-flows', isEnabled: true, channels: [], data: { chains: ['ethereum'], inclusion: { tokens: [{ address: '0xabc', chain: 'ethereum' }] } } },
-    { id: '2', type: 'common-token-transfer', isEnabled: false, channels: [], data: { chains: ['base'] } },
-    { id: '3', type: 'sm-token-flows', isEnabled: false, channels: [], data: { chains: ['ethereum'] } },
-  ];
-
-  function makeApi() {
-    return { alertsList: vi.fn().mockResolvedValue(mockAlerts) };
-  }
-
-  async function callList(flags = {}, options = {}) {
-    const logs = [];
-    const cmd = buildAlertsCommands({ log: (...a) => logs.push(a) })['alerts'];
-    return cmd(['list'], makeApi(), flags, options);
-  }
-
-  it('should return all alerts when no filters', async () => {
-    const result = await callList();
-    expect(result).toHaveLength(3);
-  });
-
-  it('should filter by --type', async () => {
-    const result = await callList({}, { type: 'sm-token-flows' });
-    expect(result).toHaveLength(2);
-    expect(result.every(a => a.type === 'sm-token-flows')).toBe(true);
-  });
-
-  it('should filter by --disabled flag', async () => {
-    const result = await callList({ disabled: true });
-    expect(result).toHaveLength(2);
-    expect(result.every(a => a.isEnabled === false)).toBe(true);
-  });
-
-  it('should filter by --enabled flag', async () => {
-    const result = await callList({ enabled: true });
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('1');
-  });
-
-  it('should apply --limit slicing', async () => {
-    const result = await callList({}, { limit: '2' });
-    expect(result).toHaveLength(2);
-  });
-
-  it('should apply --offset slicing', async () => {
-    const result = await callList({}, { offset: '2' });
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('3');
-  });
-
-  it('should apply --limit and --offset together', async () => {
-    const result = await callList({}, { limit: '1', offset: '1' });
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('2');
   });
 });
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -29,6 +29,11 @@ import {
   buildPagination,
   parseAddressList
 } from '../cli.js';
+import {
+  buildAlertData,
+  buildSmTokenFlowsData,
+  buildCommonTokenTransferData,
+} from '../commands/alerts.js';
 import { getCachedResponse, setCachedResponse, clearCache, getCacheDir, NansenError, ErrorCode } from '../api.js';
 import { EVM_CHAINS } from '../chain-ids.js';
 import * as fs from 'fs';
@@ -229,6 +234,175 @@ describe('formatAlertsTable', () => {
     ];
     const result = formatAlertsTable(alerts);
     expect(result).toContain('very-long-alert-id-that-should-not-be-truncated');
+  });
+});
+
+describe('buildSmTokenFlowsData', () => {
+  it('should build data with inflow range flags', () => {
+    const result = buildSmTokenFlowsData({
+      chains: 'ethereum',
+      'inflow-1h-min': '5000000',
+    });
+    expect(result.chains).toEqual(['ethereum']);
+    expect(result.inflow_1h).toEqual({ min: 5000000, max: null });
+  });
+
+  it('should build data with multiple flow ranges', () => {
+    const result = buildSmTokenFlowsData({
+      'inflow-1h-min': '1000000',
+      'outflow-7d-max': '500000',
+    });
+    expect(result.inflow_1h).toEqual({ min: 1000000, max: null });
+    expect(result.outflow_7d).toEqual({ min: null, max: 500000 });
+  });
+
+  it('should parse --token into inclusion.tokens', () => {
+    const result = buildSmTokenFlowsData({
+      token: '0xabc123:ethereum',
+    });
+    expect(result.inclusion).toEqual({ tokens: [{ address: '0xabc123', chain: 'ethereum' }] });
+  });
+
+  it('should parse repeated --token into inclusion.tokens array', () => {
+    const result = buildSmTokenFlowsData({
+      token: ['0xabc:ethereum', '0xdef:base'],
+    });
+    expect(result.inclusion).toEqual({
+      tokens: [
+        { address: '0xabc', chain: 'ethereum' },
+        { address: '0xdef', chain: 'base' },
+      ],
+    });
+  });
+
+  it('should parse --exclude-token into exclusion.tokens', () => {
+    const result = buildSmTokenFlowsData({
+      'exclude-token': '0xbad:ethereum',
+    });
+    expect(result.exclusion).toEqual({ tokens: [{ address: '0xbad', chain: 'ethereum' }] });
+  });
+
+  it('should return empty object when no flags provided', () => {
+    const result = buildSmTokenFlowsData({});
+    expect(result).toEqual({});
+  });
+});
+
+describe('buildCommonTokenTransferData', () => {
+  it('should build data with events and USD range', () => {
+    const result = buildCommonTokenTransferData({
+      chains: 'ethereum',
+      events: 'send,receive',
+      'usd-min': '1000000',
+    });
+    expect(result.chains).toEqual(['ethereum']);
+    expect(result.events).toEqual(['send', 'receive']);
+    expect(result.usdValue).toEqual({ min: 1000000, max: null });
+  });
+
+  it('should build data with token amount range', () => {
+    const result = buildCommonTokenTransferData({
+      'token-amount-min': '100',
+      'token-amount-max': '5000',
+    });
+    expect(result.tokenAmount).toEqual({ min: 100, max: 5000 });
+  });
+
+  it('should parse --subject into subjects array', () => {
+    const result = buildCommonTokenTransferData({
+      subject: 'label:Centralized Exchange',
+    });
+    expect(result.subjects).toEqual([{ type: 'label', value: 'Centralized Exchange' }]);
+  });
+
+  it('should parse repeated --subject values', () => {
+    const result = buildCommonTokenTransferData({
+      subject: ['label:CEX', 'label:DEX'],
+    });
+    expect(result.subjects).toEqual([
+      { type: 'label', value: 'CEX' },
+      { type: 'label', value: 'DEX' },
+    ]);
+  });
+
+  it('should parse --token into inclusion.tokens', () => {
+    const result = buildCommonTokenTransferData({
+      token: '0xusdc:ethereum',
+    });
+    expect(result.inclusion).toEqual({ tokens: [{ address: '0xusdc', chain: 'ethereum' }] });
+  });
+});
+
+describe('buildAlertData', () => {
+  it('should dispatch to buildSmTokenFlowsData for sm-token-flows type', () => {
+    const result = buildAlertData({
+      type: 'sm-token-flows',
+      chains: 'ethereum',
+      'inflow-1h-min': '5000000',
+    });
+    expect(result.chains).toEqual(['ethereum']);
+    expect(result.inflow_1h).toEqual({ min: 5000000, max: null });
+  });
+
+  it('should dispatch to buildCommonTokenTransferData for common-token-transfer type', () => {
+    const result = buildAlertData({
+      type: 'common-token-transfer',
+      chains: 'ethereum',
+      events: 'send,receive',
+      'usd-min': '1000000',
+    });
+    expect(result.chains).toEqual(['ethereum']);
+    expect(result.events).toEqual(['send', 'receive']);
+    expect(result.usdValue).toEqual({ min: 1000000, max: null });
+  });
+
+  it('should fall back to chains-only for unknown type', () => {
+    const result = buildAlertData({
+      type: 'unknown-type',
+      chains: 'solana',
+    });
+    expect(result).toEqual({ chains: ['solana'] });
+  });
+
+  it('should merge --data JSON on top of named flags (override)', () => {
+    const result = buildAlertData({
+      type: 'sm-token-flows',
+      chains: 'ethereum',
+      'inflow-1h-min': '100000',
+      data: '{"inflow_1h":{"min":999999},"chains":["base"]}',
+    });
+    // --data overrides named flags
+    expect(result.chains).toEqual(['base']);
+    expect(result.inflow_1h).toEqual({ min: 999999 });
+  });
+
+  it('should accept --data as object (not string)', () => {
+    const result = buildAlertData({
+      type: 'sm-token-flows',
+      data: { chains: ['solana'] },
+    });
+    expect(result.chains).toEqual(['solana']);
+  });
+
+  it('should throw on invalid --data JSON', () => {
+    expect(() => buildAlertData({ type: 'sm-token-flows', data: 'not-json' })).toThrow();
+  });
+
+  it('should work with no type (no flags)', () => {
+    const result = buildAlertData({});
+    expect(result).toEqual({});
+  });
+});
+
+describe('parseArgs repeatable flags', () => {
+  it('should accumulate repeated options into arrays', () => {
+    const result = parseArgs(['--token', '0xabc:ethereum', '--token', '0xdef:base']);
+    expect(result.options.token).toEqual(['0xabc:ethereum', '0xdef:base']);
+  });
+
+  it('should keep single option as string', () => {
+    const result = parseArgs(['--token', '0xabc:ethereum']);
+    expect(result.options.token).toBe('0xabc:ethereum');
   });
 });
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -33,6 +33,7 @@ import {
   buildAlertData,
   buildSmTokenFlowsData,
   buildCommonTokenTransferData,
+  buildSmartContractCallData,
 } from '../commands/alerts.js';
 import { getCachedResponse, setCachedResponse, clearCache, getCacheDir, NansenError, ErrorCode } from '../api.js';
 import { EVM_CHAINS } from '../chain-ids.js';
@@ -391,6 +392,83 @@ describe('buildAlertData', () => {
   it('should work with no type (no flags)', () => {
     const result = buildAlertData({});
     expect(result).toEqual({});
+  });
+});
+
+describe('buildSmTokenFlowsData netflow fields', () => {
+  it('should include netflow-1h range', () => {
+    const result = buildSmTokenFlowsData({ 'netflow-1h-min': '100000' });
+    expect(result.netflow_1h).toEqual({ min: 100000, max: null });
+  });
+
+  it('should include netflow-1d and netflow-7d ranges', () => {
+    const result = buildSmTokenFlowsData({ 'netflow-1d-min': '500000', 'netflow-7d-max': '2000000' });
+    expect(result.netflow_1d).toEqual({ min: 500000, max: null });
+    expect(result.netflow_7d).toEqual({ min: null, max: 2000000 });
+  });
+});
+
+describe('buildCommonTokenTransferData counterparty', () => {
+  it('should add counterparties when --counterparty is provided', () => {
+    const result = buildCommonTokenTransferData({ counterparty: 'address:0xabc' });
+    expect(result.counterparties).toEqual([{ type: 'address', value: '0xabc' }]);
+  });
+
+  it('should handle repeated --counterparty flags as array', () => {
+    const result = buildCommonTokenTransferData({ counterparty: ['address:0xabc', 'label:Whale'] });
+    expect(result.counterparties).toEqual([
+      { type: 'address', value: '0xabc' },
+      { type: 'label', value: 'Whale' },
+    ]);
+  });
+
+  it('should not add counterparties when flag is absent', () => {
+    const result = buildCommonTokenTransferData({ chains: 'ethereum' });
+    expect(result.counterparties).toBeUndefined();
+  });
+});
+
+describe('buildSmartContractCallData', () => {
+  it('should build data with chains and usd range', () => {
+    const result = buildSmartContractCallData({ chains: 'ethereum,base', 'usd-min': '1000', 'usd-max': '9999' });
+    expect(result.chains).toEqual(['ethereum', 'base']);
+    expect(result.usdValue).toEqual({ min: 1000, max: 9999 });
+  });
+
+  it('should build signatureHash as array from single value', () => {
+    const result = buildSmartContractCallData({ 'signature-hash': '0xa9059cbb' });
+    expect(result.signatureHash).toEqual(['0xa9059cbb']);
+  });
+
+  it('should build signatureHash as array from repeated flags', () => {
+    const result = buildSmartContractCallData({ 'signature-hash': ['0xa9059cbb', '0x23b872dd'] });
+    expect(result.signatureHash).toEqual(['0xa9059cbb', '0x23b872dd']);
+  });
+
+  it('should build inclusion.caller from --caller', () => {
+    const result = buildSmartContractCallData({ caller: 'address:0xabc' });
+    expect(result.inclusion.caller).toEqual([{ type: 'address', value: '0xabc' }]);
+  });
+
+  it('should build inclusion.smartContract from --contract', () => {
+    const result = buildSmartContractCallData({ contract: 'address:0xdef' });
+    expect(result.inclusion.smartContract).toEqual([{ type: 'address', value: '0xdef' }]);
+  });
+
+  it('should build exclusion.caller from --exclude-caller', () => {
+    const result = buildSmartContractCallData({ 'exclude-caller': 'label:Bot' });
+    expect(result.exclusion.caller).toEqual([{ type: 'label', value: 'Bot' }]);
+  });
+
+  it('should build exclusion.smartContract from --exclude-contract', () => {
+    const result = buildSmartContractCallData({ 'exclude-contract': 'address:0x999' });
+    expect(result.exclusion.smartContract).toEqual([{ type: 'address', value: '0x999' }]);
+  });
+
+  it('should dispatch to buildSmartContractCallData for smart-contract-call type', () => {
+    const result = buildAlertData({ type: 'smart-contract-call', chains: 'ethereum', 'signature-hash': '0xa9059cbb' });
+    expect(result.chains).toEqual(['ethereum']);
+    expect(result.signatureHash).toEqual(['0xa9059cbb']);
   });
 });
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -34,6 +34,7 @@ import {
   buildSmTokenFlowsData,
   buildCommonTokenTransferData,
   buildSmartContractCallData,
+  buildAlertsCommands,
 } from '../commands/alerts.js';
 import { getCachedResponse, setCachedResponse, clearCache, getCacheDir, NansenError, ErrorCode } from '../api.js';
 import { EVM_CHAINS } from '../chain-ids.js';
@@ -469,6 +470,187 @@ describe('buildSmartContractCallData', () => {
     const result = buildAlertData({ type: 'smart-contract-call', chains: 'ethereum', 'signature-hash': '0xa9059cbb' });
     expect(result.chains).toEqual(['ethereum']);
     expect(result.signatureHash).toEqual(['0xa9059cbb']);
+  });
+});
+
+describe('buildSmTokenFlowsData new inclusion/exclusion flags', () => {
+  it('should add token-sector to inclusion.tokenSectors', () => {
+    const result = buildSmTokenFlowsData({ 'token-sector': 'DeFi' });
+    expect(result.inclusion.tokenSectors).toEqual(['DeFi']);
+  });
+
+  it('should handle repeated --token-sector', () => {
+    const result = buildSmTokenFlowsData({ 'token-sector': ['DeFi', 'NFT'] });
+    expect(result.inclusion.tokenSectors).toEqual(['DeFi', 'NFT']);
+  });
+
+  it('should add exclude-token-sector to exclusion.tokenSectors', () => {
+    const result = buildSmTokenFlowsData({ 'exclude-token-sector': 'Meme' });
+    expect(result.exclusion.tokenSectors).toEqual(['Meme']);
+  });
+
+  it('should add token-age-max to inclusion.tokenAge', () => {
+    const result = buildSmTokenFlowsData({ 'token-age-max': '30' });
+    expect(result.inclusion.tokenAge).toEqual({ max: 30 });
+  });
+
+  it('should add market-cap range to inclusion.marketCap', () => {
+    const result = buildSmTokenFlowsData({ 'market-cap-min': '1000000', 'market-cap-max': '9000000' });
+    expect(result.inclusion.marketCap).toEqual({ min: 1000000, max: 9000000 });
+  });
+
+  it('should add fdv range to inclusion.fdvUsd', () => {
+    const result = buildSmTokenFlowsData({ 'fdv-min': '500000' });
+    expect(result.inclusion.fdvUsd).toEqual({ min: 500000, max: null });
+  });
+
+  it('should merge token-sector with existing inclusion.tokens', () => {
+    const result = buildSmTokenFlowsData({ token: '0xabc:ethereum', 'token-sector': 'DeFi' });
+    expect(result.inclusion.tokens).toEqual([{ address: '0xabc', chain: 'ethereum' }]);
+    expect(result.inclusion.tokenSectors).toEqual(['DeFi']);
+  });
+});
+
+describe('buildCommonTokenTransferData new inclusion/exclusion flags', () => {
+  it('should add token-sector to inclusion.tokenSectors', () => {
+    const result = buildCommonTokenTransferData({ 'token-sector': 'DeFi' });
+    expect(result.inclusion.tokenSectors).toEqual(['DeFi']);
+  });
+
+  it('should add exclude-token-sector to exclusion.tokenSectors', () => {
+    const result = buildCommonTokenTransferData({ 'exclude-token-sector': ['Meme', 'GameFi'] });
+    expect(result.exclusion.tokenSectors).toEqual(['Meme', 'GameFi']);
+  });
+
+  it('should add token-age-min and token-age-max to inclusion.tokenAge', () => {
+    const result = buildCommonTokenTransferData({ 'token-age-min': '7', 'token-age-max': '90' });
+    expect(result.inclusion.tokenAge).toEqual({ min: 7, max: 90 });
+  });
+
+  it('should add token-age-max only', () => {
+    const result = buildCommonTokenTransferData({ 'token-age-max': '30' });
+    expect(result.inclusion.tokenAge).toEqual({ max: 30 });
+  });
+
+  it('should add market-cap range to inclusion.marketCap', () => {
+    const result = buildCommonTokenTransferData({ 'market-cap-min': '1000000' });
+    expect(result.inclusion.marketCap).toEqual({ min: 1000000, max: null });
+  });
+
+  it('should add exclude-from to exclusion.fromTargets', () => {
+    const result = buildCommonTokenTransferData({ 'exclude-from': 'address:0xbad' });
+    expect(result.exclusion.fromTargets).toEqual([{ type: 'address', value: '0xbad' }]);
+  });
+
+  it('should add exclude-to to exclusion.toTargets', () => {
+    const result = buildCommonTokenTransferData({ 'exclude-to': ['label:Bot', 'label:Scammer'] });
+    expect(result.exclusion.toTargets).toEqual([
+      { type: 'label', value: 'Bot' },
+      { type: 'label', value: 'Scammer' },
+    ]);
+  });
+
+  it('should merge token-sector with existing inclusion.tokens', () => {
+    const result = buildCommonTokenTransferData({ token: '0xabc:base', 'token-sector': 'DeFi' });
+    expect(result.inclusion.tokens).toEqual([{ address: '0xabc', chain: 'base' }]);
+    expect(result.inclusion.tokenSectors).toEqual(['DeFi']);
+  });
+
+  it('should merge exclude-from with existing exclusion.tokens', () => {
+    const result = buildCommonTokenTransferData({ 'exclude-token': '0xbad:ethereum', 'exclude-from': 'label:Bot' });
+    expect(result.exclusion.tokens).toEqual([{ address: '0xbad', chain: 'ethereum' }]);
+    expect(result.exclusion.fromTargets).toEqual([{ type: 'label', value: 'Bot' }]);
+  });
+});
+
+describe('alerts list client-side filtering', () => {
+  const mockAlerts = [
+    { id: '1', type: 'sm-token-flows', isEnabled: true, channels: [], data: { chains: ['ethereum'], inclusion: { tokens: [{ address: '0xabc', chain: 'ethereum' }] } } },
+    { id: '2', type: 'common-token-transfer', isEnabled: false, channels: [], data: { chains: ['base'] } },
+    { id: '3', type: 'sm-token-flows', isEnabled: false, channels: [], data: { chains: ['ethereum'] } },
+  ];
+
+  function makeApi() {
+    return { alertsList: vi.fn().mockResolvedValue(mockAlerts) };
+  }
+
+  async function callList(flags = {}, options = {}) {
+    const logs = [];
+    const cmd = buildAlertsCommands({ log: (...a) => logs.push(a) })['alerts'];
+    return cmd(['list'], makeApi(), flags, options);
+  }
+
+  it('should return all alerts when no filters', async () => {
+    const result = await callList();
+    expect(result).toHaveLength(3);
+  });
+
+  it('should filter by --type', async () => {
+    const result = await callList({}, { type: 'sm-token-flows' });
+    expect(result).toHaveLength(2);
+    expect(result.every(a => a.type === 'sm-token-flows')).toBe(true);
+  });
+
+  it('should filter by --disabled flag', async () => {
+    const result = await callList({ disabled: true });
+    expect(result).toHaveLength(2);
+    expect(result.every(a => a.isEnabled === false)).toBe(true);
+  });
+
+  it('should filter by --enabled flag', async () => {
+    const result = await callList({ enabled: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
+  });
+
+  it('should apply --limit slicing', async () => {
+    const result = await callList({}, { limit: '2' });
+    expect(result).toHaveLength(2);
+  });
+
+  it('should apply --offset slicing', async () => {
+    const result = await callList({}, { offset: '2' });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('3');
+  });
+
+  it('should apply --limit and --offset together', async () => {
+    const result = await callList({}, { limit: '1', offset: '1' });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('2');
+  });
+});
+
+describe('alerts create does not require --time-window', () => {
+  it('should throw only for missing --name, --type, and channel (not --time-window)', async () => {
+    const logs = [];
+    const mockApi = { alertsCreate: vi.fn().mockResolvedValue({ id: 'new' }) };
+    const cmd = buildAlertsCommands({ log: (...a) => logs.push(a) })['alerts'];
+    // Missing --name and --type but has channel — should complain about name and type, not time-window
+    let err;
+    try {
+      await cmd(['create'], mockApi, {}, { telegram: '123' });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.message).toContain('--name');
+    expect(err.message).toContain('--type');
+    expect(err.message).not.toContain('--time-window');
+  });
+
+  it('should use TIME_WINDOW_BY_TYPE for sm-token-flows', async () => {
+    const mockApi = { alertsCreate: vi.fn().mockResolvedValue({ id: 'new' }) };
+    const cmd = buildAlertsCommands({ log: vi.fn() })['alerts'];
+    await cmd(['create'], mockApi, {}, { name: 'Test', type: 'sm-token-flows', telegram: '123' });
+    expect(mockApi.alertsCreate).toHaveBeenCalledWith(expect.objectContaining({ timeWindow: '1h' }));
+  });
+
+  it('should use realtime for common-token-transfer', async () => {
+    const mockApi = { alertsCreate: vi.fn().mockResolvedValue({ id: 'new' }) };
+    const cmd = buildAlertsCommands({ log: vi.fn() })['alerts'];
+    await cmd(['create'], mockApi, {}, { name: 'Test', type: 'common-token-transfer', telegram: '123' });
+    expect(mockApi.alertsCreate).toHaveBeenCalledWith(expect.objectContaining({ timeWindow: 'realtime' }));
   });
 });
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -826,11 +826,10 @@ describe('buildCommands', () => {
   });
 
   describe('smart-money command', () => {
-    it('should return help for unknown subcommand', async () => {
+    it('should throw for unknown subcommand', async () => {
       const mockApi = {};
-      const result = await commands['smart-money'](['unknown'], mockApi, {}, {});
-      expect(result.error).toContain('Unknown subcommand');
-      expect(result.available).toContain('netflow');
+      await expect(commands['smart-money'](['unknown'], mockApi, {}, {}))
+        .rejects.toThrow('Unknown subcommand: unknown');
     });
 
     it('should return help object for help subcommand', async () => {
@@ -868,9 +867,9 @@ describe('buildCommands', () => {
   });
 
   describe('profiler command', () => {
-    it('should return help for unknown subcommand', async () => {
-      const result = await commands['profiler'](['unknown'], {}, {}, {});
-      expect(result.error).toContain('Unknown subcommand');
+    it('should throw for unknown subcommand', async () => {
+      await expect(commands['profiler'](['unknown'], {}, {}, {}))
+        .rejects.toThrow('Unknown subcommand: unknown');
     });
 
     it('should call balance with address', async () => {
@@ -897,9 +896,9 @@ describe('buildCommands', () => {
   });
 
   describe('token command', () => {
-    it('should return help for unknown subcommand', async () => {
-      const result = await commands['token'](['unknown'], {}, {}, {});
-      expect(result.error).toContain('Unknown subcommand');
+    it('should throw for unknown subcommand', async () => {
+      await expect(commands['token'](['unknown'], {}, {}, {}))
+        .rejects.toThrow('Unknown subcommand: unknown');
     });
 
     it('should call screener with chains and timeframe', async () => {
@@ -1072,9 +1071,9 @@ describe('buildCommands', () => {
   });
 
   describe('portfolio command', () => {
-    it('should return help for unknown subcommand', async () => {
-      const result = await commands['portfolio'](['unknown'], {}, {}, {});
-      expect(result.error).toContain('Unknown subcommand');
+    it('should throw for unknown subcommand', async () => {
+      await expect(commands['portfolio'](['unknown'], {}, {}, {}))
+        .rejects.toThrow('Unknown subcommand: unknown');
     });
 
     it('should call defi-holdings with wallet', async () => {

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -199,9 +199,11 @@ describe('CLI Smoke Tests', () => {
   });
 
   it('should handle unknown subcommand gracefully', () => {
-    const { stdout } = runCLI('smart-money unknown-subcommand');
-    
+    const { stdout, exitCode } = runCLI('smart-money unknown-subcommand');
+
+    expect(exitCode).toBe(1);
     const result = JSON.parse(stdout);
-    expect(result.data.error).toContain('Unknown subcommand');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Unknown subcommand');
   });
 });

--- a/src/api.js
+++ b/src/api.js
@@ -496,7 +496,9 @@ export class NansenAPI {
         const retryAfterMs = parseRetryAfter(response.headers.get('retry-after'));
 
         // Enhance messages for specific error codes
-        if (code === ErrorCode.UNSUPPORTED_FILTER) {
+        if (code === ErrorCode.UNAUTHORIZED) {
+          message = this.apiKey ? message : 'Not logged in. Run: nansen login';
+        } else if (code === ErrorCode.UNSUPPORTED_FILTER) {
           message = message.replace(/\.+$/, '') + '. This filter is not supported for this token/chain combination. Do not retry.';
         } else if (code === ErrorCode.CREDITS_EXHAUSTED) {
           message = message.replace(/\.+$/, '') + '. No retry will help. Check your Nansen dashboard for credit balance.';

--- a/src/api.js
+++ b/src/api.js
@@ -1289,7 +1289,7 @@ export class NansenAPI {
   }
 
   async alertsDelete(alertId) {
-    return this.request(`/api/v1/smart-alert/${alertId}`, {}, { method: 'DELETE' });
+    return this.request(`/api/v1/smart-alert/${encodeURIComponent(alertId)}`, {}, { method: 'DELETE' });
   }
 }
 

--- a/src/api.js
+++ b/src/api.js
@@ -439,8 +439,9 @@ export class NansenAPI {
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       let response;
       try {
+        const method = options.method || 'POST';
         response = await fetch(url, {
-          method: 'POST',
+          method,
           headers: {
             'Content-Type': 'application/json',
             'X-Client-Type': 'nansen-cli',
@@ -449,7 +450,7 @@ export class NansenAPI {
             ...this.defaultHeaders,
             ...options.headers
           },
-          body: JSON.stringify(NansenAPI.cleanBody(body))
+          ...(method === 'GET' || method === 'DELETE' ? {} : { body: JSON.stringify(NansenAPI.cleanBody(body)) }),
         });
       } catch (err) {
         // Network-level errors - retry these too
@@ -1265,6 +1266,28 @@ export class NansenAPI {
     return this.request('/api/v1/portfolio/defi-holdings', {
       wallet_address: walletAddress
     });
+  }
+
+  // ============= Smart Alert Endpoints =============
+
+  async alertsList() {
+    return this.request('/api/v1/smart-alert/list', {}, { method: 'GET' });
+  }
+
+  async alertsCreate(params = {}) {
+    return this.request('/api/v1/smart-alert', params);
+  }
+
+  async alertsUpdate(params = {}) {
+    return this.request('/api/v1/smart-alert', params, { method: 'PATCH' });
+  }
+
+  async alertsToggle(params = {}) {
+    return this.request('/api/v1/smart-alert/toggle', params, { method: 'PATCH' });
+  }
+
+  async alertsDelete(alertId) {
+    return this.request(`/api/v1/smart-alert/${alertId}`, {}, { method: 'DELETE' });
   }
 }
 

--- a/src/api.js
+++ b/src/api.js
@@ -1272,8 +1272,10 @@ export class NansenAPI {
 
   // ============= Smart Alert Endpoints =============
 
-  async alertsList() {
-    return this.request('/api/v1/smart-alert/list', {}, { method: 'GET' });
+  async alertsList(params = {}) {
+    const defined = Object.fromEntries(Object.entries(params).filter(([, v]) => v !== undefined));
+    const qs = Object.keys(defined).length > 0 ? '?' + new URLSearchParams(defined).toString() : '';
+    return this.request(`/api/v1/smart-alert/list${qs}`, {}, { method: 'GET' });
   }
 
   async alertsCreate(params = {}) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1409,9 +1409,18 @@ EXAMPLES:
 
     // Build alert data by merging --chains into --data (if provided)
     function buildAlertData() {
-      let data = options.data
-        ? (typeof options.data === 'string' ? JSON.parse(options.data) : options.data)
-        : {};
+      let data = {};
+      if (options.data) {
+        if (typeof options.data === 'string') {
+          try {
+            data = JSON.parse(options.data);
+          } catch {
+            throw new NansenError('--data must be valid JSON', ErrorCode.INVALID_PARAM);
+          }
+        } else {
+          data = options.data;
+        }
+      }
       if (options.chains) {
         const chains = typeof options.chains === 'string' ? options.chains.split(',') : Array.isArray(options.chains) ? options.chains : [options.chains];
         data = { ...data, chains };

--- a/src/cli.js
+++ b/src/cli.js
@@ -1335,7 +1335,7 @@ SYMBOLS:
   // 'alerts' — smart alert CRUD
   cmds['alerts'] = async (args, apiInstance, flags, options) => {
     const sub = args[0];
-    if (!sub || sub === 'help') {
+    if (!sub || sub === 'help' || flags.help || flags.h) {
       log(`nansen alerts — Smart alert management
 
 SUBCOMMANDS:
@@ -1348,23 +1348,24 @@ SUBCOMMANDS:
 USAGE:
   nansen alerts list
   nansen alerts create --name <name> --type <type> --time-window <window> --chains <chains> --telegram <chatId> [--data '<json>']
-  nansen alerts update --id <id> [--name <name>] [--chains <chains>] [--data '<json>']
-  nansen alerts toggle --id <id> --enabled
-  nansen alerts toggle --id <id> --disabled
-  nansen alerts delete --id <id>
+  nansen alerts update <id> [--name <name>] [--chains <chains>] [--data '<json>']
+  nansen alerts toggle <id> --enabled
+  nansen alerts toggle <id> --disabled
+  nansen alerts delete <id>
 
 OPTIONS:
   --chains <chains>       Comma-separated chains (e.g. ethereum,solana). Merged into --data.
-  --telegram <chatId>     Send to Telegram chat. Use --channels for multiple.
+  --telegram <chatId>     Send to Telegram chat.
   --slack <webhookUrl>    Send to Slack webhook.
-  --discord <webhookUrl>  Send to Discord webhook.
+  --discord <webhookUrl>  Send to Discord webhook. Combine multiple channel flags for multi-channel alerts.
   --data '<json>'         Alert config as JSON. --chains is merged on top if both provided.
+  --description '<text>'  Alert description. Use single quotes to avoid shell interpolation.
 
 EXAMPLES:
   nansen alerts list --pretty
-  nansen alerts create --name "ETH SM Flows" --type sm-token-flows --time-window 1h --chains ethereum --telegram 5238612255 --data '{"events":["sm-token-flows"],"inflow_1h":{"min":100000}}'
-  nansen alerts toggle --id abc123 --disabled
-  nansen alerts delete --id abc123`);
+  nansen alerts create --name 'ETH SM Flows' --type sm-token-flows --time-window 1h --chains ethereum --telegram 5238612255 --description 'Alert when SM pours $1M+ into ETH' --data '{"events":["sm-token-flows"],"inflow_1h":{"min":100000}}'
+  nansen alerts toggle abc123 --disabled
+  nansen alerts delete abc123`);
       return;
     }
 
@@ -1397,8 +1398,13 @@ EXAMPLES:
         const timeWindow = options['time-window'];
         const channels = buildChannels();
         const data = buildAlertData();
-        if (!name || !type || !timeWindow || !channels) {
-          throw new NansenError('Required: --name, --type, --time-window, and a channel (--telegram, --slack, or --discord)', ErrorCode.MISSING_PARAM);
+        const missing = [];
+        if (!name) missing.push('--name');
+        if (!type) missing.push('--type');
+        if (!timeWindow) missing.push('--time-window');
+        if (!channels) missing.push('a channel (--telegram, --slack, or --discord)');
+        if (missing.length > 0) {
+          throw new NansenError(`Required: ${missing.join(', ')}`, ErrorCode.MISSING_PARAM);
         }
         return apiInstance.alertsCreate({
           name,
@@ -1411,8 +1417,8 @@ EXAMPLES:
         });
       },
       'update': () => {
-        const id = options.id;
-        if (!id) throw new NansenError('Required: --id', ErrorCode.MISSING_PARAM);
+        const id = args[1];
+        if (!id) throw new NansenError('Required: <id>', ErrorCode.MISSING_PARAM);
         const params = { id };
         if (options.name) params.name = options.name;
         if (options.type) params.type = options.type;
@@ -1427,15 +1433,15 @@ EXAMPLES:
         return apiInstance.alertsUpdate(params);
       },
       'toggle': () => {
-        const id = options.id;
-        if (!id) throw new NansenError('Required: --id', ErrorCode.MISSING_PARAM);
+        const id = args[1];
+        if (!id) throw new NansenError('Required: <id>', ErrorCode.MISSING_PARAM);
         const isEnabled = flags.enabled ? true : flags.disabled ? false : undefined;
         if (isEnabled === undefined) throw new NansenError('Required: --enabled or --disabled', ErrorCode.MISSING_PARAM);
         return apiInstance.alertsToggle({ id, isEnabled });
       },
       'delete': () => {
-        const id = options.id;
-        if (!id) throw new NansenError('Required: --id', ErrorCode.MISSING_PARAM);
+        const id = args[1];
+        if (!id) throw new NansenError('Required: <id>', ErrorCode.MISSING_PARAM);
         return apiInstance.alertsDelete(id);
       },
     };

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,6 +6,7 @@
 import { NansenAPI, NansenError, ErrorCode, saveConfig, deleteConfig, getConfigFile, clearCache, getCacheDir, validateAddress, sleep } from './api.js';
 import { buildWalletCommands } from './wallet.js';
 import { buildTradingCommands } from './trading.js';
+import { formatAlertsTable, buildAlertsCommands, buildAlertData } from './commands/alerts.js';
 import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
@@ -169,13 +170,23 @@ export function parseArgs(args) {
         // Try to parse as JSON first (for objects/arrays/booleans),
         // but keep numeric strings as strings to avoid precision loss
         // and scientific notation for large integers (e.g. 1e+21).
+        let parsedValue;
         try {
           const parsed = JSON.parse(next);
-          result.options[key] = typeof parsed === 'number' ? next : parsed;
+          parsedValue = typeof parsed === 'number' ? next : parsed;
         } catch {
-          result.options[key] = next;
+          parsedValue = next;
         }
         i++;
+        // Accumulate repeated options into arrays (supports repeatable flags like --token, --subject)
+        if (key in result.options) {
+          if (!Array.isArray(result.options[key])) {
+            result.options[key] = [result.options[key]];
+          }
+          result.options[key].push(parsedValue);
+        } else {
+          result.options[key] = parsedValue;
+        }
       } else {
         result.flags[key] = true;
       }
@@ -202,45 +213,8 @@ export function formatValue(val) {
   return String(val);
 }
 
-// Format alerts list as human-readable table
-export function formatAlertsTable(alerts) {
-  if (!Array.isArray(alerts) || alerts.length === 0) {
-    return 'No alerts';
-  }
-
-  const formatChannels = (channels) => {
-    if (!channels || !Array.isArray(channels) || channels.length === 0) return '';
-    return channels.map(ch => ch.type).join(', ');
-  };
-
-  const formatEnabled = (isEnabled) => isEnabled ? '✓' : '✗';
-
-  const truncate = (str, maxLen) => {
-    if (!str) return '';
-    return str.length > maxLen ? str.slice(0, maxLen - 1) + '…' : str;
-  };
-
-  const idWidth = Math.max(2, Math.max(...alerts.map(a => (a.id || '').length)));
-  const nameWidth = Math.max(4, Math.min(30, Math.max(...alerts.map(a => (a.name || '').length))));
-  const typeWidth = Math.max(4, Math.min(25, Math.max(...alerts.map(a => (a.type || '').length))));
-  const channelsWidth = Math.max(8, Math.min(20, Math.max(...alerts.map(a => formatChannels(a.channels).length))));
-
-  const lines = [];
-  const header = `${'ID'.padEnd(idWidth)} │ ${'NAME'.padEnd(nameWidth)} │ ${'TYPE'.padEnd(typeWidth)} │ ${'ENABLED'.padEnd(7)} │ ${'CHANNELS'.padEnd(channelsWidth)}`;
-  lines.push(header);
-  lines.push('─'.repeat(idWidth) + '─┼─' + '─'.repeat(nameWidth) + '─┼─' + '─'.repeat(typeWidth) + '─┼─' + '─'.repeat(7) + '─┼─' + '─'.repeat(channelsWidth));
-
-  for (const alert of alerts) {
-    const id = (alert.id || '').padEnd(idWidth);
-    const name = truncate(alert.name, nameWidth).padEnd(nameWidth);
-    const type = truncate(alert.type, typeWidth).padEnd(typeWidth);
-    const enabled = formatEnabled(alert.isEnabled).padEnd(7);
-    const channels = truncate(formatChannels(alert.channels), channelsWidth).padEnd(channelsWidth);
-    lines.push(`${id} │ ${name} │ ${type} │ ${enabled} │ ${channels}`);
-  }
-
-  return lines.join('\n');
-}
+// formatAlertsTable is exported from ./commands/alerts.js (re-exported for backwards compat)
+export { formatAlertsTable, buildAlertData };
 
 // Table formatter for human-readable output
 export function formatTable(data) {
@@ -1372,135 +1346,6 @@ SYMBOLS:
     return tradingCmds[sub](args.slice(1), apiInstance, flags, options);
   };
 
-  // 'alerts' — smart alert CRUD
-  cmds['alerts'] = async (args, apiInstance, flags, options) => {
-    const sub = args[0];
-    if (!sub || sub === 'help' || flags.help || flags.h) {
-      log(`nansen alerts — Smart alert management
-
-SUBCOMMANDS:
-  list        List all alerts
-  create      Create a new alert
-  update      Update an existing alert
-  toggle      Enable or disable an alert
-  delete      Delete an alert
-
-USAGE:
-  nansen alerts list
-  nansen alerts create --name <name> --type <type> --time-window <window> --chains <chains> --telegram <chatId> [--data '<json>']
-  nansen alerts update <id> [--name <name>] [--chains <chains>] [--data '<json>']
-  nansen alerts toggle <id> --enabled
-  nansen alerts toggle <id> --disabled
-  nansen alerts delete <id>
-
-OPTIONS:
-  --chains <chains>       Comma-separated chains (e.g. ethereum,solana). Merged into --data.
-  --telegram <chatId>     Send to Telegram chat.
-  --slack <webhookUrl>    Send to Slack webhook.
-  --discord <webhookUrl>  Send to Discord webhook. Combine multiple channel flags for multi-channel alerts.
-  --data '<json>'         Alert config as JSON. --chains is merged on top if both provided.
-  --description '<text>'  Alert description. Use single quotes to avoid shell interpolation.
-
-EXAMPLES:
-  nansen alerts list --table
-  nansen alerts create --name 'ETH SM Flows' --type sm-token-flows --time-window 1h --chains ethereum --telegram 5238612255 --description 'Alert when SM pours $1M+ into ETH' --data '{"events":["sm-token-flows"],"inflow_1h":{"min":100000}}'
-  nansen alerts toggle abc123 --disabled
-  nansen alerts delete abc123`);
-      return;
-    }
-
-    // Build alert data by merging --chains into --data (if provided)
-    function buildAlertData() {
-      let data = {};
-      if (options.data) {
-        if (typeof options.data === 'string') {
-          try {
-            data = JSON.parse(options.data);
-          } catch {
-            throw new NansenError('--data must be valid JSON', ErrorCode.INVALID_PARAM);
-          }
-        } else {
-          data = options.data;
-        }
-      }
-      if (options.chains) {
-        const chains = typeof options.chains === 'string' ? options.chains.split(',') : Array.isArray(options.chains) ? options.chains : [options.chains];
-        data = { ...data, chains };
-      }
-      return data;
-    }
-
-    // Build channels array from --telegram/--slack/--discord flags
-    function buildChannels() {
-      const channels = [];
-      if (options.telegram) channels.push({ type: 'telegram', data: { chatId: String(options.telegram) } });
-      if (options.slack) channels.push({ type: 'slack', data: { webhookUrl: options.slack } });
-      if (options.discord) channels.push({ type: 'discord', data: { webhookUrl: options.discord } });
-      return channels.length > 0 ? channels : null;
-    }
-
-    const handlers = {
-      'list': () => apiInstance.alertsList(),
-      'create': () => {
-        const name = options.name;
-        const type = options.type;
-        const timeWindow = options['time-window'];
-        const channels = buildChannels();
-        const data = buildAlertData();
-        const missing = [];
-        if (!name) missing.push('--name');
-        if (!type) missing.push('--type');
-        if (!timeWindow) missing.push('--time-window');
-        if (!channels) missing.push('a channel (--telegram, --slack, or --discord)');
-        if (missing.length > 0) {
-          throw new NansenError(`Required: ${missing.join(', ')}`, ErrorCode.MISSING_PARAM);
-        }
-        return apiInstance.alertsCreate({
-          name,
-          type,
-          timeWindow,
-          channels,
-          data,
-          ...(options.description ? { description: options.description } : {}),
-          isEnabled: !flags.disabled,
-        });
-      },
-      'update': () => {
-        const id = args[1];
-        if (!id) throw new NansenError('Required: <id>', ErrorCode.MISSING_PARAM);
-        const params = { id };
-        if (options.name) params.name = options.name;
-        if (options.type) params.type = options.type;
-        if (options['time-window']) params.timeWindow = options['time-window'];
-        const channels = buildChannels();
-        if (channels) params.channels = channels;
-        const data = buildAlertData();
-        if (Object.keys(data).length > 0) params.data = data;
-        if (options.description) params.description = options.description;
-        if (flags.enabled) params.isEnabled = true;
-        if (flags.disabled) params.isEnabled = false;
-        return apiInstance.alertsUpdate(params);
-      },
-      'toggle': () => {
-        const id = args[1];
-        if (!id) throw new NansenError('Required: <id>', ErrorCode.MISSING_PARAM);
-        const isEnabled = flags.enabled ? true : flags.disabled ? false : undefined;
-        if (isEnabled === undefined) throw new NansenError('Required: --enabled or --disabled', ErrorCode.MISSING_PARAM);
-        return apiInstance.alertsToggle({ id, isEnabled });
-      },
-      'delete': () => {
-        const id = args[1];
-        if (!id) throw new NansenError('Required: <id>', ErrorCode.MISSING_PARAM);
-        return apiInstance.alertsDelete(id);
-      },
-    };
-
-    if (!handlers[sub]) {
-      throw new NansenError(`Unknown alerts subcommand: ${sub}. Available: list, create, update, toggle, delete`, ErrorCode.UNKNOWN);
-    }
-    return handlers[sub]();
-  };
-
   return cmds;
 }
 
@@ -1609,7 +1454,7 @@ export async function runCLI(rawArgs, deps = {}) {
     if (updateNotification) errorOutput(updateNotification);
   };
 
-  const commands = { ...buildCommands(deps), ...buildWalletCommands(deps), ...buildTradingCommands(deps), ...commandOverrides };
+  const commands = { ...buildCommands(deps), ...buildWalletCommands(deps), ...buildTradingCommands(deps), ...buildAlertsCommands(deps), ...commandOverrides };
 
   if (flags.version || flags.v) {
     output(VERSION);

--- a/src/cli.js
+++ b/src/cli.js
@@ -202,6 +202,44 @@ export function formatValue(val) {
   return String(val);
 }
 
+// Format alerts list as human-readable table
+export function formatAlertsTable(alerts) {
+  if (!Array.isArray(alerts) || alerts.length === 0) {
+    return 'No alerts';
+  }
+
+  const formatChannels = (channels) => {
+    if (!channels || !Array.isArray(channels) || channels.length === 0) return '';
+    return channels.map(ch => ch.type).join(', ');
+  };
+
+  const formatEnabled = (isEnabled) => isEnabled ? '✓' : '';
+
+  const truncate = (str, maxLen) => {
+    if (!str) return '';
+    return str.length > maxLen ? str.slice(0, maxLen - 1) + '…' : str;
+  };
+
+  const nameWidth = Math.max(4, Math.min(30, Math.max(...alerts.map(a => (a.name || '').length))));
+  const typeWidth = Math.max(4, Math.min(25, Math.max(...alerts.map(a => (a.type || '').length))));
+  const channelsWidth = Math.max(8, Math.min(20, Math.max(...alerts.map(a => formatChannels(a.channels).length))));
+
+  const lines = [];
+  const header = `${'NAME'.padEnd(nameWidth)} │ ${'TYPE'.padEnd(typeWidth)} │ ${'ENABLED'.padEnd(7)} │ ${'CHANNELS'.padEnd(channelsWidth)}`;
+  lines.push(header);
+  lines.push('─'.repeat(nameWidth) + '─┼─' + '─'.repeat(typeWidth) + '─┼─' + '─'.repeat(7) + '─┼─' + '─'.repeat(channelsWidth));
+
+  for (const alert of alerts) {
+    const name = truncate(alert.name, nameWidth).padEnd(nameWidth);
+    const type = truncate(alert.type, typeWidth).padEnd(typeWidth);
+    const enabled = formatEnabled(alert.isEnabled).padEnd(7);
+    const channels = truncate(formatChannels(alert.channels), channelsWidth).padEnd(channelsWidth);
+    lines.push(`${name} │ ${type} │ ${enabled} │ ${channels}`);
+  }
+
+  return lines.join('\n');
+}
+
 // Table formatter for human-readable output
 export function formatTable(data) {
   // Extract array of records from various response shapes
@@ -226,7 +264,7 @@ export function formatTable(data) {
   // Get columns from first record, prioritize common useful fields
   const priorityFields = ['token_symbol', 'token_name', 'symbol', 'name', 'address', 'label', 'chain', 'value_usd', 'amount', 'pnl_usd', 'price_usd', 'volume_usd', 'net_flow_usd', 'timestamp', 'block_timestamp'];
   const allKeys = [...new Set(records.flatMap(r => Object.keys(r)))];
-  
+
   // Sort: priority fields first, then alphabetically
   const columns = allKeys.sort((a, b) => {
     const aIdx = priorityFields.indexOf(a);
@@ -250,12 +288,12 @@ export function formatTable(data) {
   // Build table
   const separator = '─';
   const lines = [];
-  
+
   // Header
   const header = columns.map((col, i) => col.padEnd(widths[i])).join(' │ ');
   lines.push(header);
   lines.push(widths.map(w => separator.repeat(w)).join('─┼─'));
-  
+
   // Rows
   for (const record of records.slice(0, 50)) { // Limit to 50 rows
     const row = columns.map((col, i) => {
@@ -1362,7 +1400,7 @@ OPTIONS:
   --description '<text>'  Alert description. Use single quotes to avoid shell interpolation.
 
 EXAMPLES:
-  nansen alerts list --pretty
+  nansen alerts list --table
   nansen alerts create --name 'ETH SM Flows' --type sm-token-flows --time-window 1h --chains ethereum --telegram 5238612255 --description 'Alert when SM pours $1M+ into ETH' --data '{"events":["sm-token-flows"],"inflow_1h":{"min":100000}}'
   nansen alerts toggle abc123 --disabled
   nansen alerts delete abc123`);
@@ -1598,7 +1636,7 @@ export async function runCLI(rawArgs, deps = {}) {
       }
       // First try subcommand help
       // Skip for 'trade' — its handlers show their own rich usage when required args are missing
-      if (command && subcommand && command !== 'trade' && command !== 'alerts') {
+      if (command && subcommand && command !== 'trade') {
         const subHelp = generateSubcommandHelp(command, subcommand);
         if (subHelp) {
           output(subHelp);
@@ -1608,7 +1646,7 @@ export async function runCLI(rawArgs, deps = {}) {
       }
       // Then try command-level help (list subcommands)
       // Skip for 'trade' — let the handler show its own usage
-      const cmdSchemaLookup = command !== 'trade' && command !== 'alerts' && (SCHEMA.commands[command] || SCHEMA.commands.research.subcommands[command]);
+      const cmdSchemaLookup = command !== 'trade' && (SCHEMA.commands[command] || SCHEMA.commands.research.subcommands[command]);
       if (command && cmdSchemaLookup) {
         const cmdSchema = cmdSchemaLookup;
         const lines = [`${command} — ${cmdSchema.description}`];
@@ -1687,6 +1725,13 @@ export async function runCLI(rawArgs, deps = {}) {
       output(formatted.text);
       notify();
       return { type: 'schema', data: result };
+    }
+
+    // Alerts list with --table uses custom table format
+    if (command === 'alerts' && subcommand === 'list' && table) {
+      output(formatAlertsTable(result));
+      notify();
+      return { type: 'success', data: result };
     }
 
     // Apply field filtering if --fields is specified

--- a/src/cli.js
+++ b/src/cli.js
@@ -1488,8 +1488,8 @@ export async function runCLI(rawArgs, deps = {}) {
         }
       }
       // First try subcommand help
-      // Skip for 'trade' — its handlers show their own rich usage when required args are missing
-      if (command && subcommand && command !== 'trade') {
+      // Skip for 'trade'/'alerts' — their handlers show their own rich usage
+      if (command && subcommand && command !== 'trade' && command !== 'alerts') {
         const subHelp = generateSubcommandHelp(command, subcommand);
         if (subHelp) {
           output(subHelp);
@@ -1498,8 +1498,8 @@ export async function runCLI(rawArgs, deps = {}) {
         }
       }
       // Then try command-level help (list subcommands)
-      // Skip for 'trade' — let the handler show its own usage
-      const cmdSchemaLookup = command !== 'trade' && (SCHEMA.commands[command] || SCHEMA.commands.research.subcommands[command]);
+      // Skip for 'trade'/'alerts' — let the handler show its own usage
+      const cmdSchemaLookup = command !== 'trade' && command !== 'alerts' && (SCHEMA.commands[command] || SCHEMA.commands.research.subcommands[command]);
       if (command && cmdSchemaLookup) {
         const cmdSchema = cmdSchemaLookup;
         const lines = [`${command} — ${cmdSchema.description}`];

--- a/src/cli.js
+++ b/src/cli.js
@@ -213,7 +213,7 @@ export function formatAlertsTable(alerts) {
     return channels.map(ch => ch.type).join(', ');
   };
 
-  const formatEnabled = (isEnabled) => isEnabled ? '✓' : '';
+  const formatEnabled = (isEnabled) => isEnabled ? '✓' : '✗';
 
   const truncate = (str, maxLen) => {
     if (!str) return '';

--- a/src/cli.js
+++ b/src/cli.js
@@ -213,7 +213,7 @@ export function formatValue(val) {
   return String(val);
 }
 
-// formatAlertsTable is exported from ./commands/alerts.js (re-exported for backwards compat)
+// Re-exported from ./commands/alerts.js for convenience (e.g. tests, external callers)
 export { formatAlertsTable, buildAlertData };
 
 // Table formatter for human-readable output

--- a/src/cli.js
+++ b/src/cli.js
@@ -220,21 +220,23 @@ export function formatAlertsTable(alerts) {
     return str.length > maxLen ? str.slice(0, maxLen - 1) + '…' : str;
   };
 
+  const idWidth = Math.max(2, Math.max(...alerts.map(a => (a.id || '').length)));
   const nameWidth = Math.max(4, Math.min(30, Math.max(...alerts.map(a => (a.name || '').length))));
   const typeWidth = Math.max(4, Math.min(25, Math.max(...alerts.map(a => (a.type || '').length))));
   const channelsWidth = Math.max(8, Math.min(20, Math.max(...alerts.map(a => formatChannels(a.channels).length))));
 
   const lines = [];
-  const header = `${'NAME'.padEnd(nameWidth)} │ ${'TYPE'.padEnd(typeWidth)} │ ${'ENABLED'.padEnd(7)} │ ${'CHANNELS'.padEnd(channelsWidth)}`;
+  const header = `${'ID'.padEnd(idWidth)} │ ${'NAME'.padEnd(nameWidth)} │ ${'TYPE'.padEnd(typeWidth)} │ ${'ENABLED'.padEnd(7)} │ ${'CHANNELS'.padEnd(channelsWidth)}`;
   lines.push(header);
-  lines.push('─'.repeat(nameWidth) + '─┼─' + '─'.repeat(typeWidth) + '─┼─' + '─'.repeat(7) + '─┼─' + '─'.repeat(channelsWidth));
+  lines.push('─'.repeat(idWidth) + '─┼─' + '─'.repeat(nameWidth) + '─┼─' + '─'.repeat(typeWidth) + '─┼─' + '─'.repeat(7) + '─┼─' + '─'.repeat(channelsWidth));
 
   for (const alert of alerts) {
+    const id = (alert.id || '').padEnd(idWidth);
     const name = truncate(alert.name, nameWidth).padEnd(nameWidth);
     const type = truncate(alert.type, typeWidth).padEnd(typeWidth);
     const enabled = formatEnabled(alert.isEnabled).padEnd(7);
     const channels = truncate(formatChannels(alert.channels), channelsWidth).padEnd(channelsWidth);
-    lines.push(`${name} │ ${type} │ ${enabled} │ ${channels}`);
+    lines.push(`${id} │ ${name} │ ${type} │ ${enabled} │ ${channels}`);
   }
 
   return lines.join('\n');
@@ -1736,17 +1738,17 @@ export async function runCLI(rawArgs, deps = {}) {
       return { type: 'schema', data: result };
     }
 
+    // Apply field filtering if --fields is specified
+    const fields = parseFields(options.fields);
+    if (fields) {
+      result = filterFields(result, fields);
+    }
+
     // Alerts list with --table uses custom table format
     if (command === 'alerts' && subcommand === 'list' && table) {
       output(formatAlertsTable(result));
       notify();
       return { type: 'success', data: result };
-    }
-
-    // Apply field filtering if --fields is specified
-    const fields = parseFields(options.fields);
-    if (fields) {
-      result = filterFields(result, fields);
     }
 
     // Output in requested format

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,7 +6,7 @@
 import { NansenAPI, NansenError, ErrorCode, saveConfig, deleteConfig, getConfigFile, clearCache, getCacheDir, validateAddress, sleep } from './api.js';
 import { buildWalletCommands } from './wallet.js';
 import { buildTradingCommands } from './trading.js';
-import { formatAlertsTable, buildAlertsCommands, buildAlertData } from './commands/alerts.js';
+import { formatAlertsTable, buildAlertsCommands } from './commands/alerts.js';
 import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
@@ -212,9 +212,6 @@ export function formatValue(val) {
   if (typeof val === 'object') return JSON.stringify(val);
   return String(val);
 }
-
-// Re-exported from ./commands/alerts.js for convenience (e.g. tests, external callers)
-export { formatAlertsTable, buildAlertData };
 
 // Table formatter for human-readable output
 export function formatTable(data) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -163,7 +163,7 @@ export function parseArgs(args) {
       const key = arg.slice(2);
       const next = args[i + 1];
       
-      if (key === 'pretty' || key === 'help' || key === 'version' || key === 'table' || key === 'no-retry' || key === 'cache' || key === 'no-cache' || key === 'stream' || key === 'enrich' || key === 'full' || key === 'human') {
+      if (key === 'pretty' || key === 'help' || key === 'version' || key === 'table' || key === 'no-retry' || key === 'cache' || key === 'no-cache' || key === 'stream' || key === 'enrich' || key === 'full' || key === 'human' || key === 'enabled' || key === 'disabled') {
         result.flags[key] = true;
       } else if (next && !next.startsWith('-')) {
         // Try to parse as JSON first (for objects/arrays/booleans),
@@ -1332,6 +1332,120 @@ SYMBOLS:
     return tradingCmds[sub](args.slice(1), apiInstance, flags, options);
   };
 
+  // 'alerts' — smart alert CRUD
+  cmds['alerts'] = async (args, apiInstance, flags, options) => {
+    const sub = args[0];
+    if (!sub || sub === 'help') {
+      log(`nansen alerts — Smart alert management
+
+SUBCOMMANDS:
+  list        List all alerts
+  create      Create a new alert
+  update      Update an existing alert
+  toggle      Enable or disable an alert
+  delete      Delete an alert
+
+USAGE:
+  nansen alerts list
+  nansen alerts create --name <name> --type <type> --time-window <window> --chains <chains> --telegram <chatId> [--data '<json>']
+  nansen alerts update --id <id> [--name <name>] [--chains <chains>] [--data '<json>']
+  nansen alerts toggle --id <id> --enabled
+  nansen alerts toggle --id <id> --disabled
+  nansen alerts delete --id <id>
+
+OPTIONS:
+  --chains <chains>       Comma-separated chains (e.g. ethereum,solana). Merged into --data.
+  --telegram <chatId>     Send to Telegram chat. Use --channels for multiple.
+  --slack <webhookUrl>    Send to Slack webhook.
+  --discord <webhookUrl>  Send to Discord webhook.
+  --data '<json>'         Alert config as JSON. --chains is merged on top if both provided.
+
+EXAMPLES:
+  nansen alerts list --pretty
+  nansen alerts create --name "ETH SM Flows" --type sm-token-flows --time-window 1h --chains ethereum --telegram 5238612255 --data '{"events":["sm-token-flows"],"inflow_1h":{"min":100000}}'
+  nansen alerts toggle --id abc123 --disabled
+  nansen alerts delete --id abc123`);
+      return;
+    }
+
+    // Build alert data by merging --chains into --data (if provided)
+    function buildAlertData() {
+      let data = options.data
+        ? (typeof options.data === 'string' ? JSON.parse(options.data) : options.data)
+        : {};
+      if (options.chains) {
+        const chains = typeof options.chains === 'string' ? options.chains.split(',') : Array.isArray(options.chains) ? options.chains : [options.chains];
+        data = { ...data, chains };
+      }
+      return data;
+    }
+
+    // Build channels array from --telegram/--slack/--discord flags
+    function buildChannels() {
+      const channels = [];
+      if (options.telegram) channels.push({ type: 'telegram', data: { chatId: String(options.telegram) } });
+      if (options.slack) channels.push({ type: 'slack', data: { webhookUrl: options.slack } });
+      if (options.discord) channels.push({ type: 'discord', data: { webhookUrl: options.discord } });
+      return channels.length > 0 ? channels : null;
+    }
+
+    const handlers = {
+      'list': () => apiInstance.alertsList(),
+      'create': () => {
+        const name = options.name;
+        const type = options.type;
+        const timeWindow = options['time-window'];
+        const channels = buildChannels();
+        const data = buildAlertData();
+        if (!name || !type || !timeWindow || !channels) {
+          throw new NansenError('Required: --name, --type, --time-window, and a channel (--telegram, --slack, or --discord)', ErrorCode.MISSING_PARAM);
+        }
+        return apiInstance.alertsCreate({
+          name,
+          type,
+          timeWindow,
+          channels,
+          data,
+          ...(options.description ? { description: options.description } : {}),
+          isEnabled: !flags.disabled,
+        });
+      },
+      'update': () => {
+        const id = options.id;
+        if (!id) throw new NansenError('Required: --id', ErrorCode.MISSING_PARAM);
+        const params = { id };
+        if (options.name) params.name = options.name;
+        if (options.type) params.type = options.type;
+        if (options['time-window']) params.timeWindow = options['time-window'];
+        const channels = buildChannels();
+        if (channels) params.channels = channels;
+        const data = buildAlertData();
+        if (Object.keys(data).length > 0) params.data = data;
+        if (options.description) params.description = options.description;
+        if (flags.enabled) params.isEnabled = true;
+        if (flags.disabled) params.isEnabled = false;
+        return apiInstance.alertsUpdate(params);
+      },
+      'toggle': () => {
+        const id = options.id;
+        if (!id) throw new NansenError('Required: --id', ErrorCode.MISSING_PARAM);
+        const isEnabled = flags.enabled ? true : flags.disabled ? false : undefined;
+        if (isEnabled === undefined) throw new NansenError('Required: --enabled or --disabled', ErrorCode.MISSING_PARAM);
+        return apiInstance.alertsToggle({ id, isEnabled });
+      },
+      'delete': () => {
+        const id = options.id;
+        if (!id) throw new NansenError('Required: --id', ErrorCode.MISSING_PARAM);
+        return apiInstance.alertsDelete(id);
+      },
+    };
+
+    if (!handlers[sub]) {
+      throw new NansenError(`Unknown alerts subcommand: ${sub}. Available: list, create, update, toggle, delete`, ErrorCode.UNKNOWN);
+    }
+    return handlers[sub]();
+  };
+
   return cmds;
 }
 
@@ -1478,7 +1592,7 @@ export async function runCLI(rawArgs, deps = {}) {
       }
       // First try subcommand help
       // Skip for 'trade' — its handlers show their own rich usage when required args are missing
-      if (command && subcommand && command !== 'trade') {
+      if (command && subcommand && command !== 'trade' && command !== 'alerts') {
         const subHelp = generateSubcommandHelp(command, subcommand);
         if (subHelp) {
           output(subHelp);
@@ -1488,7 +1602,7 @@ export async function runCLI(rawArgs, deps = {}) {
       }
       // Then try command-level help (list subcommands)
       // Skip for 'trade' — let the handler show its own usage
-      const cmdSchemaLookup = command !== 'trade' && (SCHEMA.commands[command] || SCHEMA.commands.research.subcommands[command]);
+      const cmdSchemaLookup = command !== 'trade' && command !== 'alerts' && (SCHEMA.commands[command] || SCHEMA.commands.research.subcommands[command]);
       if (command && cmdSchemaLookup) {
         const cmdSchema = cmdSchemaLookup;
         const lines = [`${command} — ${cmdSchema.description}`];

--- a/src/cli.js
+++ b/src/cli.js
@@ -944,7 +944,7 @@ export function buildCommands(deps = {}) {
           : [options.labels];
       }
 
-      const days = options.days ? parseInt(options.days) : 30;
+      const days = options.days ? parseInt(options.days, 10) : 30;
 
       const handlers = {
         'netflow': () => apiInstance.smartMoneyNetflow({ chains, filters, orderBy, pagination }),
@@ -961,7 +961,7 @@ export function buildCommands(deps = {}) {
       };
 
       if (!handlers[subcommand]) {
-        return { error: `Unknown subcommand: ${subcommand}`, available: Object.keys(handlers) };
+        throw new NansenError(`Unknown subcommand: ${subcommand}. Available: ${Object.keys(handlers).filter(k => k !== 'help').join(', ')}`, ErrorCode.INVALID_PARAMS);
       }
 
       return handlers[subcommand]();
@@ -987,7 +987,7 @@ export function buildCommands(deps = {}) {
       const filters = options.filters || {};
       const orderBy = parseSort(options.sort, options['order-by']);
       const pagination = buildPagination(options);
-      const days = options.days ? parseInt(options.days) : 30;
+      const days = options.days ? parseInt(options.days, 10) : 30;
 
       const handlers = {
         'balance': () => apiInstance.addressBalance({ address, entityName, chain, filters, orderBy }),
@@ -1031,13 +1031,13 @@ export function buildCommands(deps = {}) {
             throw new NansenError('Batch is limited to 100 addresses', ErrorCode.INVALID_PARAMS);
           }
           const include = options.include ? options.include.split(',').map(s => s.trim()) : ['labels', 'balance'];
-          const delayMs = options.delay ? parseInt(options.delay) : 1000;
+          const delayMs = options.delay ? parseInt(options.delay, 10) : 1000;
           return batchProfile(apiInstance, { addresses, chain, include, delayMs });
         },
         'trace': () => {
-          const depth = options.depth ? Math.max(1, Math.min(parseInt(options.depth), 5)) : 2;
-          const width = options.width ? parseInt(options.width) : 10;
-          const delayMs = options.delay ? parseInt(options.delay) : 1000;
+          const depth = options.depth ? Math.max(1, Math.min(parseInt(options.depth, 10), 5)) : 2;
+          const width = options.width ? parseInt(options.width, 10) : 10;
+          const delayMs = options.delay ? parseInt(options.delay, 10) : 1000;
           return traceCounterparties(apiInstance, { address, chain, depth, width, days, delayMs });
         },
         'compare': () => {
@@ -1052,7 +1052,7 @@ export function buildCommands(deps = {}) {
       };
 
       if (!handlers[subcommand]) {
-        return { error: `Unknown subcommand: ${subcommand}`, available: Object.keys(handlers) };
+        throw new NansenError(`Unknown subcommand: ${subcommand}. Available: ${Object.keys(handlers).filter(k => k !== 'help').join(', ')}`, ErrorCode.INVALID_PARAMS);
       }
 
       const result = await handlers[subcommand]();
@@ -1073,7 +1073,7 @@ export function buildCommands(deps = {}) {
       const filters = options.filters || {};
       const orderBy = parseSort(options.sort, options['order-by']);
       const pagination = buildPagination(options);
-      const days = options.days ? parseInt(options.days) : 30;
+      const days = options.days ? parseInt(options.days, 10) : 30;
 
       // Convenience filter for smart money only
       const onlySmartMoney = options['smart-money'] || flags['smart-money'] || false;
@@ -1140,7 +1140,7 @@ export function buildCommands(deps = {}) {
       };
 
       if (!handlers[subcommand]) {
-        return { error: `Unknown subcommand: ${subcommand}`, available: Object.keys(handlers) };
+        throw new NansenError(`Unknown subcommand: ${subcommand}. Available: ${Object.keys(handlers).filter(k => k !== 'help').join(', ')}`, ErrorCode.INVALID_PARAMS);
       }
 
       let result = await handlers[subcommand]();
@@ -1190,7 +1190,7 @@ export function buildCommands(deps = {}) {
       };
 
       if (!handlers[subcommand]) {
-        return { error: `Unknown subcommand: ${subcommand}`, available: Object.keys(handlers) };
+        throw new NansenError(`Unknown subcommand: ${subcommand}. Available: ${Object.keys(handlers).filter(k => k !== 'help').join(', ')}`, ErrorCode.INVALID_PARAMS);
       }
 
       return handlers[subcommand]();
@@ -1201,7 +1201,7 @@ export function buildCommands(deps = {}) {
       const filters = options.filters || {};
       const orderBy = parseSort(options.sort, options['order-by']);
       const pagination = buildPagination(options);
-      const days = options.days ? parseInt(options.days) : 30;
+      const days = options.days ? parseInt(options.days, 10) : 30;
 
       const handlers = {
         'screener': () => apiInstance.perpScreener({ filters, orderBy, pagination, days }),
@@ -1214,7 +1214,7 @@ export function buildCommands(deps = {}) {
       };
 
       if (!handlers[subcommand]) {
-        return { error: `Unknown subcommand: ${subcommand}`, available: Object.keys(handlers) };
+        throw new NansenError(`Unknown subcommand: ${subcommand}. Available: ${Object.keys(handlers).filter(k => k !== 'help').join(', ')}`, ErrorCode.INVALID_PARAMS);
       }
 
       return handlers[subcommand]();
@@ -1244,7 +1244,7 @@ export function buildCommands(deps = {}) {
       };
 
       if (!handlers[subcommand]) {
-        return { error: `Unknown subcommand: ${subcommand}`, available: Object.keys(handlers) };
+        throw new NansenError(`Unknown subcommand: ${subcommand}. Available: ${Object.keys(handlers).filter(k => k !== 'help').join(', ')}`, ErrorCode.INVALID_PARAMS);
       }
 
       return handlers[subcommand]();
@@ -1347,7 +1347,7 @@ SYMBOLS:
 }
 
 // Categories that moved under 'research'
-export const DEPRECATED_TO_RESEARCH = new Set(['smart-money', 'profiler', 'token', 'search', 'perp', 'portfolio', 'points']);
+export const DEPRECATED_TO_RESEARCH = new Set(['smart-money', 'profiler', 'token', 'search', 'perp', 'portfolio', 'points', 'prediction-market']);
 // Subcommands that moved under 'trade'
 export const DEPRECATED_TO_TRADE = new Set(['quote', 'execute']);
 

--- a/src/commands/alerts.js
+++ b/src/commands/alerts.js
@@ -1,0 +1,324 @@
+/**
+ * Nansen CLI - Alerts command
+ * Smart alert CRUD with type-specific named flags.
+ */
+
+import { NansenError, ErrorCode } from '../api.js';
+
+// ============= Formatting =============
+
+// Format alerts list as human-readable table
+export function formatAlertsTable(alerts) {
+  if (!Array.isArray(alerts) || alerts.length === 0) {
+    return 'No alerts';
+  }
+
+  const formatChannels = (channels) => {
+    if (!channels || !Array.isArray(channels) || channels.length === 0) return '';
+    return channels.map(ch => ch.type).join(', ');
+  };
+
+  const formatEnabled = (isEnabled) => isEnabled ? '✓' : '✗';
+
+  const truncate = (str, maxLen) => {
+    if (!str) return '';
+    return str.length > maxLen ? str.slice(0, maxLen - 1) + '…' : str;
+  };
+
+  const idWidth = Math.max(2, Math.max(...alerts.map(a => (a.id || '').length)));
+  const nameWidth = Math.max(4, Math.min(30, Math.max(...alerts.map(a => (a.name || '').length))));
+  const typeWidth = Math.max(4, Math.min(25, Math.max(...alerts.map(a => (a.type || '').length))));
+  const channelsWidth = Math.max(8, Math.min(20, Math.max(...alerts.map(a => formatChannels(a.channels).length))));
+
+  const lines = [];
+  const header = `${'ID'.padEnd(idWidth)} │ ${'NAME'.padEnd(nameWidth)} │ ${'TYPE'.padEnd(typeWidth)} │ ${'ENABLED'.padEnd(7)} │ ${'CHANNELS'.padEnd(channelsWidth)}`;
+  lines.push(header);
+  lines.push('─'.repeat(idWidth) + '─┼─' + '─'.repeat(nameWidth) + '─┼─' + '─'.repeat(typeWidth) + '─┼─' + '─'.repeat(7) + '─┼─' + '─'.repeat(channelsWidth));
+
+  for (const alert of alerts) {
+    const id = (alert.id || '').padEnd(idWidth);
+    const name = truncate(alert.name, nameWidth).padEnd(nameWidth);
+    const type = truncate(alert.type, typeWidth).padEnd(typeWidth);
+    const enabled = formatEnabled(alert.isEnabled).padEnd(7);
+    const channels = truncate(formatChannels(alert.channels), channelsWidth).padEnd(channelsWidth);
+    lines.push(`${id} │ ${name} │ ${type} │ ${enabled} │ ${channels}`);
+  }
+
+  return lines.join('\n');
+}
+
+// ============= Data Builders =============
+
+/**
+ * Parse a token string "address:chain" into { address, chain }.
+ * Handles single string or array of strings (from repeated --token flags).
+ */
+function parseTokens(tokenArg) {
+  if (!tokenArg) return undefined;
+  const tokens = Array.isArray(tokenArg) ? tokenArg : [tokenArg];
+  return tokens.map(t => {
+    const colonIdx = t.lastIndexOf(':');
+    if (colonIdx === -1) throw new NansenError(`Invalid token format: "${t}". Expected address:chain`, ErrorCode.INVALID_PARAM);
+    return { address: t.slice(0, colonIdx), chain: t.slice(colonIdx + 1) };
+  });
+}
+
+/**
+ * Parse a subject string "type:value" into { type, value }.
+ * Handles single string or array (from repeated --subject flags).
+ */
+function parseSubjects(subjectArg) {
+  if (!subjectArg) return undefined;
+  const subjects = Array.isArray(subjectArg) ? subjectArg : [subjectArg];
+  return subjects.map(s => {
+    const colonIdx = s.indexOf(':');
+    if (colonIdx === -1) throw new NansenError(`Invalid subject format: "${s}". Expected type:value`, ErrorCode.INVALID_PARAM);
+    return { type: s.slice(0, colonIdx), value: s.slice(colonIdx + 1) };
+  });
+}
+
+/**
+ * Normalise chains option to array.
+ */
+function parseChains(chainsOpt) {
+  if (!chainsOpt) return undefined;
+  if (Array.isArray(chainsOpt)) return chainsOpt;
+  return chainsOpt.split(',');
+}
+
+/**
+ * Build a { min, max } range object from two option values.
+ * Returns undefined if neither is provided.
+ */
+function buildRange(minVal, maxVal) {
+  if (minVal === undefined && maxVal === undefined) return undefined;
+  return {
+    min: minVal !== undefined ? Number(minVal) : null,
+    max: maxVal !== undefined ? Number(maxVal) : null,
+  };
+}
+
+/**
+ * Build the data payload for sm-token-flows alerts from named flags.
+ */
+export function buildSmTokenFlowsData(options) {
+  const data = {};
+
+  const chains = parseChains(options.chains);
+  if (chains) data.chains = chains;
+
+  const flowFields = ['inflow-1h', 'inflow-1d', 'inflow-7d', 'outflow-1h', 'outflow-1d', 'outflow-7d'];
+  for (const field of flowFields) {
+    const range = buildRange(options[`${field}-min`], options[`${field}-max`]);
+    if (range) {
+      // Convert CLI key "inflow-1h" → data key "inflow_1h"
+      data[field.replace(/-/g, '_')] = range;
+    }
+  }
+
+  const tokens = parseTokens(options.token);
+  const excludeTokens = parseTokens(options['exclude-token']);
+  if (tokens) data.inclusion = { tokens };
+  if (excludeTokens) data.exclusion = { tokens: excludeTokens };
+
+  return data;
+}
+
+/**
+ * Build the data payload for common-token-transfer alerts from named flags.
+ */
+export function buildCommonTokenTransferData(options) {
+  const data = {};
+
+  const chains = parseChains(options.chains);
+  if (chains) data.chains = chains;
+
+  if (options.events) {
+    data.events = typeof options.events === 'string' ? options.events.split(',') : options.events;
+  }
+
+  const usdRange = buildRange(options['usd-min'], options['usd-max']);
+  if (usdRange) data.usdValue = usdRange;
+
+  const amountRange = buildRange(options['token-amount-min'], options['token-amount-max']);
+  if (amountRange) data.tokenAmount = amountRange;
+
+  const subjects = parseSubjects(options.subject);
+  if (subjects) data.subjects = subjects;
+
+  const tokens = parseTokens(options.token);
+  const excludeTokens = parseTokens(options['exclude-token']);
+  if (tokens) data.inclusion = { tokens };
+  if (excludeTokens) data.exclusion = { tokens: excludeTokens };
+
+  return data;
+}
+
+/**
+ * Build the alert data payload from named flags, dispatching on type.
+ * --data '<json>' is merged on top as an escape-hatch override.
+ */
+export function buildAlertData(options) {
+  let data;
+
+  if (options.type === 'sm-token-flows') {
+    data = buildSmTokenFlowsData(options);
+  } else if (options.type === 'common-token-transfer') {
+    data = buildCommonTokenTransferData(options);
+  } else {
+    // Unknown / no type — minimal fallback: just handle chains
+    data = {};
+    const chains = parseChains(options.chains);
+    if (chains) data.chains = chains;
+  }
+
+  // Merge --data on top (power-user escape hatch, overrides named flags)
+  if (options.data) {
+    let override;
+    if (typeof options.data === 'string') {
+      try {
+        override = JSON.parse(options.data);
+      } catch {
+        throw new NansenError('--data must be valid JSON', ErrorCode.INVALID_PARAM);
+      }
+    } else {
+      override = options.data;
+    }
+    data = { ...data, ...override };
+  }
+
+  return data;
+}
+
+// ============= Command Builder =============
+
+export function buildAlertsCommands(deps = {}) {
+  const { log = console.log } = deps;
+
+  return {
+    'alerts': async (args, apiInstance, flags, options) => {
+      const sub = args[0];
+      if (!sub || sub === 'help' || flags.help || flags.h) {
+        log(`nansen alerts — Smart alert management
+
+SUBCOMMANDS:
+  list        List all alerts
+  create      Create a new alert
+  update      Update an existing alert
+  toggle      Enable or disable an alert
+  delete      Delete an alert
+
+USAGE:
+  nansen alerts list
+  nansen alerts create --name <name> --type <type> --time-window <window> --chains <chains> --telegram <chatId>
+  nansen alerts update <id> [--name <name>] [--chains <chains>]
+  nansen alerts toggle <id> --enabled
+  nansen alerts toggle <id> --disabled
+  nansen alerts delete <id>
+
+OPTIONS (all types):
+  --chains <chains>            Comma-separated chains (e.g. ethereum,solana).
+  --token <address:chain>      Filter by token (repeatable). Adds to inclusion list.
+  --exclude-token <addr:chain> Exclude token (repeatable). Adds to exclusion list.
+  --telegram <chatId>          Send to Telegram chat.
+  --slack <webhookUrl>         Send to Slack webhook.
+  --discord <webhookUrl>       Send to Discord webhook. Combine multiple channel flags.
+  --description '<text>'       Alert description.
+
+OPTIONS (sm-token-flows):
+  --inflow-1h-min <usd>   --inflow-1h-max <usd>
+  --inflow-1d-min <usd>   --inflow-1d-max <usd>
+  --inflow-7d-min <usd>   --inflow-7d-max <usd>
+  --outflow-1h-min <usd>  --outflow-1h-max <usd>
+  --outflow-1d-min <usd>  --outflow-1d-max <usd>
+  --outflow-7d-min <usd>  --outflow-7d-max <usd>
+
+OPTIONS (common-token-transfer):
+  --events <buy,sell,swap,send,receive>   Comma-separated event types.
+  --usd-min <usd>          --usd-max <usd>
+  --token-amount-min <n>   --token-amount-max <n>
+  --subject <type:value>   Filter by subject (repeatable, e.g. label:"Centralized Exchange").
+
+EXAMPLES:
+  nansen alerts list --table
+  nansen alerts create --name 'ETH SM Inflow' --type sm-token-flows --time-window 1h --chains ethereum --telegram 5238612255 --inflow-1h-min 1000000
+  nansen alerts create --name 'USDC Transfers' --type common-token-transfer --time-window 1h --chains ethereum --telegram 5238612255 --events send,receive --usd-min 1000000 --subject label:"Centralized Exchange"
+  nansen alerts toggle abc123 --disabled
+  nansen alerts delete abc123
+
+Advanced: use --data '<json>' to pass the full alert config directly (merged on top of any named flags).`);
+        return;
+      }
+
+      // Build channels array from --telegram/--slack/--discord flags
+      function buildChannels() {
+        const channels = [];
+        if (options.telegram) channels.push({ type: 'telegram', data: { chatId: String(options.telegram) } });
+        if (options.slack) channels.push({ type: 'slack', data: { webhookUrl: options.slack } });
+        if (options.discord) channels.push({ type: 'discord', data: { webhookUrl: options.discord } });
+        return channels.length > 0 ? channels : null;
+      }
+
+      const handlers = {
+        'list': () => apiInstance.alertsList(),
+        'create': () => {
+          const name = options.name;
+          const type = options.type;
+          const timeWindow = options['time-window'];
+          const channels = buildChannels();
+          const data = buildAlertData(options);
+          const missing = [];
+          if (!name) missing.push('--name');
+          if (!type) missing.push('--type');
+          if (!timeWindow) missing.push('--time-window');
+          if (!channels) missing.push('a channel (--telegram, --slack, or --discord)');
+          if (missing.length > 0) {
+            throw new NansenError(`Required: ${missing.join(', ')}`, ErrorCode.MISSING_PARAM);
+          }
+          return apiInstance.alertsCreate({
+            name,
+            type,
+            timeWindow,
+            channels,
+            data,
+            ...(options.description ? { description: options.description } : {}),
+            isEnabled: !flags.disabled,
+          });
+        },
+        'update': () => {
+          const id = args[1];
+          if (!id) throw new NansenError('Required: <id>', ErrorCode.MISSING_PARAM);
+          const params = { id };
+          if (options.name) params.name = options.name;
+          if (options.type) params.type = options.type;
+          if (options['time-window']) params.timeWindow = options['time-window'];
+          const channels = buildChannels();
+          if (channels) params.channels = channels;
+          const data = buildAlertData(options);
+          if (Object.keys(data).length > 0) params.data = data;
+          if (options.description) params.description = options.description;
+          if (flags.enabled) params.isEnabled = true;
+          if (flags.disabled) params.isEnabled = false;
+          return apiInstance.alertsUpdate(params);
+        },
+        'toggle': () => {
+          const id = args[1];
+          if (!id) throw new NansenError('Required: <id>', ErrorCode.MISSING_PARAM);
+          const isEnabled = flags.enabled ? true : flags.disabled ? false : undefined;
+          if (isEnabled === undefined) throw new NansenError('Required: --enabled or --disabled', ErrorCode.MISSING_PARAM);
+          return apiInstance.alertsToggle({ id, isEnabled });
+        },
+        'delete': () => {
+          const id = args[1];
+          if (!id) throw new NansenError('Required: <id>', ErrorCode.MISSING_PARAM);
+          return apiInstance.alertsDelete(id);
+        },
+      };
+
+      if (!handlers[sub]) {
+        throw new NansenError(`Unknown alerts subcommand: ${sub}. Available: list, create, update, toggle, delete`, ErrorCode.UNKNOWN);
+      }
+      return handlers[sub]();
+    },
+  };
+}

--- a/src/commands/alerts.js
+++ b/src/commands/alerts.js
@@ -107,7 +107,7 @@ export function buildSmTokenFlowsData(options) {
   const chains = parseChains(options.chains);
   if (chains) data.chains = chains;
 
-  const flowFields = ['inflow-1h', 'inflow-1d', 'inflow-7d', 'outflow-1h', 'outflow-1d', 'outflow-7d'];
+  const flowFields = ['inflow-1h', 'inflow-1d', 'inflow-7d', 'outflow-1h', 'outflow-1d', 'outflow-7d', 'netflow-1h', 'netflow-1d', 'netflow-7d'];
   for (const field of flowFields) {
     const range = buildRange(options[`${field}-min`], options[`${field}-max`]);
     if (range) {
@@ -146,10 +146,50 @@ export function buildCommonTokenTransferData(options) {
   const subjects = parseSubjects(options.subject);
   if (subjects) data.subjects = subjects;
 
+  const counterparties = parseSubjects(options.counterparty);
+  if (counterparties) data.counterparties = counterparties;
+
   const tokens = parseTokens(options.token);
   const excludeTokens = parseTokens(options['exclude-token']);
   if (tokens) data.inclusion = { tokens };
   if (excludeTokens) data.exclusion = { tokens: excludeTokens };
+
+  return data;
+}
+
+/**
+ * Build the data payload for smart-contract-call alerts from named flags.
+ */
+export function buildSmartContractCallData(options) {
+  const data = {};
+
+  const chains = parseChains(options.chains);
+  if (chains) data.chains = chains;
+
+  const usdRange = buildRange(options['usd-min'], options['usd-max']);
+  if (usdRange) data.usdValue = usdRange;
+
+  if (options['signature-hash']) {
+    data.signatureHash = Array.isArray(options['signature-hash'])
+      ? options['signature-hash']
+      : [options['signature-hash']];
+  }
+
+  const callers = parseSubjects(options.caller);
+  const contracts = parseSubjects(options.contract);
+  const excludeCallers = parseSubjects(options['exclude-caller']);
+  const excludeContracts = parseSubjects(options['exclude-contract']);
+
+  if (callers || contracts) {
+    data.inclusion = {};
+    if (callers) data.inclusion.caller = callers;
+    if (contracts) data.inclusion.smartContract = contracts;
+  }
+  if (excludeCallers || excludeContracts) {
+    data.exclusion = {};
+    if (excludeCallers) data.exclusion.caller = excludeCallers;
+    if (excludeContracts) data.exclusion.smartContract = excludeContracts;
+  }
 
   return data;
 }
@@ -165,6 +205,8 @@ export function buildAlertData(options) {
     data = buildSmTokenFlowsData(options);
   } else if (options.type === 'common-token-transfer') {
     data = buildCommonTokenTransferData(options);
+  } else if (options.type === 'smart-contract-call') {
+    data = buildSmartContractCallData(options);
   } else {
     // Unknown / no type — minimal fallback: just handle chains
     data = {};
@@ -209,12 +251,18 @@ SUBCOMMANDS:
   delete      Delete an alert
 
 USAGE:
-  nansen alerts list
+  nansen alerts list [--type sm-token-flows] [--enabled] [--disabled] [--token-address <addr>] [--chain <chain>] [--limit <n>] [--offset <n>]
   nansen alerts create --name <name> --type <type> --time-window <window> --chains <chains> --telegram <chatId>
   nansen alerts update <id> [--name <name>] [--chains <chains>]
   nansen alerts toggle <id> --enabled
   nansen alerts toggle <id> --disabled
   nansen alerts delete <id>
+
+SUBJECT TYPES:
+  address, entity, label, custom-label
+  Example: --subject address:0xabc  --subject label:"Centralized Exchange"
+
+  Chain aliases: For Hyperliquid use hyperevm, for BSC use bnb.
 
 OPTIONS (all types):
   --chains <chains>            Comma-separated chains (e.g. ethereum,solana).
@@ -226,23 +274,37 @@ OPTIONS (all types):
   --description '<text>'       Alert description.
 
 OPTIONS (sm-token-flows):
-  --inflow-1h-min <usd>   --inflow-1h-max <usd>
-  --inflow-1d-min <usd>   --inflow-1d-max <usd>
-  --inflow-7d-min <usd>   --inflow-7d-max <usd>
-  --outflow-1h-min <usd>  --outflow-1h-max <usd>
-  --outflow-1d-min <usd>  --outflow-1d-max <usd>
-  --outflow-7d-min <usd>  --outflow-7d-max <usd>
+  --inflow-1h-min <usd>    --inflow-1h-max <usd>
+  --inflow-1d-min <usd>    --inflow-1d-max <usd>
+  --inflow-7d-min <usd>    --inflow-7d-max <usd>
+  --outflow-1h-min <usd>   --outflow-1h-max <usd>
+  --outflow-1d-min <usd>   --outflow-1d-max <usd>
+  --outflow-7d-min <usd>   --outflow-7d-max <usd>
+  --netflow-1h-min <usd>   --netflow-1h-max <usd>
+  --netflow-1d-min <usd>   --netflow-1d-max <usd>
+  --netflow-7d-min <usd>   --netflow-7d-max <usd>
 
 OPTIONS (common-token-transfer):
   --events <buy,sell,swap,send,receive>   Comma-separated event types.
-  --usd-min <usd>          --usd-max <usd>
-  --token-amount-min <n>   --token-amount-max <n>
-  --subject <type:value>   Filter by subject (repeatable, e.g. label:"Centralized Exchange").
+  --usd-min <usd>              --usd-max <usd>
+  --token-amount-min <n>       --token-amount-max <n>
+  --subject <type:value>       Filter by subject (repeatable, e.g. label:"Centralized Exchange").
+  --counterparty <type:value>  Filter by counterparty (repeatable, same format as --subject).
+
+OPTIONS (smart-contract-call):
+  --usd-min <usd>              --usd-max <usd>
+  --signature-hash <hash>      Function signature hash (repeatable).
+  --caller <type:value>        Include callers (repeatable).
+  --contract <type:value>      Include smart contracts (repeatable).
+  --exclude-caller <type:value>    Exclude callers (repeatable).
+  --exclude-contract <type:value>  Exclude contracts (repeatable).
 
 EXAMPLES:
   nansen alerts list --table
+  nansen alerts list --type sm-token-flows --enabled
   nansen alerts create --name 'ETH SM Inflow' --type sm-token-flows --time-window 1h --chains ethereum --telegram 5238612255 --inflow-1h-min 1000000
   nansen alerts create --name 'USDC Transfers' --type common-token-transfer --time-window 1h --chains ethereum --telegram 5238612255 --events send,receive --usd-min 1000000 --subject label:"Centralized Exchange"
+  nansen alerts create --name 'Contract Calls' --type smart-contract-call --time-window 1h --chains ethereum --telegram 5238612255 --signature-hash 0xa9059cbb --caller address:0xabc
   nansen alerts toggle abc123 --disabled
   nansen alerts delete abc123
 
@@ -260,7 +322,17 @@ Advanced: use --data '<json>' to pass the full alert config directly (merged on 
       }
 
       const handlers = {
-        'list': () => apiInstance.alertsList(),
+        'list': () => {
+          const params = {};
+          if (options.type) params.type = options.type;
+          if (options['token-address']) params.tokenAddress = options['token-address'];
+          if (options.chain) params.chain = options.chain;
+          if (options.limit) params.limit = options.limit;
+          if (options.offset) params.offset = options.offset;
+          if (flags.enabled) params.isEnabled = true;
+          if (flags.disabled) params.isEnabled = false;
+          return apiInstance.alertsList(params);
+        },
         'create': () => {
           const name = options.name;
           const type = options.type;

--- a/src/commands/alerts.js
+++ b/src/commands/alerts.js
@@ -448,6 +448,7 @@ Advanced: use --data '<json>' to pass the full alert config directly (merged on 
           const data = buildAlertData(options);
           if (Object.keys(data).length > 0) params.data = data;
           if (options.description) params.description = options.description;
+          if (flags.enabled && flags.disabled) throw new NansenError('Cannot specify both --enabled and --disabled', ErrorCode.INVALID_PARAM);
           if (flags.enabled) params.isEnabled = true;
           if (flags.disabled) params.isEnabled = false;
           return apiInstance.alertsUpdate(params);
@@ -455,6 +456,7 @@ Advanced: use --data '<json>' to pass the full alert config directly (merged on 
         'toggle': () => {
           const id = args[1];
           if (!id) throw new NansenError('Required: <id>', ErrorCode.MISSING_PARAM);
+          if (flags.enabled && flags.disabled) throw new NansenError('Cannot specify both --enabled and --disabled', ErrorCode.INVALID_PARAM);
           const isEnabled = flags.enabled ? true : flags.disabled ? false : undefined;
           if (isEnabled === undefined) throw new NansenError('Required: --enabled or --disabled', ErrorCode.MISSING_PARAM);
           return apiInstance.alertsToggle({ id, isEnabled });

--- a/src/commands/alerts.js
+++ b/src/commands/alerts.js
@@ -253,6 +253,7 @@ export function buildAlertData(options) {
       'outflow-1h-min', 'outflow-1h-max', 'outflow-1d-min', 'outflow-1d-max', 'outflow-7d-min', 'outflow-7d-max',
       'netflow-1h-min', 'netflow-1h-max', 'netflow-1d-min', 'netflow-1d-max', 'netflow-7d-min', 'netflow-7d-max',
       'events', 'usd-min', 'usd-max', 'token-amount-min', 'token-amount-max',
+      'token', 'exclude-token',
       'subject', 'counterparty', 'signature-hash', 'caller', 'contract',
       'exclude-caller', 'exclude-contract', 'exclude-from', 'exclude-to',
       'token-sector', 'exclude-token-sector', 'token-age-min', 'token-age-max',

--- a/src/commands/alerts.js
+++ b/src/commands/alerts.js
@@ -58,7 +58,7 @@ function parseTokens(tokenArg) {
   const tokens = Array.isArray(tokenArg) ? tokenArg : [tokenArg];
   return tokens.map(t => {
     const colonIdx = t.lastIndexOf(':');
-    if (colonIdx === -1) throw new NansenError(`Invalid token format: "${t}". Expected address:chain`, ErrorCode.INVALID_PARAM);
+    if (colonIdx === -1) throw new NansenError(`Invalid token format: "${t}". Expected address:chain`, ErrorCode.INVALID_PARAMS);
     return { address: t.slice(0, colonIdx), chain: t.slice(colonIdx + 1) };
   });
 }
@@ -72,7 +72,7 @@ function parseSubjects(subjectArg) {
   const subjects = Array.isArray(subjectArg) ? subjectArg : [subjectArg];
   return subjects.map(s => {
     const colonIdx = s.indexOf(':');
-    if (colonIdx === -1) throw new NansenError(`Invalid subject format: "${s}". Expected type:value`, ErrorCode.INVALID_PARAM);
+    if (colonIdx === -1) throw new NansenError(`Invalid subject format: "${s}". Expected type:value`, ErrorCode.INVALID_PARAMS);
     return { type: s.slice(0, colonIdx), value: s.slice(colonIdx + 1) };
   });
 }
@@ -260,7 +260,7 @@ export function buildAlertData(options) {
       try {
         override = JSON.parse(options.data);
       } catch {
-        throw new NansenError('--data must be valid JSON', ErrorCode.INVALID_PARAM);
+        throw new NansenError('--data must be valid JSON', ErrorCode.INVALID_PARAMS);
       }
     } else {
       override = options.data;
@@ -385,6 +385,7 @@ Advanced: use --data '<json>' to pass the full alert config directly (merged on 
           if (options.chain) params.chain = options.chain;
           if (options.limit) params.limit = Number(options.limit);
           if (options.offset) params.offset = Number(options.offset);
+          if (flags.enabled && flags.disabled) throw new NansenError('Cannot specify both --enabled and --disabled', ErrorCode.INVALID_PARAMS);
           if (flags.enabled) params.isEnabled = true;
           if (flags.disabled) params.isEnabled = false;
 
@@ -430,7 +431,7 @@ Advanced: use --data '<json>' to pass the full alert config directly (merged on 
           const data = buildAlertData(options);
           if (Object.keys(data).length > 0) params.data = data;
           if (options.description) params.description = options.description;
-          if (flags.enabled && flags.disabled) throw new NansenError('Cannot specify both --enabled and --disabled', ErrorCode.INVALID_PARAM);
+          if (flags.enabled && flags.disabled) throw new NansenError('Cannot specify both --enabled and --disabled', ErrorCode.INVALID_PARAMS);
           if (flags.enabled) params.isEnabled = true;
           if (flags.disabled) params.isEnabled = false;
           return apiInstance.alertsUpdate(params);
@@ -438,7 +439,7 @@ Advanced: use --data '<json>' to pass the full alert config directly (merged on 
         'toggle': () => {
           const id = args[1];
           if (!id) throw new NansenError('Required: <id>', ErrorCode.MISSING_PARAM);
-          if (flags.enabled && flags.disabled) throw new NansenError('Cannot specify both --enabled and --disabled', ErrorCode.INVALID_PARAM);
+          if (flags.enabled && flags.disabled) throw new NansenError('Cannot specify both --enabled and --disabled', ErrorCode.INVALID_PARAMS);
           const isEnabled = flags.enabled ? true : flags.disabled ? false : undefined;
           if (isEnabled === undefined) throw new NansenError('Required: --enabled or --disabled', ErrorCode.MISSING_PARAM);
           return apiInstance.alertsToggle({ id, isEnabled });

--- a/src/commands/alerts.js
+++ b/src/commands/alerts.js
@@ -247,7 +247,24 @@ export function buildAlertData(options) {
   } else if (options.type === 'smart-contract-call') {
     data = buildSmartContractCallData(options);
   } else {
-    // Unknown / no type — minimal fallback: just handle chains
+    // No type — only --chains and --data are valid; warn if type-specific flags are present
+    const typeSpecificFlags = [
+      'inflow-1h-min', 'inflow-1h-max', 'inflow-1d-min', 'inflow-1d-max', 'inflow-7d-min', 'inflow-7d-max',
+      'outflow-1h-min', 'outflow-1h-max', 'outflow-1d-min', 'outflow-1d-max', 'outflow-7d-min', 'outflow-7d-max',
+      'netflow-1h-min', 'netflow-1h-max', 'netflow-1d-min', 'netflow-1d-max', 'netflow-7d-min', 'netflow-7d-max',
+      'events', 'usd-min', 'usd-max', 'token-amount-min', 'token-amount-max',
+      'subject', 'counterparty', 'signature-hash', 'caller', 'contract',
+      'exclude-caller', 'exclude-contract', 'exclude-from', 'exclude-to',
+      'token-sector', 'exclude-token-sector', 'token-age-min', 'token-age-max',
+      'market-cap-min', 'market-cap-max', 'fdv-min', 'fdv-max',
+    ];
+    const present = typeSpecificFlags.filter(f => options[f] !== undefined);
+    if (present.length > 0) {
+      throw new NansenError(
+        `--type is required when using type-specific flags (${present.map(f => '--' + f).join(', ')})`,
+        ErrorCode.MISSING_PARAM,
+      );
+    }
     data = {};
     const chains = parseChains(options.chains);
     if (chains) data.chains = chains;
@@ -372,7 +389,7 @@ All create options are accepted. Only provided fields are updated.
 
 EXAMPLES:
   nansen alerts update abc123 --name 'New Name'
-  nansen alerts update abc123 --chains ethereum,base --inflow-1h-min 2000000`,
+  nansen alerts update abc123 --type sm-token-flows --chains ethereum,base --inflow-1h-min 2000000`,
 
         toggle: `nansen alerts toggle — Enable or disable an alert
 

--- a/src/commands/alerts.js
+++ b/src/commands/alerts.js
@@ -99,6 +99,14 @@ function buildRange(minVal, maxVal) {
 }
 
 /**
+ * Normalise a repeatable string option to array, or undefined if absent.
+ */
+function normArray(val) {
+  if (!val) return undefined;
+  return Array.isArray(val) ? val : [val];
+}
+
+/**
  * Build the data payload for sm-token-flows alerts from named flags.
  */
 export function buildSmTokenFlowsData(options) {
@@ -118,8 +126,23 @@ export function buildSmTokenFlowsData(options) {
 
   const tokens = parseTokens(options.token);
   const excludeTokens = parseTokens(options['exclude-token']);
-  if (tokens) data.inclusion = { tokens };
-  if (excludeTokens) data.exclusion = { tokens: excludeTokens };
+  if (tokens) data.inclusion = { ...data.inclusion, tokens };
+  if (excludeTokens) data.exclusion = { ...data.exclusion, tokens: excludeTokens };
+
+  const sectors = normArray(options['token-sector']);
+  if (sectors) data.inclusion = { ...data.inclusion, tokenSectors: sectors };
+  const excludeSectors = normArray(options['exclude-token-sector']);
+  if (excludeSectors) data.exclusion = { ...data.exclusion, tokenSectors: excludeSectors };
+
+  if (options['token-age-max'] !== undefined) {
+    data.inclusion = { ...data.inclusion, tokenAge: { max: Number(options['token-age-max']) } };
+  }
+
+  const marketCapRange = buildRange(options['market-cap-min'], options['market-cap-max']);
+  if (marketCapRange) data.inclusion = { ...data.inclusion, marketCap: marketCapRange };
+
+  const fdvRange = buildRange(options['fdv-min'], options['fdv-max']);
+  if (fdvRange) data.inclusion = { ...data.inclusion, fdvUsd: fdvRange };
 
   return data;
 }
@@ -151,8 +174,30 @@ export function buildCommonTokenTransferData(options) {
 
   const tokens = parseTokens(options.token);
   const excludeTokens = parseTokens(options['exclude-token']);
-  if (tokens) data.inclusion = { tokens };
-  if (excludeTokens) data.exclusion = { tokens: excludeTokens };
+  if (tokens) data.inclusion = { ...data.inclusion, tokens };
+  if (excludeTokens) data.exclusion = { ...data.exclusion, tokens: excludeTokens };
+
+  const sectors = normArray(options['token-sector']);
+  if (sectors) data.inclusion = { ...data.inclusion, tokenSectors: sectors };
+  const excludeSectors = normArray(options['exclude-token-sector']);
+  if (excludeSectors) data.exclusion = { ...data.exclusion, tokenSectors: excludeSectors };
+
+  const tokenAgeMin = options['token-age-min'];
+  const tokenAgeMax = options['token-age-max'];
+  if (tokenAgeMin !== undefined || tokenAgeMax !== undefined) {
+    const tokenAge = {};
+    if (tokenAgeMin !== undefined) tokenAge.min = Number(tokenAgeMin);
+    if (tokenAgeMax !== undefined) tokenAge.max = Number(tokenAgeMax);
+    data.inclusion = { ...data.inclusion, tokenAge };
+  }
+
+  const marketCapRange = buildRange(options['market-cap-min'], options['market-cap-max']);
+  if (marketCapRange) data.inclusion = { ...data.inclusion, marketCap: marketCapRange };
+
+  const excludeFrom = parseSubjects(options['exclude-from']);
+  if (excludeFrom) data.exclusion = { ...data.exclusion, fromTargets: excludeFrom };
+  const excludeTo = parseSubjects(options['exclude-to']);
+  if (excludeTo) data.exclusion = { ...data.exclusion, toTargets: excludeTo };
 
   return data;
 }
@@ -180,16 +225,10 @@ export function buildSmartContractCallData(options) {
   const excludeCallers = parseSubjects(options['exclude-caller']);
   const excludeContracts = parseSubjects(options['exclude-contract']);
 
-  if (callers || contracts) {
-    data.inclusion = {};
-    if (callers) data.inclusion.caller = callers;
-    if (contracts) data.inclusion.smartContract = contracts;
-  }
-  if (excludeCallers || excludeContracts) {
-    data.exclusion = {};
-    if (excludeCallers) data.exclusion.caller = excludeCallers;
-    if (excludeContracts) data.exclusion.smartContract = excludeContracts;
-  }
+  if (callers) data.inclusion = { ...data.inclusion, caller: callers };
+  if (contracts) data.inclusion = { ...data.inclusion, smartContract: contracts };
+  if (excludeCallers) data.exclusion = { ...data.exclusion, caller: excludeCallers };
+  if (excludeContracts) data.exclusion = { ...data.exclusion, smartContract: excludeContracts };
 
   return data;
 }
@@ -234,6 +273,12 @@ export function buildAlertData(options) {
 
 // ============= Command Builder =============
 
+const TIME_WINDOW_BY_TYPE = {
+  'common-token-transfer': 'realtime',
+  'smart-contract-call': 'realtime',
+  'sm-token-flows': '1h',
+};
+
 export function buildAlertsCommands(deps = {}) {
   const { log = console.log } = deps;
 
@@ -252,7 +297,7 @@ SUBCOMMANDS:
 
 USAGE:
   nansen alerts list [--type sm-token-flows] [--enabled] [--disabled] [--token-address <addr>] [--chain <chain>] [--limit <n>] [--offset <n>]
-  nansen alerts create --name <name> --type <type> --time-window <window> --chains <chains> --telegram <chatId>
+  nansen alerts create --name <name> --type <type> --chains <chains> --telegram <chatId>
   nansen alerts update <id> [--name <name>] [--chains <chains>]
   nansen alerts toggle <id> --enabled
   nansen alerts toggle <id> --disabled
@@ -283,6 +328,11 @@ OPTIONS (sm-token-flows):
   --netflow-1h-min <usd>   --netflow-1h-max <usd>
   --netflow-1d-min <usd>   --netflow-1d-max <usd>
   --netflow-7d-min <usd>   --netflow-7d-max <usd>
+  --token-sector <name>        Filter by token sector (repeatable).
+  --exclude-token-sector <name> Exclude token sector (repeatable).
+  --token-age-max <days>       Maximum token age in days.
+  --market-cap-min <usd>       --market-cap-max <usd>
+  --fdv-min <usd>              --fdv-max <usd>
 
 OPTIONS (common-token-transfer):
   --events <buy,sell,swap,send,receive>   Comma-separated event types.
@@ -290,6 +340,12 @@ OPTIONS (common-token-transfer):
   --token-amount-min <n>       --token-amount-max <n>
   --subject <type:value>       Filter by subject (repeatable, e.g. label:"Centralized Exchange").
   --counterparty <type:value>  Filter by counterparty (repeatable, same format as --subject).
+  --token-sector <name>        Filter by token sector (repeatable).
+  --exclude-token-sector <name> Exclude token sector (repeatable).
+  --token-age-min <days>       --token-age-max <days>
+  --market-cap-min <usd>       --market-cap-max <usd>
+  --exclude-from <type:value>  Exclude by sender (repeatable).
+  --exclude-to <type:value>    Exclude by recipient (repeatable).
 
 OPTIONS (smart-contract-call):
   --usd-min <usd>              --usd-max <usd>
@@ -302,9 +358,9 @@ OPTIONS (smart-contract-call):
 EXAMPLES:
   nansen alerts list --table
   nansen alerts list --type sm-token-flows --enabled
-  nansen alerts create --name 'ETH SM Inflow' --type sm-token-flows --time-window 1h --chains ethereum --telegram 5238612255 --inflow-1h-min 1000000
-  nansen alerts create --name 'USDC Transfers' --type common-token-transfer --time-window 1h --chains ethereum --telegram 5238612255 --events send,receive --usd-min 1000000 --subject label:"Centralized Exchange"
-  nansen alerts create --name 'Contract Calls' --type smart-contract-call --time-window 1h --chains ethereum --telegram 5238612255 --signature-hash 0xa9059cbb --caller address:0xabc
+  nansen alerts create --name 'ETH SM Inflow' --type sm-token-flows --chains ethereum --telegram 5238612255 --inflow-1h-min 1000000
+  nansen alerts create --name 'USDC Transfers' --type common-token-transfer --chains ethereum --telegram 5238612255 --events send,receive --usd-min 1000000 --subject label:"Centralized Exchange"
+  nansen alerts create --name 'Contract Calls' --type smart-contract-call --chains ethereum --telegram 5238612255 --signature-hash 0xa9059cbb --caller address:0xabc
   nansen alerts toggle abc123 --disabled
   nansen alerts delete abc123
 
@@ -322,27 +378,48 @@ Advanced: use --data '<json>' to pass the full alert config directly (merged on 
       }
 
       const handlers = {
-        'list': () => {
+        'list': async () => {
           const params = {};
           if (options.type) params.type = options.type;
           if (options['token-address']) params.tokenAddress = options['token-address'];
           if (options.chain) params.chain = options.chain;
-          if (options.limit) params.limit = options.limit;
-          if (options.offset) params.offset = options.offset;
+          if (options.limit) params.limit = Number(options.limit);
+          if (options.offset) params.offset = Number(options.offset);
           if (flags.enabled) params.isEnabled = true;
           if (flags.disabled) params.isEnabled = false;
-          return apiInstance.alertsList(params);
+
+          let results = await apiInstance.alertsList(params);
+          // Normalise to array
+          if (!Array.isArray(results)) results = results?.alerts ?? results?.data ?? [];
+
+          // Client-side filters (defensive — backend may or may not support them)
+          if (params.type) results = results.filter(a => a.type === params.type);
+          if (params.isEnabled !== undefined) results = results.filter(a => a.isEnabled === params.isEnabled);
+          if (params.tokenAddress) {
+            const addr = params.tokenAddress.toLowerCase();
+            results = results.filter(a => {
+              const tokens = [...(a.data?.inclusion?.tokens ?? []), ...(a.data?.exclusion?.tokens ?? [])];
+              return tokens.some(t => t.address?.toLowerCase() === addr);
+            });
+          }
+          if (params.chain) {
+            const chain = params.chain.toLowerCase();
+            results = results.filter(a => (a.data?.chains ?? []).some(c => c.toLowerCase() === chain));
+          }
+          const offset = params.offset ?? 0;
+          const limit = params.limit;
+          results = results.slice(offset, limit != null ? offset + limit : undefined);
+          return results;
         },
         'create': () => {
           const name = options.name;
           const type = options.type;
-          const timeWindow = options['time-window'];
+          const timeWindow = TIME_WINDOW_BY_TYPE[type] ?? 'realtime';
           const channels = buildChannels();
           const data = buildAlertData(options);
           const missing = [];
           if (!name) missing.push('--name');
           if (!type) missing.push('--type');
-          if (!timeWindow) missing.push('--time-window');
           if (!channels) missing.push('a channel (--telegram, --slack, or --discord)');
           if (missing.length > 0) {
             throw new NansenError(`Required: ${missing.join(', ')}`, ErrorCode.MISSING_PARAM);
@@ -362,8 +439,10 @@ Advanced: use --data '<json>' to pass the full alert config directly (merged on 
           if (!id) throw new NansenError('Required: <id>', ErrorCode.MISSING_PARAM);
           const params = { id };
           if (options.name) params.name = options.name;
-          if (options.type) params.type = options.type;
-          if (options['time-window']) params.timeWindow = options['time-window'];
+          if (options.type) {
+            params.type = options.type;
+            params.timeWindow = TIME_WINDOW_BY_TYPE[options.type] ?? 'realtime';
+          }
           const channels = buildChannels();
           if (channels) params.channels = channels;
           const data = buildAlertData(options);

--- a/src/commands/alerts.js
+++ b/src/commands/alerts.js
@@ -285,8 +285,9 @@ export function buildAlertsCommands(deps = {}) {
   return {
     'alerts': async (args, apiInstance, flags, options) => {
       const sub = args[0];
-      if (!sub || sub === 'help' || flags.help || flags.h) {
-        log(`nansen alerts — Smart alert management
+
+      const HELP = {
+        _top: `nansen alerts — Smart alert management
 
 SUBCOMMANDS:
   list        List all alerts
@@ -295,76 +296,98 @@ SUBCOMMANDS:
   toggle      Enable or disable an alert
   delete      Delete an alert
 
+Run: nansen alerts <subcommand> --help`,
+
+        list: `nansen alerts list — List all alerts
+
 USAGE:
-  nansen alerts list [--type sm-token-flows] [--enabled] [--disabled] [--token-address <addr>] [--chain <chain>] [--limit <n>] [--offset <n>]
-  nansen alerts create --name <name> --type <type> --chains <chains> --telegram <chatId>
-  nansen alerts update <id> [--name <name>] [--chains <chains>]
-  nansen alerts toggle <id> --enabled
-  nansen alerts toggle <id> --disabled
-  nansen alerts delete <id>
+  nansen alerts list [--table] [--type <type>] [--enabled|--disabled] [--token-address <addr>] [--chain <chain>] [--limit <n>] [--offset <n>]
 
-SUBJECT TYPES:
-  address, entity, label, custom-label
-  Example: --subject address:0xabc  --subject label:"Centralized Exchange"
-
-  Chain aliases: For Hyperliquid use hyperevm, for BSC use bnb.
-
-OPTIONS (all types):
-  --chains <chains>            Comma-separated chains (e.g. ethereum,solana).
-  --token <address:chain>      Filter by token (repeatable). Adds to inclusion list.
-  --exclude-token <addr:chain> Exclude token (repeatable). Adds to exclusion list.
-  --telegram <chatId>          Send to Telegram chat.
-  --slack <webhookUrl>         Send to Slack webhook.
-  --discord <webhookUrl>       Send to Discord webhook. Combine multiple channel flags.
-  --description '<text>'       Alert description.
-
-OPTIONS (sm-token-flows):
-  --inflow-1h-min <usd>    --inflow-1h-max <usd>
-  --inflow-1d-min <usd>    --inflow-1d-max <usd>
-  --inflow-7d-min <usd>    --inflow-7d-max <usd>
-  --outflow-1h-min <usd>   --outflow-1h-max <usd>
-  --outflow-1d-min <usd>   --outflow-1d-max <usd>
-  --outflow-7d-min <usd>   --outflow-7d-max <usd>
-  --netflow-1h-min <usd>   --netflow-1h-max <usd>
-  --netflow-1d-min <usd>   --netflow-1d-max <usd>
-  --netflow-7d-min <usd>   --netflow-7d-max <usd>
-  --token-sector <name>        Filter by token sector (repeatable).
-  --exclude-token-sector <name> Exclude token sector (repeatable).
-  --token-age-max <days>       Maximum token age in days.
-  --market-cap-min <usd>       --market-cap-max <usd>
-  --fdv-min <usd>              --fdv-max <usd>
-
-OPTIONS (common-token-transfer):
-  --events <buy,sell,swap,send,receive>   Comma-separated event types.
-  --usd-min <usd>              --usd-max <usd>
-  --token-amount-min <n>       --token-amount-max <n>
-  --subject <type:value>       Filter by subject (repeatable, e.g. label:"Centralized Exchange").
-  --counterparty <type:value>  Filter by counterparty (repeatable, same format as --subject).
-  --token-sector <name>        Filter by token sector (repeatable).
-  --exclude-token-sector <name> Exclude token sector (repeatable).
-  --token-age-min <days>       --token-age-max <days>
-  --market-cap-min <usd>       --market-cap-max <usd>
-  --exclude-from <type:value>  Exclude by sender (repeatable).
-  --exclude-to <type:value>    Exclude by recipient (repeatable).
-
-OPTIONS (smart-contract-call):
-  --usd-min <usd>              --usd-max <usd>
-  --signature-hash <hash>      Function signature hash (repeatable).
-  --caller <type:value>        Include callers (repeatable).
-  --contract <type:value>      Include smart contracts (repeatable).
-  --exclude-caller <type:value>    Exclude callers (repeatable).
-  --exclude-contract <type:value>  Exclude contracts (repeatable).
+OPTIONS:
+  --table                      Human-readable table output
+  --type <type>                Filter by alert type (sm-token-flows, common-token-transfer, smart-contract-call)
+  --enabled / --disabled       Filter by enabled state
+  --token-address <addr>       Filter by token address
+  --chain <chain>              Filter by chain
+  --limit <n>                  Max results
+  --offset <n>                 Skip first N results
 
 EXAMPLES:
   nansen alerts list --table
-  nansen alerts list --type sm-token-flows --enabled
+  nansen alerts list --type sm-token-flows --enabled`,
+
+        create: `nansen alerts create — Create a new alert
+
+USAGE:
+  nansen alerts create --name <name> --type <type> --chains <chains> --telegram <chatId> [options]
+
+REQUIRED:
+  --name <name>                Alert name
+  --type <type>                sm-token-flows | common-token-transfer | smart-contract-call
+  At least one channel:        --telegram <chatId> | --slack <url> | --discord <url>
+
+OPTIONS (all types):
+  --chains <chains>            Comma-separated chains (e.g. ethereum,solana)
+  --token <address:chain>      Include token (repeatable)
+  --exclude-token <addr:chain> Exclude token (repeatable)
+  --description '<text>'       Alert description
+  --disabled                   Create in disabled state
+  --data '<json>'              Raw JSON merged on top of named flags (escape hatch)
+
+OPTIONS (sm-token-flows):
+  --inflow-1h-min/max <usd>   --outflow-1h-min/max <usd>   --netflow-1h-min/max <usd>
+  --inflow-1d-min/max <usd>   --outflow-1d-min/max <usd>   --netflow-1d-min/max <usd>
+  --inflow-7d-min/max <usd>   --outflow-7d-min/max <usd>   --netflow-7d-min/max <usd>
+  --token-sector <name>        --exclude-token-sector <name> (repeatable)
+  --token-age-max <days>       --market-cap-min/max <usd>    --fdv-min/max <usd>
+
+OPTIONS (common-token-transfer):
+  --events <buy,sell,swap,send,receive>   Comma-separated event types
+  --usd-min/max <usd>         --token-amount-min/max <n>
+  --subject <type:value>       Filter by subject (repeatable, e.g. label:"Centralized Exchange")
+  --counterparty <type:value>  Filter by counterparty (repeatable, requires --subject)
+  --token-sector <name>        --exclude-token-sector <name> (repeatable)
+  --token-age-min/max <days>   --market-cap-min/max <usd>
+  --exclude-from <type:value>  --exclude-to <type:value> (repeatable)
+
+OPTIONS (smart-contract-call):
+  --usd-min/max <usd>         --signature-hash <hash> (repeatable)
+  --caller <type:value>        --exclude-caller <type:value> (repeatable)
+  --contract <type:value>      --exclude-contract <type:value> (repeatable)
+
+SUBJECT TYPES: address, entity, label, custom-label
+CHAIN ALIASES: Hyperliquid = hyperevm, BSC = bnb
+
+EXAMPLES:
   nansen alerts create --name 'ETH SM Inflow' --type sm-token-flows --chains ethereum --telegram 5238612255 --inflow-1h-min 1000000
   nansen alerts create --name 'USDC Transfers' --type common-token-transfer --chains ethereum --telegram 5238612255 --events send,receive --usd-min 1000000 --subject label:"Centralized Exchange"
-  nansen alerts create --name 'Contract Calls' --type smart-contract-call --chains ethereum --telegram 5238612255 --signature-hash 0xa9059cbb --caller address:0xabc
-  nansen alerts toggle abc123 --disabled
-  nansen alerts delete abc123
+  nansen alerts create --name 'Contract Calls' --type smart-contract-call --chains ethereum --telegram 5238612255 --signature-hash 0xa9059cbb --caller address:0xabc`,
 
-Advanced: use --data '<json>' to pass the full alert config directly (merged on top of any named flags).`);
+        update: `nansen alerts update — Update an existing alert
+
+USAGE:
+  nansen alerts update <id> [--name <name>] [--type <type>] [--chains <chains>] [--enabled|--disabled] ...
+
+All create options are accepted. Only provided fields are updated.
+
+EXAMPLES:
+  nansen alerts update abc123 --name 'New Name'
+  nansen alerts update abc123 --chains ethereum,base --inflow-1h-min 2000000`,
+
+        toggle: `nansen alerts toggle — Enable or disable an alert
+
+USAGE:
+  nansen alerts toggle <id> --enabled
+  nansen alerts toggle <id> --disabled`,
+
+        delete: `nansen alerts delete — Delete an alert
+
+USAGE:
+  nansen alerts delete <id>`,
+      };
+
+      if (!sub || sub === 'help') {
+        log(HELP._top);
         return;
       }
 
@@ -454,6 +477,13 @@ Advanced: use --data '<json>' to pass the full alert config directly (merged on 
       if (!handlers[sub]) {
         throw new NansenError(`Unknown alerts subcommand: ${sub}. Available: list, create, update, toggle, delete`, ErrorCode.UNKNOWN);
       }
+
+      // Subcommand-level help: --help flag or "help" as second positional arg
+      if (flags.help || flags.h || args[1] === 'help') {
+        log(HELP[sub] || HELP._top);
+        return;
+      }
+
       return handlers[sub]();
     },
   };

--- a/src/commands/alerts.js
+++ b/src/commands/alerts.js
@@ -388,35 +388,15 @@ Advanced: use --data '<json>' to pass the full alert config directly (merged on 
           if (flags.enabled) params.isEnabled = true;
           if (flags.disabled) params.isEnabled = false;
 
-          let results = await apiInstance.alertsList(params);
+          const results = await apiInstance.alertsList(params);
           // Normalise to array
-          if (!Array.isArray(results)) results = results?.alerts ?? results?.data ?? [];
-
-          // Client-side filters (defensive — backend may or may not support them)
-          if (params.type) results = results.filter(a => a.type === params.type);
-          if (params.isEnabled !== undefined) results = results.filter(a => a.isEnabled === params.isEnabled);
-          if (params.tokenAddress) {
-            const addr = params.tokenAddress.toLowerCase();
-            results = results.filter(a => {
-              const tokens = [...(a.data?.inclusion?.tokens ?? []), ...(a.data?.exclusion?.tokens ?? [])];
-              return tokens.some(t => t.address?.toLowerCase() === addr);
-            });
-          }
-          if (params.chain) {
-            const chain = params.chain.toLowerCase();
-            results = results.filter(a => (a.data?.chains ?? []).some(c => c.toLowerCase() === chain));
-          }
-          const offset = params.offset ?? 0;
-          const limit = params.limit;
-          results = results.slice(offset, limit != null ? offset + limit : undefined);
+          if (!Array.isArray(results)) return results?.alerts ?? results?.data ?? [];
           return results;
         },
         'create': () => {
           const name = options.name;
           const type = options.type;
-          const timeWindow = TIME_WINDOW_BY_TYPE[type] ?? 'realtime';
           const channels = buildChannels();
-          const data = buildAlertData(options);
           const missing = [];
           if (!name) missing.push('--name');
           if (!type) missing.push('--type');
@@ -424,6 +404,8 @@ Advanced: use --data '<json>' to pass the full alert config directly (merged on 
           if (missing.length > 0) {
             throw new NansenError(`Required: ${missing.join(', ')}`, ErrorCode.MISSING_PARAM);
           }
+          const timeWindow = TIME_WINDOW_BY_TYPE[type] ?? 'realtime';
+          const data = buildAlertData(options);
           return apiInstance.alertsCreate({
             name,
             type,

--- a/src/schema.json
+++ b/src/schema.json
@@ -1793,7 +1793,7 @@
           "options": {
             "name": { "type": "string", "required": true, "description": "Alert name" },
             "type": { "type": "string", "required": true, "description": "Alert type (e.g. sm-token-flows, common-token-transfer)" },
-            "time-window": { "type": "string", "required": true, "description": "Time window (e.g. 1h, realtime)" },
+            "time-window": { "type": "string", "description": "Auto-inferred from --type (sm-token-flows→1h, others→realtime). Ignored if provided." },
             "chains": { "type": "string", "description": "Comma-separated chains (e.g. ethereum,solana). Merged into data." },
             "telegram": { "type": "string", "description": "Telegram chat ID for notifications" },
             "slack": { "type": "string", "description": "Slack webhook URL for notifications" },
@@ -1808,7 +1808,7 @@
           "options": {
             "name": { "type": "string", "description": "Alert name" },
             "type": { "type": "string", "description": "Alert type" },
-            "time-window": { "type": "string", "description": "Time window" },
+            "time-window": { "type": "string", "description": "Auto-inferred from --type. Ignored if provided." },
             "chains": { "type": "string", "description": "Comma-separated chains. Merged into data." },
             "telegram": { "type": "string", "description": "Telegram chat ID" },
             "slack": { "type": "string", "description": "Slack webhook URL" },

--- a/src/schema.json
+++ b/src/schema.json
@@ -1804,9 +1804,8 @@
           }
         },
         "update": {
-          "description": "Update an existing alert",
+          "description": "Update an existing alert. Usage: nansen alerts update <id> [options]",
           "options": {
-            "id": { "type": "string", "required": true, "description": "Alert ID" },
             "name": { "type": "string", "description": "Alert name" },
             "type": { "type": "string", "description": "Alert type" },
             "time-window": { "type": "string", "description": "Time window" },
@@ -1821,18 +1820,15 @@
           }
         },
         "toggle": {
-          "description": "Enable or disable an alert",
+          "description": "Enable or disable an alert. Usage: nansen alerts toggle <id> --enabled|--disabled",
           "options": {
-            "id": { "type": "string", "required": true, "description": "Alert ID" },
             "enabled": { "type": "boolean", "description": "Enable alert" },
             "disabled": { "type": "boolean", "description": "Disable alert" }
           }
         },
         "delete": {
-          "description": "Delete an alert",
-          "options": {
-            "id": { "type": "string", "required": true, "description": "Alert ID" }
-          }
+          "description": "Delete an alert. Usage: nansen alerts delete <id>",
+          "options": {}
         }
       }
     },

--- a/src/schema.json
+++ b/src/schema.json
@@ -1781,6 +1781,61 @@
         }
       }
     },
+    "alerts": {
+      "description": "Smart alert management — create, update, toggle, delete alerts",
+      "subcommands": {
+        "list": {
+          "description": "List all alerts",
+          "returns": ["id", "name", "type", "timeWindow", "isEnabled", "channels", "data", "description"]
+        },
+        "create": {
+          "description": "Create a new alert",
+          "options": {
+            "name": { "type": "string", "required": true, "description": "Alert name" },
+            "type": { "type": "string", "required": true, "description": "Alert type (e.g. sm-token-flows, common-token-transfer)" },
+            "time-window": { "type": "string", "required": true, "description": "Time window (e.g. 1h, realtime)" },
+            "chains": { "type": "string", "description": "Comma-separated chains (e.g. ethereum,solana). Merged into data." },
+            "telegram": { "type": "string", "description": "Telegram chat ID for notifications" },
+            "slack": { "type": "string", "description": "Slack webhook URL for notifications" },
+            "discord": { "type": "string", "description": "Discord webhook URL for notifications" },
+            "data": { "type": "string", "description": "Alert config JSON. --chains is merged on top." },
+            "description": { "type": "string", "description": "Optional description" },
+            "disabled": { "type": "boolean", "description": "Create alert in disabled state" }
+          }
+        },
+        "update": {
+          "description": "Update an existing alert",
+          "options": {
+            "id": { "type": "string", "required": true, "description": "Alert ID" },
+            "name": { "type": "string", "description": "Alert name" },
+            "type": { "type": "string", "description": "Alert type" },
+            "time-window": { "type": "string", "description": "Time window" },
+            "chains": { "type": "string", "description": "Comma-separated chains. Merged into data." },
+            "telegram": { "type": "string", "description": "Telegram chat ID" },
+            "slack": { "type": "string", "description": "Slack webhook URL" },
+            "discord": { "type": "string", "description": "Discord webhook URL" },
+            "data": { "type": "string", "description": "Alert config JSON. --chains merged on top." },
+            "description": { "type": "string", "description": "Description" },
+            "enabled": { "type": "boolean", "description": "Enable alert" },
+            "disabled": { "type": "boolean", "description": "Disable alert" }
+          }
+        },
+        "toggle": {
+          "description": "Enable or disable an alert",
+          "options": {
+            "id": { "type": "string", "required": true, "description": "Alert ID" },
+            "enabled": { "type": "boolean", "description": "Enable alert" },
+            "disabled": { "type": "boolean", "description": "Disable alert" }
+          }
+        },
+        "delete": {
+          "description": "Delete an alert",
+          "options": {
+            "id": { "type": "string", "required": true, "description": "Alert ID" }
+          }
+        }
+      }
+    },
     "trade": {
       "description": "DEX trading commands",
       "subcommands": {

--- a/src/schema.json
+++ b/src/schema.json
@@ -1793,7 +1793,6 @@
           "options": {
             "name": { "type": "string", "required": true, "description": "Alert name" },
             "type": { "type": "string", "required": true, "description": "Alert type (e.g. sm-token-flows, common-token-transfer)" },
-            "time-window": { "type": "string", "description": "Auto-inferred from --type (sm-token-flows→1h, others→realtime). Ignored if provided." },
             "chains": { "type": "string", "description": "Comma-separated chains (e.g. ethereum,solana). Merged into data." },
             "telegram": { "type": "string", "description": "Telegram chat ID for notifications" },
             "slack": { "type": "string", "description": "Slack webhook URL for notifications" },
@@ -1808,7 +1807,6 @@
           "options": {
             "name": { "type": "string", "description": "Alert name" },
             "type": { "type": "string", "description": "Alert type" },
-            "time-window": { "type": "string", "description": "Auto-inferred from --type. Ignored if provided." },
             "chains": { "type": "string", "description": "Comma-separated chains. Merged into data." },
             "telegram": { "type": "string", "description": "Telegram chat ID" },
             "slack": { "type": "string", "description": "Slack webhook URL" },

--- a/src/schema.json
+++ b/src/schema.json
@@ -647,7 +647,7 @@
                 },
                 "chain": {
                   "type": "string",
-                  "default": "ethereum"
+                  "default": "solana"
                 }
               },
               "returns": [
@@ -1920,6 +1920,8 @@
         },
         "export": { "description": "Export private keys (local only, requires password)" },
         "default": { "description": "Set default wallet (local only)" },
+        "secure": { "description": "Migrate wallet password to OS keychain for secure storage" },
+        "forget-password": { "description": "Remove saved wallet password from keychain and credentials file" },
         "help": { "description": "Show wallet help" }
       }
     }
@@ -1953,6 +1955,27 @@
         "csv"
       ],
       "description": "Output format (default: json)"
+    },
+    "stream": {
+      "type": "boolean",
+      "description": "Output results as newline-delimited JSON (NDJSON), one record per line"
+    },
+    "cache": {
+      "type": "boolean",
+      "description": "Enable response caching (default: true)"
+    },
+    "no-cache": {
+      "type": "boolean",
+      "description": "Disable response caching"
+    },
+    "cache-ttl": {
+      "type": "number",
+      "default": 300,
+      "description": "Cache TTL in seconds (default: 300)"
+    },
+    "enrich": {
+      "type": "boolean",
+      "description": "Enrich results with additional labels/metadata (slower, extra API calls)"
     },
     "x402-payment-signature": {
       "type": "string",

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -27,7 +27,6 @@ const SCRYPT_P = 1;
 const SCRYPT_KEYLEN = 32;
 const SALT_LEN = 16;
 const IV_LEN = 12;
-const _AUTH_TAG_LEN = 16;
 
 import { keccak256 } from './crypto.js';
 
@@ -364,16 +363,20 @@ export function listWallets() {
   const files = fs.readdirSync(getWalletsDir()).filter(f => f.endsWith('.json') && f !== 'config.json');
 
   const wallets = files.map(f => {
-    const data = JSON.parse(fs.readFileSync(path.join(getWalletsDir(), f), 'utf8'));
-    return {
-      name: data.name,
-      provider: data.provider || 'local',
-      evm: data.evm?.address || null,
-      solana: data.solana?.address || null,
-      createdAt: data.createdAt,
-      isDefault: data.name === config.defaultWallet,
-    };
-  });
+    try {
+      const data = JSON.parse(fs.readFileSync(path.join(getWalletsDir(), f), 'utf8'));
+      return {
+        name: data.name,
+        provider: data.provider || 'local',
+        evm: data.evm?.address || null,
+        solana: data.solana?.address || null,
+        createdAt: data.createdAt,
+        isDefault: data.name === config.defaultWallet,
+      };
+    } catch {
+      return null;
+    }
+  }).filter(Boolean);
 
   return { wallets, defaultWallet: config.defaultWallet };
 }
@@ -502,11 +505,11 @@ export function exportWallet(name, password) {
     name: data.name,
     evm: {
       address: data.evm?.address,
-      privateKey: data.evm ? decryptKey(data.evm.encrypted, password) : null,
+      privateKey: data.evm?.encrypted ? decryptKey(data.evm.encrypted, password) : null,
     },
     solana: {
       address: data.solana?.address,
-      privateKey: data.solana ? decryptKey(data.solana.encrypted, password) : null,
+      privateKey: data.solana?.encrypted ? decryptKey(data.solana.encrypted, password) : null,
     },
   };
 }


### PR DESCRIPTION
## Summary

Full dogfood + critique cycle. 8 parallel agents audited code (8,823 LOC), ran 941 tests, exercised all 35 nansen skills end-to-end, and critiqued UX from an AI agent perspective.

### Bugs fixed
- **Unknown subcommand returns `success:true` with exit code 0** — 6 research categories (smart-money, profiler, token, portfolio, perp, points) returned `{success:true, data:{error:...}}` instead of throwing. Agents parsing `success` would think the command succeeded. Now throws `NansenError` with `INVALID_PARAMS` code and exit code 1.
- **7 `parseInt()` calls missing radix** — could cause subtle bugs with leading-zero strings
- **`prediction-market` missing from `DEPRECATED_TO_RESEARCH`** — no deprecation warning when used as top-level command
- **`listWallets()` crashes on malformed JSON** in wallets directory — now skips bad files
- **`exportWallet()` null dereference** — crashes if wallet has address but no encrypted key
- **Dead code** — unused `_AUTH_TAG_LEN` constant removed

### Schema fixes
- Token indicators default chain was `ethereum` but code defaults to `solana`
- `wallet secure` and `wallet forget-password` subcommands added to schema
- `--stream`, `--cache`, `--no-cache`, `--cache-ttl`, `--enrich` added to globalOptions

### Docs fixes
- README `--fields` example: `net_flow_usd` -> `net_flow_24h_usd`
- Profiler SKILL.md: broken `profiler search` -> `nansen research search`
- Token SKILL.md: wrong sort field `total_pnl_usd` -> `pnl_usd_total`

## Test plan
- [x] All 941 tests pass (0 failures)
- [x] Lint clean
- [x] Unknown subcommand now returns `{success:false, error:..., code:"INVALID_PARAMS"}` with exit 1

## Additional findings (not fixed here)
- `profiler perp-trades` returns null `side`/empty `action` for all trades (API-side)
- `profiler balance` pagination silently ignored (API-side)
- `flow-intelligence` `wallet_count` is 0 when flows are non-zero (API-side)
- Trading/wallet commands output human text instead of JSON (larger UX change)
- Record extraction logic duplicated 4x in cli.js (refactor candidate)

Generated with [Claude Code](https://claude.com/claude-code)