### PR TITLE
chore: add changeset for Jupiter Limit Order V2

### DIFF
--- a/.changeset/limit-order-v2.md
+++ b/.changeset/limit-order-v2.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add `trade limit-order` commands (create, list, cancel, update) for Jupiter Limit Order V2 on Solana. Supports local, Privy, and WalletConnect wallets.


### PR DESCRIPTION
## Summary
- Adds a changeset covering the `trade limit-order` commands shipped in #328 (create / list / cancel / update on Solana).
- `minor` bump — new user-facing feature.

## Test plan
- [x] `.changeset/limit-order-v2.md` follows the existing frontmatter pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)