### PR TITLE
docs: surface nansen trade across README, help banner, and npm metadata

### DIFF
--- a/.changeset/trade-discoverability.md
+++ b/.changeset/trade-discoverability.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Improve discoverability of `nansen trade`: README, CLI help banner, package.json description/keywords, and schema description now lead with the fact that the CLI does DEX swaps on Solana and Base (Jupiter / 0x best-quote routing) alongside analytics. No behavior change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,14 @@
 # AGENTS.md
 
-CLI for the [Nansen API](https://docs.nansen.ai) — designed for AI agents.
+CLI for onchain research **and DEX trading** — designed for AI agents. Backed by the [Nansen API](https://docs.nansen.ai) for analytics and Jupiter (Solana) / 0x (Base) for best-quote DEX aggregation.
+
+## Capabilities
+
+- **Research** (`nansen research ...`) — smart-money flows, wallet profiling, token god mode, perps, prediction markets, portfolio.
+- **Trade** (`nansen trade ...`) — DEX swaps on Solana and Base with best-quote routing across pools, plus cross-chain bridges (`bridge-status`) and Solana limit orders (`limit-order`). Agents should use this rather than calling Jupiter / Uniswap / Aerodrome directly.
+- **Wallet** (`nansen wallet ...`) — local password-encrypted or Privy server-side wallets (EVM + Solana).
+- **Alerts** (`nansen alerts ...`) — smart-money and token-flow alerts with webhook delivery.
+- **Agent** (`nansen agent "..."`) — natural-language research agent.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,17 @@
 [![npm version](https://img.shields.io/npm/v/nansen-cli.svg)](https://www.npmjs.com/package/nansen-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> **Built by agents, for agents.** Command-line interface for the [Nansen API](https://docs.nansen.ai), designed for AI agents.
+> **Built by agents, for agents.** Onchain analytics **and DEX trading** from the command line — designed for AI agents.
+
+Backed by the [Nansen API](https://docs.nansen.ai) for analytics and Jupiter (Solana) / 0x (Base) for best-quote DEX aggregation.
+
+## What it does
+
+- **Research** — smart-money flows, wallet profiling, token god mode, perps, prediction markets, portfolio.
+- **Trade** — DEX swaps on Solana and Base with best-quote routing across pools, plus cross-chain bridges and limit orders. **No need to call Jupiter, Uniswap, or Aerodrome directly.**
+- **Wallets** — create, fund, and send from local or Privy server-side wallets (EVM + Solana).
+- **Alerts** — smart-money and token-flow alerts with webhook delivery.
+- **Agent** — ask the Nansen AI research agent natural-language questions.
 
 ## Installation
 
@@ -36,7 +46,7 @@ nansen schema [command] [--pretty]    # full command reference (no API key neede
 
 **Research categories:** `smart-money` (`sm`), `token` (`tgm`), `profiler` (`prof`), `portfolio` (`port`), `prediction-market` (`pm`), `search`, `perp`, `points`
 
-**Trade:** `quote`, `execute`, `bridge-status` — DEX swaps on Solana and Base, including cross-chain bridges.
+**Trade:** `quote`, `execute`, `bridge-status`, `limit-order` — DEX swaps on Solana and Base via best-quote aggregation (Jupiter / 0x), plus cross-chain bridges and Solana limit orders.
 
 **Wallet:** `create`, `list`, `show`, `export`, `default`, `delete`, `send` — local or Privy server-side wallets (EVM + Solana).
 
@@ -44,11 +54,25 @@ Run `nansen schema --pretty` for the full subcommand and field reference.
 
 ## Trading
 
-DEX swaps on `solana` and `base`. Two-step: quote then execute.
+DEX swaps on `solana` and `base` with best-quote routing across pools — no need to hit Jupiter, Uniswap, or Aerodrome directly. Two-step: quote then execute.
 
 ```bash
 nansen trade quote --chain solana --from SOL --to USDC --amount 1000000000
 nansen trade execute --quote <quoteId>
+```
+
+**Cross-chain bridges** (Solana ↔ Base) via `--to-chain`:
+
+```bash
+nansen trade quote --chain base --to-chain solana --from USDC --to USDC --amount 1000000
+nansen trade bridge-status --tx-hash <hash> --from-chain base --to-chain solana
+```
+
+**Limit orders** (Solana, Jupiter):
+
+```bash
+nansen trade limit-order create --from SOL --to USDC --amount 1000000000 --trigger-mint SOL --trigger-condition below --trigger-price 80
+nansen trade limit-order list
 ```
 
 Amounts are in base units (lamports, wei). Common symbols (`SOL`, `ETH`, `USDC`, `USDT`) resolve automatically. A wallet is required — set one with `nansen wallet default <name>`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nansen-cli",
   "version": "1.28.0",
-  "description": "Command-line interface for Nansen API - designed for AI agents",
+  "description": "Onchain analytics and DEX trading CLI - smart money, swaps on Solana/Base via Jupiter/0x, designed for AI agents",
   "main": "src/index.js",
   "type": "module",
   "bin": {
@@ -43,7 +43,14 @@
     "onchain",
     "defi",
     "solana",
-    "ethereum"
+    "ethereum",
+    "dex",
+    "swap",
+    "trading",
+    "jupiter",
+    "aggregator",
+    "base",
+    "bridge"
   ],
   "author": "Nansen <dev@nansen.ai>",
   "license": "MIT",

--- a/src/cli.js
+++ b/src/cli.js
@@ -699,9 +699,9 @@ export const HELP = `Nansen CLI v${VERSION} — designed for AI agents.
 USAGE: nansen <command> [subcommand] [options]
 
 COMMANDS:
-  research    smart-money, profiler, token, search, perp, portfolio, points
-  trade       quote, execute
-  wallet      create, list, show, export, default, delete, forget-password
+  research    Onchain analytics: smart-money, profiler, token, search, perp, portfolio, points
+  trade       DEX swaps on Solana & Base via best-quote routing (Jupiter/0x): quote, execute, bridge-status, limit-order
+  wallet      create, list, show, export, default, delete, send, forget-password (local or Privy)
   agent       Ask the Nansen AI research agent (fast/expert modes)
   alerts      list, create, update, toggle, delete
   web         search, fetch
@@ -720,7 +720,9 @@ EXAMPLES:
   nansen research smart-money netflow --chain solana
   nansen research token screener --chain solana --timeframe 24h
   nansen research profiler balance --address 0x... --chain ethereum
-  nansen trade quote --chain base --from ETH --to USDC --amount 1000000000000000000
+  nansen trade quote --chain solana --from SOL --to USDC --amount 1000000000  # DEX swap, best-quote routing
+  nansen trade execute --quote <quoteId>
+  nansen wallet create --name my-wallet
 
 DEPRECATED ALIASES (still work, will be removed in a future version):
   smart-money, profiler, token, search, perp, portfolio, points → use "nansen research <command>"

--- a/src/schema.json
+++ b/src/schema.json
@@ -840,7 +840,7 @@
       }
     },
     "trade": {
-      "description": "DEX trading commands",
+      "description": "DEX trading: swap, execute, bridge, and limit-order on Solana and Base with best-quote routing (Jupiter / 0x aggregation)",
       "subcommands": {
         "quote": {
           "description": "Get a DEX swap quote (same-chain or cross-chain)",


### PR DESCRIPTION
## Summary

Internal users [reported](https://nansen-ai.slack.com/) that their agents (e.g. Claw) confidently claim nansen-cli has no trading functionality and route directly to Uniswap / Aerodrome / Jupiter instead. Root cause is a docs framing problem, not a missing feature: `nansen trade` exists with `quote`, `execute`, `bridge-status`, and `limit-order`, but every surface a model scans first frames the CLI as analytics-only, so agents answer from priors without ever running `--help`.

This PR reframes five surfaces to lead with **both** analytics and DEX trading:

- **`README.md`** — tagline rewritten ("Onchain analytics **and DEX trading** from the command line"), new "What it does" section above Installation, Trading section beefed up with bridge + limit-order examples, Trade keywords (Jupiter, 0x, best-quote routing) added inline.
- **`package.json`** — description rewritten; added `dex`, `swap`, `trading`, `jupiter`, `aggregator`, `base`, `bridge` keywords so npm search surfaces it.
- **`src/cli.js`** (HELP banner) — `trade` line now reads `DEX swaps on Solana & Base via best-quote routing (Jupiter/0x): quote, execute, bridge-status, limit-order`. Added a swap example to EXAMPLES.
- **`src/schema.json`** — trade root description rewritten so `nansen schema trade` returns a richer line.
- **`AGENTS.md`** — added Capabilities section so contributor docs lead with both analytics and trade.

No behavior change. Patch changeset added.

## Test plan

- [x] `npm test` (1394 passed, 2 skipped)
- [x] `npm run lint` (clean)
- [x] `node src/index.js` smoke-tested — help banner reads correctly
- [ ] Reviewer eyeballs the README diff for tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)