### PR TITLE
Add Relay aggregator support for cross-chain trading

### DIFF
--- a/.changeset/relay-cross-chain.md
+++ b/.changeset/relay-cross-chain.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add Relay aggregator support for Base↔Solana cross-chain swaps. Users now see Relay quotes alongside Li.Fi in `nansen trade quote --to-chain ...`, can execute them through `trade execute`, and optionally use Relay's gasless path with `--gasless` (local/Privy wallets only — not WalletConnect). `trade bridge-status` auto-detects which aggregator produced a tx (via a local tx record) and polls the right backend.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,16 @@ nansen trade quote --chain solana --from SOL --to USDC --amount 1000000000
 nansen trade execute --quote <quoteId>
 ```
 
-Amounts are in base units (lamports, wei). Common symbols (`SOL`, `ETH`, `USDC`, `USDT`) resolve automatically. A wallet is required — set one with `nansen wallet default <name>`.
+Cross-chain swaps work the same way — add `--to-chain`. Bridge providers (Li.Fi or Relay) are selected automatically based on best price.
+
+```bash
+nansen trade quote --chain base --to-chain solana --from ETH --to SOL --amount 0.0003 --amount-unit token
+nansen trade execute --quote <quoteId>                # signed broadcast
+nansen trade execute --quote <quoteId> --gasless      # Relay-only: solver pays gas
+nansen trade bridge-status --tx-hash <hash> --from-chain base --to-chain solana
+```
+
+Amounts are in base units (lamports, wei) by default — use `--amount-unit token|usd|percent` for friendlier inputs. Common symbols (`SOL`, `ETH`, `USDC`, `USDT`) resolve automatically. A wallet is required — set one with `nansen wallet default <name>`.
 
 ## Wallet
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1741,6 +1741,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2078,6 +2079,7 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3128,6 +3130,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3645,6 +3648,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3720,6 +3724,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -2954,3 +2954,140 @@ describe('Relay aggregator: --aggregator override on bridge-status', () => {
     })).rejects.toThrow(/Invalid --aggregator/);
   });
 });
+
+describe('Relay aggregator: --aggregator filter on trade quote', () => {
+  it('filters quote list to the requested aggregator', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({
+        success: true,
+        quotes: [
+          { aggregator: 'lifi', inputMint: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', outputMint: '11111111111111111111111111111111', inAmount: '1000', outAmount: '500', transaction: { to: '0xa', data: '0x', value: '1000' } },
+          { aggregator: 'relay', inputMint: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', outputMint: '11111111111111111111111111111111', inAmount: '1000', outAmount: '550', transaction: { to: '0xb', data: '0x', value: '1000' } },
+        ],
+      }),
+    });
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    await cmds.quote([], null, {}, {
+      chain: 'base',
+      'to-chain': 'solana',
+      from: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      to: 'SOL',
+      amount: '1000',
+      aggregator: 'relay',
+    });
+
+    // Output must include relay quote and not the lifi one
+    expect(logs.some(l => l.includes('(relay)'))).toBe(true);
+    expect(logs.some(l => l.includes('(lifi)'))).toBe(false);
+
+    global.fetch = origFetch;
+    delete process.env.NANSEN_WALLET_PASSWORD;
+  });
+
+  it('errors when no quote from the requested aggregator is available', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({
+        success: true,
+        quotes: [
+          { aggregator: 'lifi', inputMint: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', outputMint: '11111111111111111111111111111111', inAmount: '1000', outAmount: '500', transaction: { to: '0xa', data: '0x', value: '1000' } },
+        ],
+      }),
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    await expect(cmds.quote([], null, {}, {
+      chain: 'base',
+      'to-chain': 'solana',
+      from: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      to: 'SOL',
+      amount: '1000',
+      aggregator: 'relay',
+    })).rejects.toThrow(/No quotes from aggregator "relay"/);
+
+    global.fetch = origFetch;
+    delete process.env.NANSEN_WALLET_PASSWORD;
+  });
+
+  it('rejects unknown --aggregator values on quote', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    await expect(cmds.quote([], null, {}, {
+      chain: 'base',
+      'to-chain': 'solana',
+      from: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      to: 'SOL',
+      amount: '1000',
+      aggregator: 'pancake',
+    })).rejects.toThrow(/Invalid --aggregator/);
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
+  });
+});
+
+describe('Relay aggregator: bridge-status 502 handling', () => {
+  it('retries on 502 then returns the eventual JSON body', async () => {
+    const origFetch = global.fetch;
+    let calls = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      calls += 1;
+      if (calls < 3) {
+        return Promise.resolve({
+          ok: false,
+          status: 502,
+          text: async () => '<!DOCTYPE html><html>502 Bad Gateway from Cloudflare</html>',
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ status: 'PENDING' }),
+      });
+    });
+
+    const result = await getBridgeStatus('0xabc', 'base', 'solana', { retryDelayMs: 5 });
+    expect(result.status).toBe('PENDING');
+    expect(calls).toBe(3); // 2 failed + 1 success
+
+    global.fetch = origFetch;
+  });
+
+  it('throws clean message without leaking HTML when 502 persists', async () => {
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: async () => '<!DOCTYPE html><html><body>Cloudflare error 1101 details: foo bar baz</body></html>',
+    });
+
+    let caught;
+    try {
+      await getBridgeStatus('0xabc', 'base', 'solana', { retries: 1, retryDelayMs: 5 });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeDefined();
+    expect(caught.message).not.toContain('<!DOCTYPE');
+    expect(caught.message).not.toContain('<html>');
+    expect(caught.message).toContain('502');
+    expect(caught.message).toContain('temporarily unavailable');
+    // No `details` field at all on the non-JSON path — nothing to leak.
+    expect(caught.details).toBeUndefined();
+
+    global.fetch = origFetch;
+  });
+});

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -2726,16 +2726,228 @@ describe('Relay aggregator: tx record persistence', () => {
     expect(loadTxRecord('0xnonexistent')).toBe(null);
   });
 
-  it('loadTxRecord returns null for expired record', () => {
+  it('loadTxRecord persists past the 1-hour quote TTL (uses 30-day TTL)', () => {
+    saveTxRecord('0xstillvalid', { aggregator: 'relay', requestId: 'req-2', fromChain: 'base', toChain: 'solana' });
+    // Age the record 2 hours — quote TTL would expire it; tx-record TTL must not.
+    const dir = path.join(process.env.HOME, '.nansen', 'quotes');
+    const filePath = path.join(dir, 'tx-0xstillvalid.json');
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    data.timestamp = Date.now() - (2 * 3600000);
+    fs.writeFileSync(filePath, JSON.stringify(data));
+    const record = loadTxRecord('0xstillvalid');
+    expect(record).not.toBeNull();
+    expect(record.aggregator).toBe('relay');
+  });
+
+  it('loadTxRecord returns null past the 30-day TTL', () => {
     saveTxRecord('0xexpired', { aggregator: 'relay', requestId: 'req-2', fromChain: 'base', toChain: 'solana' });
-    // Mutate the file to age it past the 1-hour TTL
     const dir = path.join(process.env.HOME, '.nansen', 'quotes');
     const filePath = path.join(dir, 'tx-0xexpired.json');
     const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-    data.timestamp = Date.now() - (3600000 + 10000);
+    data.timestamp = Date.now() - (31 * 24 * 3600000);
     fs.writeFileSync(filePath, JSON.stringify(data));
     expect(loadTxRecord('0xexpired')).toBe(null);
-    // File is removed after expiry
     expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it('cleanupQuotes preserves tx records (30-day TTL) but sweeps stale quotes', async () => {
+    // A 2-hour-old tx record must survive a cleanup triggered by saveQuote.
+    saveTxRecord('0xpreserved', { aggregator: 'relay', requestId: 'req-3', fromChain: 'base', toChain: 'solana' });
+    const dir = path.join(process.env.HOME, '.nansen', 'quotes');
+    const filePath = path.join(dir, 'tx-0xpreserved.json');
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    data.timestamp = Date.now() - (2 * 3600000); // 2 hours old
+    fs.writeFileSync(filePath, JSON.stringify(data));
+
+    // saveQuote calls cleanupQuotes internally
+    saveQuote({ success: true, quotes: [{ aggregator: 'test' }] }, 'base');
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(loadTxRecord('0xpreserved')).not.toBeNull();
+  });
+});
+
+describe('Relay aggregator: EVM execute forwards requestId', () => {
+  it('non-gasless EVM Relay execute sends requestId in /execute body', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? (() => { try { return JSON.parse(opts.body); } catch { return {}; } })() : {};
+      if (body.method === 'eth_getTransactionCount') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+      }
+      if (body.method === 'eth_call') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x' })) });
+      }
+      if (body.method === 'eth_getTransactionReceipt') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { status: '0x1', blockNumber: '0x100' } })) });
+      }
+      if (urlStr.includes('/bridge/status')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({ status: 'DONE', receiving: { status: 'DONE', txHash: 'destTx' } })),
+        });
+      }
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(JSON.parse(opts.body));
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Success', txHash: '0xRelayHash', chainType: 'evm', broadcaster: 'test' })),
+        });
+      }
+      return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'relay',
+        inputMint: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913', // USDC
+        outputMint: '11111111111111111111111111111111',
+        inAmount: '10000000',
+        outAmount: '50000000',
+        approvalAddress: '', // skip approval
+        transaction: { to: '0xRelayRouter', data: '0xswap', value: '0', gas: '300000', maxFeePerGas: '5000000', maxPriorityFeePerGas: '1000000' },
+        metadata: { requestId: 'relay-evm-req', isCrossChain: true, bridgeTool: 'relay' },
+      }],
+    }, 'base', 'local', null, 'solana');
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    try { await cmds.execute([], null, {}, { quote: quoteId }); } catch { /* may fail later, ok */ }
+
+    expect(executeBodies.length).toBeGreaterThanOrEqual(1);
+    expect(executeBodies[0].aggregator).toBe('relay');
+    expect(executeBodies[0].requestId).toBe('relay-evm-req');
+    expect(executeBodies[0].gasless).toBeUndefined();
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
+    vi.unstubAllGlobals();
+  });
+
+  it('gasless EVM Relay execute sends requestId + gasless + steps', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? (() => { try { return JSON.parse(opts.body); } catch { return {}; } })() : {};
+      if (body.method === 'eth_getTransactionCount') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+      }
+      if (body.method === 'eth_call') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x' })) });
+      }
+      if (body.method === 'eth_getTransactionReceipt') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { status: '0x1', blockNumber: '0x100' } })) });
+      }
+      if (urlStr.includes('/bridge/status')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({ status: 'DONE', receiving: { status: 'DONE', txHash: 'destTx' } })),
+        });
+      }
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(JSON.parse(opts.body));
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Success', txHash: '0xRelayHash', chainType: 'evm', broadcaster: 'relay' })),
+        });
+      }
+      return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'relay',
+        inputMint: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        outputMint: '11111111111111111111111111111111',
+        inAmount: '10000000',
+        outAmount: '50000000',
+        approvalAddress: '',
+        transaction: { to: '0xRelayRouter', data: '0xswap', value: '0', gas: '300000', maxFeePerGas: '5000000', maxPriorityFeePerGas: '1000000' },
+        metadata: { requestId: 'relay-evm-gas-req', isCrossChain: true, bridgeTool: 'relay', steps: [{ kind: 'evm-tx' }] },
+      }],
+    }, 'base', 'local', null, 'solana');
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    try { await cmds.execute([], null, { gasless: true }, { quote: quoteId }); } catch { /* ok */ }
+
+    expect(executeBodies.length).toBeGreaterThanOrEqual(1);
+    expect(executeBodies[0].aggregator).toBe('relay');
+    expect(executeBodies[0].gasless).toBe(true);
+    expect(executeBodies[0].requestId).toBe('relay-evm-gas-req');
+    expect(executeBodies[0].steps).toEqual([{ kind: 'evm-tx' }]);
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('Relay aggregator: --aggregator override on bridge-status', () => {
+  it('uses --aggregator flag when no tx record exists', async () => {
+    const origFetch = global.fetch;
+    const fetchedUrls = [];
+    global.fetch = vi.fn().mockImplementation((url) => {
+      fetchedUrls.push(typeof url === 'string' ? url : url.toString());
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ status: 'PENDING' }),
+      });
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    await cmds['bridge-status']([], null, {}, {
+      'tx-hash': '0xfreshmachine',
+      'from-chain': 'base',
+      'to-chain': 'solana',
+      aggregator: 'relay',
+    });
+
+    expect(fetchedUrls[0]).toContain('aggregator=relay');
+    global.fetch = origFetch;
+  });
+
+  it('--aggregator flag overrides a stale tx record', async () => {
+    const origFetch = global.fetch;
+    saveTxRecord('0xstaletx', { aggregator: 'lifi', fromChain: 'base', toChain: 'solana' });
+
+    const fetchedUrls = [];
+    global.fetch = vi.fn().mockImplementation((url) => {
+      fetchedUrls.push(typeof url === 'string' ? url : url.toString());
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ status: 'PENDING' }),
+      });
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    await cmds['bridge-status']([], null, {}, {
+      'tx-hash': '0xstaletx',
+      'from-chain': 'base',
+      'to-chain': 'solana',
+      aggregator: 'relay',
+    });
+
+    expect(fetchedUrls[0]).toContain('aggregator=relay');
+    expect(fetchedUrls[0]).not.toContain('aggregator=lifi');
+    global.fetch = origFetch;
+  });
+
+  it('rejects invalid --aggregator values', async () => {
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    await expect(cmds['bridge-status']([], null, {}, {
+      'tx-hash': '0xabc',
+      'from-chain': 'base',
+      'to-chain': 'solana',
+      aggregator: 'jupiter',
+    })).rejects.toThrow(/Invalid --aggregator/);
   });
 });

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -2955,6 +2955,111 @@ describe('Relay aggregator: --aggregator override on bridge-status', () => {
   });
 });
 
+describe('Relay aggregator: Solana non-gasless omits requestId', () => {
+  it('non-gasless Solana Relay execute does NOT send requestId (backend 502s otherwise)', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(JSON.parse(opts.body));
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Success', signature: 'SolSig', chainType: 'solana', broadcaster: 'solana-rpc' })),
+        });
+      }
+      if (urlStr.includes('/bridge/status')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({ status: 'DONE', receiving: { status: 'DONE', txHash: 'destTx' } })),
+        });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null })) });
+    }));
+
+    // Minimal Solana tx for signing
+    const sigCount = Buffer.from([0x01]);
+    const emptySig = Buffer.alloc(64);
+    const message = Buffer.from([0x01, 0x00, 0x01, 0x02, ...Buffer.alloc(32), ...Buffer.alloc(32), ...Buffer.alloc(32), 0x01, 0x01, 0x01, 0x00, 0x04, 0x02, 0x00, 0x00, 0x00]);
+    const txBase64 = Buffer.concat([sigCount, emptySig, message]).toString('base64');
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'relay',
+        inputMint: '11111111111111111111111111111111',
+        outputMint: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        inAmount: '8300000',
+        outAmount: '278359729005750',
+        approvalAddress: '',
+        transaction: txBase64,
+        metadata: { requestId: 'relay-sol-req', isCrossChain: true, bridgeTool: 'relay' },
+      }],
+    }, 'solana', 'local', null, 'base');
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    try { await cmds.execute([], null, {}, { quote: quoteId }); } catch { /* bridge poll may fail, ok */ }
+
+    expect(executeBodies.length).toBeGreaterThanOrEqual(1);
+    // Critical: backend treats requestId as a Jupiter Ultra intent ID and 502s on
+    // Relay-Solana submissions. Must omit it on this code path.
+    expect(executeBodies[0].requestId).toBeUndefined();
+    expect(executeBodies[0].aggregator).toBeUndefined();
+    expect(executeBodies[0].gasless).toBeUndefined();
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
+    vi.unstubAllGlobals();
+  });
+
+  it('non-gasless Solana Jupiter execute DOES send requestId (Jupiter Ultra intent)', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(JSON.parse(opts.body));
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Success', signature: 'SolSig', chainType: 'solana', broadcaster: 'jupiter' })),
+        });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null })) });
+    }));
+
+    const sigCount = Buffer.from([0x01]);
+    const emptySig = Buffer.alloc(64);
+    const message = Buffer.from([0x01, 0x00, 0x01, 0x02, ...Buffer.alloc(32), ...Buffer.alloc(32), ...Buffer.alloc(32), 0x01, 0x01, 0x01, 0x00, 0x04, 0x02, 0x00, 0x00, 0x00]);
+    const txBase64 = Buffer.concat([sigCount, emptySig, message]).toString('base64');
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'jupiter',
+        inputMint: 'So11111111111111111111111111111111111111112',
+        outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        inAmount: '1000000000', outAmount: '50000000',
+        transaction: txBase64,
+        metadata: { requestId: 'jupiter-ultra-req' },
+      }],
+    }, 'solana');
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    try { await cmds.execute([], null, {}, { quote: quoteId }); } catch { /* ok */ }
+
+    expect(executeBodies.length).toBeGreaterThanOrEqual(1);
+    expect(executeBodies[0].requestId).toBe('jupiter-ultra-req'); // Jupiter Ultra still needs it
+    expect(executeBodies[0].aggregator).toBeUndefined();
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
+    vi.unstubAllGlobals();
+  });
+});
+
 describe('Relay aggregator: --aggregator filter on trade quote', () => {
   it('filters quote list to the requested aggregator', async () => {
     createWallet('default', 'testpass');

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -34,6 +34,8 @@ import {
   simulateEvmCall,
   getBridgeStatus,
   pollBridgeStatus,
+  saveTxRecord,
+  loadTxRecord,
 } from '../trading.js';
 import { keccak256, rlpEncode } from '../crypto.js';
 import { base58Decode } from '../transfer.js';
@@ -2377,5 +2379,363 @@ describe('resolveUsdPrice', () => {
     const { resolveUsdPrice } = await import('../trading.js');
     await expect(resolveUsdPrice(mockApi, 'So11111111111111111111111111111111111111112', 'solana'))
       .rejects.toThrow('Could not resolve USD price');
+  });
+});
+
+// ============= Relay aggregator =============
+
+describe('Relay aggregator: native SOL system mint', () => {
+  it('formatQuote does not crash on Solana system-mint inputMint', () => {
+    const output = formatQuote({
+      aggregator: 'relay',
+      inputMint: '11111111111111111111111111111111',
+      outputMint: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+      inAmount: '1000000000',
+      outAmount: '180000000',
+      metadata: {
+        isCrossChain: true,
+        bridgeTool: 'relay',
+        estimatedTimeSeconds: 60,
+      },
+    });
+    expect(output).toContain('relay');
+    expect(output).toContain('11111111111');
+    expect(output).toContain('Bridge:       relay');
+    expect(output).toContain('Est. Time:    ~1 min');
+  });
+
+  it('formatQuote does NOT show approval warning for native SOL system mint', () => {
+    // Even if approvalAddress somehow leaks through, native SOL must skip the warning.
+    const output = formatQuote({
+      aggregator: 'relay',
+      inputMint: '11111111111111111111111111111111',
+      outputMint: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+      inAmount: '1000000000',
+      outAmount: '180000000',
+      approvalAddress: '0xshouldNotBeShown',
+    });
+    expect(output).not.toContain('Requires token approval');
+  });
+});
+
+describe('Relay aggregator: empty approvalAddress', () => {
+  it('formatQuote skips approval line when approvalAddress is empty string', () => {
+    const output = formatQuote({
+      aggregator: 'relay',
+      inputMint: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913', // USDC
+      outputMint: '11111111111111111111111111111111',
+      inAmount: '10000000',
+      outAmount: '50000000',
+      approvalAddress: '', // Relay's "no approval needed" signal
+    });
+    expect(output).not.toContain('Requires token approval');
+  });
+
+  it('execute path skips allowance check + approval tx when approvalAddress is empty', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+
+    const fetchCalls = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? (() => { try { return JSON.parse(opts.body); } catch { return {}; } })() : {};
+      fetchCalls.push({ url: urlStr, method: body.method, body });
+      // RPC: nonce + receipt
+      if (body.method === 'eth_getTransactionCount') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+      }
+      if (body.method === 'eth_call') {
+        // Should NOT be hit for empty approvalAddress (no allowance check); succeed in case simulation runs.
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x' })) });
+      }
+      if (body.method === 'eth_getTransactionReceipt') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { status: '0x1', blockNumber: '0x100' } })) });
+      }
+      // Bridge status: return DONE so the post-execute polling exits quickly
+      if (urlStr.includes('/bridge/status')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({ status: 'DONE', receiving: { status: 'DONE', txHash: 'destTx' } })),
+        });
+      }
+      // Trading API /execute → success
+      if (urlStr.includes('trading-api')) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Success', txHash: '0xRelayHash', chainType: 'evm', broadcaster: 'test' })),
+        });
+      }
+      return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'relay',
+        inputMint: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913', // USDC
+        outputMint: '11111111111111111111111111111111',
+        inAmount: '10000000',
+        outAmount: '50000000',
+        approvalAddress: '', // Relay says no approval needed
+        transaction: { to: '0xRelayRouter', data: '0xswap', value: '0', gas: '300000', maxFeePerGas: '5000000', maxPriorityFeePerGas: '1000000' },
+        metadata: { requestId: 'relay-req-empty', isCrossChain: true, bridgeTool: 'relay' },
+      }],
+    }, 'base', 'local', null, 'solana');
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    try { await cmds.execute([], null, {}, { quote: quoteId }); } catch { /* may fail at bridge-poll, that's fine */ }
+
+    // No approval message
+    expect(logs.some(l => l.includes('Approval required'))).toBe(false);
+    expect(logs.some(l => l.includes('Approval confirmed'))).toBe(false);
+
+    // /execute was called exactly once (the swap), not twice (no approval tx)
+    const executeCalls = fetchCalls.filter(c => c.url.includes('trading-api') && c.url.endsWith('/execute'));
+    expect(executeCalls.length).toBe(1);
+
+    // No allowance check (eth_call with the allowance selector 0xdd62ed3e)
+    const allowanceCalls = fetchCalls.filter(c => c.method === 'eth_call'
+      && c.body?.params?.[0]?.data?.startsWith('0xdd62ed3e'));
+    expect(allowanceCalls.length).toBe(0);
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('Relay aggregator: --gasless flag dispatch', () => {
+  it('forwards aggregator/gasless/steps/requestId to /execute when gasless flag is set', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(JSON.parse(opts.body));
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Success', signature: 'SolSig', chainType: 'solana', broadcaster: 'relay' })),
+        });
+      }
+      // Bridge status: return DONE so post-execute polling exits
+      if (urlStr.includes('/bridge/status')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({ status: 'DONE', receiving: { status: 'DONE', txHash: 'destTx' } })),
+        });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null })) });
+    }));
+
+    // Minimal Solana tx so signSolanaTransaction succeeds
+    const sigCount = Buffer.from([0x01]);
+    const emptySig = Buffer.alloc(64);
+    const message = Buffer.from([0x01, 0x00, 0x01, 0x02, ...Buffer.alloc(32), ...Buffer.alloc(32), ...Buffer.alloc(32), 0x01, 0x01, 0x01, 0x00, 0x04, 0x02, 0x00, 0x00, 0x00]);
+    const txBase64 = Buffer.concat([sigCount, emptySig, message]).toString('base64');
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'relay',
+        inputMint: '11111111111111111111111111111111',
+        outputMint: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        inAmount: '1000000000',
+        outAmount: '180000000',
+        approvalAddress: '',
+        transaction: txBase64,
+        metadata: {
+          requestId: 'relay-req-gas',
+          isCrossChain: true,
+          bridgeTool: 'relay',
+          steps: [{ kind: 'transaction', items: [{ data: 'opaque-step-blob' }] }],
+        },
+      }],
+    }, 'solana', 'local', null, 'base');
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    try { await cmds.execute([], null, { gasless: true }, { quote: quoteId }); } catch { /* bridge polling may fail in test, that's fine */ }
+
+    expect(executeBodies.length).toBeGreaterThanOrEqual(1);
+    const body = executeBodies[0];
+    expect(body.aggregator).toBe('relay');
+    expect(body.gasless).toBe(true);
+    expect(body.requestId).toBe('relay-req-gas');
+    expect(body.steps).toEqual([{ kind: 'transaction', items: [{ data: 'opaque-step-blob' }] }]);
+    expect(body.simulate).toBe(false); // gasless skips simulation
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
+    vi.unstubAllGlobals();
+  });
+
+  it('throws GASLESS_UNSUPPORTED_AGGREGATOR when --gasless is used on a LiFi quote', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'lifi',
+        inputMint: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        outputMint: '11111111111111111111111111111111',
+        inAmount: '10000000',
+        outAmount: '50000000',
+        approvalAddress: '0xLifiSpender',
+        transaction: { to: '0xLifiRouter', data: '0x1234', value: '0', gas: '300000' },
+        metadata: { isCrossChain: true, bridgeTool: 'across' },
+      }],
+    }, 'base', 'local', null, 'solana');
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    await expect(cmds.execute([], null, { gasless: true }, { quote: quoteId }))
+      .rejects.toThrow(/only supported for Relay quotes/);
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
+  });
+
+  it('throws GASLESS_UNSUPPORTED_WALLET when --gasless is used with WalletConnect', async () => {
+    vi.spyOn(wcTrading, 'getWalletConnectAddress').mockResolvedValue('0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4');
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'relay',
+        inputMint: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        outputMint: '11111111111111111111111111111111',
+        inAmount: '10000000',
+        outAmount: '50000000',
+        approvalAddress: '',
+        transaction: { to: '0xRelayRouter', data: '0xswap', value: '0', gas: '300000' },
+        metadata: { requestId: 'relay-req-wc', isCrossChain: true, bridgeTool: 'relay' },
+      }],
+    }, 'base', 'walletconnect', null, 'solana');
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    await expect(cmds.execute([], null, { gasless: true }, { quote: quoteId }))
+      .rejects.toThrow(/not supported via WalletConnect/);
+
+    vi.restoreAllMocks();
+  });
+});
+
+describe('Relay aggregator: bridge status', () => {
+  it('pollBridgeStatus appends aggregator query param when set', async () => {
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ status: 'DONE', receiving: { status: 'DONE', txHash: '0xfinal' } }),
+    });
+
+    await pollBridgeStatus('0xabc', 'base', 'solana', { log: () => {}, aggregator: 'relay' });
+
+    const callUrl = new URL(global.fetch.mock.calls[0][0]);
+    expect(callUrl.searchParams.get('aggregator')).toBe('relay');
+    expect(callUrl.searchParams.get('txHash')).toBe('0xabc');
+
+    global.fetch = origFetch;
+  });
+
+  it('pollBridgeStatus returns DONE+REFUNDED status without throwing', async () => {
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ status: 'DONE', substatus: 'REFUNDED', substatusMessage: 'Refunded due to slippage' }),
+    });
+
+    const logs = [];
+    const result = await pollBridgeStatus('0xabc', 'base', 'solana', { log: (m) => logs.push(m), aggregator: 'relay' });
+    expect(result.status).toBe('DONE');
+    expect(result.substatus).toBe('REFUNDED');
+    expect(logs.some(l => l.includes('REFUNDED'))).toBe(true);
+
+    global.fetch = origFetch;
+  });
+
+  it('bridge-status command shows REFUNDED warning instead of completed', async () => {
+    const origFetch = global.fetch;
+    // saveTxRecord first so the command picks up aggregator=relay
+    saveTxRecord('0xrelaytx', { aggregator: 'relay', requestId: 'relay-req-X', fromChain: 'base', toChain: 'solana' });
+
+    const fetchedUrls = [];
+    global.fetch = vi.fn().mockImplementation((url) => {
+      fetchedUrls.push(typeof url === 'string' ? url : url.toString());
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ status: 'DONE', substatus: 'REFUNDED', substatusMessage: 'Funds returned' }),
+      });
+    });
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    await cmds['bridge-status']([], null, {}, { 'tx-hash': '0xrelaytx', 'from-chain': 'base', 'to-chain': 'solana' });
+
+    expect(logs.some(l => l.includes('REFUNDED'))).toBe(true);
+    expect(logs.every(l => !l.includes('completed'))).toBe(true);
+
+    // Auto-detected aggregator forwarded as query param
+    expect(fetchedUrls[0]).toContain('aggregator=relay');
+    // Relay explorer link surfaced
+    expect(logs.some(l => l.includes('https://relay.link/transaction/relay-req-X'))).toBe(true);
+
+    global.fetch = origFetch;
+  });
+
+  it('bridge-status command omits aggregator query when no tx record exists', async () => {
+    const origFetch = global.fetch;
+    const fetchedUrls = [];
+    global.fetch = vi.fn().mockImplementation((url) => {
+      fetchedUrls.push(typeof url === 'string' ? url : url.toString());
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ status: 'DONE', tool: 'lifi' }),
+      });
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    await cmds['bridge-status']([], null, {}, { 'tx-hash': '0xunknowntx', 'from-chain': 'base', 'to-chain': 'solana' });
+
+    expect(fetchedUrls[0]).not.toContain('aggregator=');
+
+    global.fetch = origFetch;
+  });
+});
+
+describe('Relay aggregator: tx record persistence', () => {
+  it('saveTxRecord and loadTxRecord round-trip', () => {
+    saveTxRecord('0xroundtrip', { aggregator: 'relay', requestId: 'req-1', fromChain: 'base', toChain: 'solana' });
+    const record = loadTxRecord('0xroundtrip');
+    expect(record).toMatchObject({
+      txHash: '0xroundtrip',
+      aggregator: 'relay',
+      requestId: 'req-1',
+      fromChain: 'base',
+      toChain: 'solana',
+    });
+    expect(typeof record.timestamp).toBe('number');
+  });
+
+  it('loadTxRecord returns null for unknown tx hash', () => {
+    expect(loadTxRecord('0xnonexistent')).toBe(null);
+  });
+
+  it('loadTxRecord returns null for expired record', () => {
+    saveTxRecord('0xexpired', { aggregator: 'relay', requestId: 'req-2', fromChain: 'base', toChain: 'solana' });
+    // Mutate the file to age it past the 1-hour TTL
+    const dir = path.join(process.env.HOME, '.nansen', 'quotes');
+    const filePath = path.join(dir, 'tx-0xexpired.json');
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    data.timestamp = Date.now() - (3600000 + 10000);
+    fs.writeFileSync(filePath, JSON.stringify(data));
+    expect(loadTxRecord('0xexpired')).toBe(null);
+    // File is removed after expiry
+    expect(fs.existsSync(filePath)).toBe(false);
   });
 });

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -2767,7 +2767,7 @@ describe('Relay aggregator: tx record persistence', () => {
 });
 
 describe('Relay aggregator: EVM execute forwards requestId', () => {
-  it('non-gasless EVM Relay execute sends requestId in /execute body', async () => {
+  it('non-gasless EVM Relay execute omits requestId/aggregator (backend rejects them on EVM)', async () => {
     createWallet('default', 'testpass');
     process.env.NANSEN_WALLET_PASSWORD = 'testpass';
 
@@ -2819,8 +2819,11 @@ describe('Relay aggregator: EVM execute forwards requestId', () => {
     try { await cmds.execute([], null, {}, { quote: quoteId }); } catch { /* may fail later, ok */ }
 
     expect(executeBodies.length).toBeGreaterThanOrEqual(1);
-    expect(executeBodies[0].aggregator).toBe('relay');
-    expect(executeBodies[0].requestId).toBe('relay-evm-req');
+    // Non-gasless EVM Relay: the backend's /execute schema rejects both
+    // `aggregator` and `requestId` on EVM submissions (requestId is "Solana only").
+    // The signed tx itself contains the routing info; no aggregator hint needed.
+    expect(executeBodies[0].requestId).toBeUndefined();
+    expect(executeBodies[0].aggregator).toBeUndefined();
     expect(executeBodies[0].gasless).toBeUndefined();
 
     delete process.env.NANSEN_WALLET_PASSWORD;

--- a/src/cli.js
+++ b/src/cli.js
@@ -1520,12 +1520,12 @@ SYMBOLS:
 
 CROSS-CHAIN NOTES (when using --to-chain):
   Supported combos:
-    native → native (ETH <-> SOL) — requires $5+ per trade
+    native → native (ETH <-> SOL)
     USDC → USDC (both directions)
     USDC → native (USDC → ETH or SOL)
     native → USDC (ETH/SOL → USDC)
     non-native → non-native — not supported (use USDC as intermediate)
-  Bridge provider: Li.Fi
+  Bridge providers: Li.Fi or Relay (selected automatically based on best price)
   Typical bridge time: 1-5 minutes`);
       return;
     }

--- a/src/schema.json
+++ b/src/schema.json
@@ -905,7 +905,7 @@
           }
         },
         "bridge-status": {
-          "description": "Check cross-chain bridge transaction status. Aggregator (Li.Fi or Relay) is auto-detected from the local tx record saved at execute time; falls back to Li.Fi if no record exists.",
+          "description": "Check cross-chain bridge transaction status. Aggregator (Li.Fi or Relay) is auto-detected from a local tx record saved at execute time (kept 30 days); pass --aggregator to override when polling from a different machine.",
           "options": {
             "tx-hash": {
               "type": "string",
@@ -921,6 +921,10 @@
               "type": "string",
               "required": true,
               "description": "Destination chain (solana or base)"
+            },
+            "aggregator": {
+              "type": "string",
+              "description": "lifi or relay. Overrides auto-detection — use when polling from a different machine or after the 30-day local record TTL has expired."
             }
           }
         },

--- a/src/schema.json
+++ b/src/schema.json
@@ -852,7 +852,7 @@
             },
             "to-chain": {
               "type": "string",
-              "description": "Destination blockchain for cross-chain swap (solana or base). Omit for same-chain. At least one side must be USDC or a native token (ETH, SOL). Non-native to non-native is not supported — swap to USDC first, then bridge. Minimum ~$5 per cross-chain trade (Li.Fi bridge)."
+              "description": "Destination blockchain for cross-chain swap (solana or base). Omit for same-chain. At least one side must be USDC or a native token (ETH, SOL). Non-native to non-native is not supported — swap to USDC first, then bridge. Bridge providers (Li.Fi or Relay) are selected automatically based on best price. Minimum ~$5 per cross-chain trade."
             },
             "from": {
               "type": "string",
@@ -897,11 +897,15 @@
             "wallet": {
               "type": "string",
               "description": "Wallet name, or \"walletconnect\"/\"wc\" for WalletConnect (EVM only)"
+            },
+            "gasless": {
+              "type": "boolean",
+              "description": "Relay-only: have Relay's solver pay gas + broadcast (user signs only). Requires the selected quote's aggregator to be \"relay\". Not supported via WalletConnect."
             }
           }
         },
         "bridge-status": {
-          "description": "Check cross-chain bridge transaction status",
+          "description": "Check cross-chain bridge transaction status. Aggregator (Li.Fi or Relay) is auto-detected from the local tx record saved at execute time; falls back to Li.Fi if no record exists.",
           "options": {
             "tx-hash": {
               "type": "string",

--- a/src/schema.json
+++ b/src/schema.json
@@ -880,6 +880,10 @@
             "to-wallet": {
               "type": "string",
               "description": "Destination wallet address for cross-chain swaps. Auto-derived from wallet if omitted."
+            },
+            "aggregator": {
+              "type": "string",
+              "description": "Force a specific aggregator: lifi, relay, jupiter, or okx. Filters the returned quote list client-side; errors if no quote from that aggregator was returned."
             }
           },
           "prerequisites": [

--- a/src/schema.json
+++ b/src/schema.json
@@ -852,7 +852,7 @@
             },
             "to-chain": {
               "type": "string",
-              "description": "Destination blockchain for cross-chain swap (solana or base). Omit for same-chain. At least one side must be USDC or a native token (ETH, SOL). Non-native to non-native is not supported — swap to USDC first, then bridge. Bridge providers (Li.Fi or Relay) are selected automatically based on best price. Minimum ~$5 per cross-chain trade."
+              "description": "Destination blockchain for cross-chain swap (solana or base). Omit for same-chain. At least one side must be USDC or a native token (ETH, SOL). Non-native to non-native is not supported — swap to USDC first, then bridge. Bridge providers (Li.Fi or Relay) are selected automatically based on best price. Sub-dollar swaps are supported via Relay."
             },
             "from": {
               "type": "string",

--- a/src/trading.js
+++ b/src/trading.js
@@ -37,6 +37,10 @@ const WRAPPED_NATIVE_TOKENS = {
 // Wrapped-native addresses (WETH) are derived from WRAPPED_NATIVE_TOKENS
 // to avoid duplication — keep that map as the single source of truth.
 const EVM_NATIVE = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+// Relay returns the Solana System Program mint as the sentinel for native SOL.
+// Recognise it as native so approval/value validation behaves correctly when
+// cross-chain quotes route through Relay. (LiFi/Jupiter still use WSOL.)
+const NATIVE_SOL_SYSTEM_MINT = '11111111111111111111111111111111';
 const TOKEN_SYMBOLS = {
   solana: {
     SOL:  'So11111111111111111111111111111111111111112',
@@ -209,15 +213,19 @@ export async function executeTransaction(params, { retries = 2, retryDelayMs = 1
  * @param {string} txHash - Source chain transaction hash
  * @param {string} fromChain - Source chain name (e.g. 'base')
  * @param {string} toChain - Destination chain name (e.g. 'solana')
+ * @param {object} [opts]
+ * @param {string} [opts.aggregator] - 'lifi' (default) or 'relay'. Relay txHashes
+ *   return NOT_FOUND when polled with the LiFi default, so this must be set.
  * @returns {Promise<object>} Bridge status
  */
-export async function getBridgeStatus(txHash, fromChain, toChain) {
+export async function getBridgeStatus(txHash, fromChain, toChain, { aggregator } = {}) {
   const fromConfig = resolveChain(fromChain);
   const toConfig = resolveChain(toChain);
   const url = new URL('/bridge/status', TRADING_API_URL);
   url.searchParams.set('txHash', txHash);
   url.searchParams.set('fromChain', fromConfig.lifiChainId || fromConfig.index);
   url.searchParams.set('toChain', toConfig.lifiChainId || toConfig.index);
+  if (aggregator) url.searchParams.set('aggregator', aggregator);
 
   const res = await fetch(url.toString(), { headers: { 'Accept': 'application/json', 'User-Agent': CLIENT_USER_AGENT } });
   const text = await res.text();
@@ -248,14 +256,15 @@ export async function getBridgeStatus(txHash, fromChain, toChain) {
  * @param {number} [opts.timeoutMs=600000] - Timeout (default 10 min)
  * @param {number} [opts.pollMs=10000] - Poll interval (default 10s)
  * @param {Function} [opts.log=console.log] - Logger
+ * @param {string} [opts.aggregator] - 'lifi' or 'relay'; forwarded to bridge-status query.
  * @returns {Promise<object>} Final bridge status
  */
-export async function pollBridgeStatus(txHash, fromChain, toChain, { timeoutMs = 600000, pollMs = 10000, log = console.log } = {}) {
+export async function pollBridgeStatus(txHash, fromChain, toChain, { timeoutMs = 600000, pollMs = 10000, log = console.log, aggregator } = {}) {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     let status;
     try {
-      status = await getBridgeStatus(txHash, fromChain, toChain);
+      status = await getBridgeStatus(txHash, fromChain, toChain, { aggregator });
     } catch (err) {
       // Transient errors (502, 503, network failures) — retry after poll interval.
       log(`  Bridge: poll error (${err.status || err.code || 'unknown'}) — retrying...`);
@@ -266,7 +275,13 @@ export async function pollBridgeStatus(txHash, fromChain, toChain, { timeoutMs =
     const receiving = status.receiving?.status || 'pending';
     log(`  Bridge: ${sending} → ${receiving}`);
 
-    if (status.status === 'DONE' || status.receiving?.status === 'DONE') return status;
+    const isTerminal = status.status === 'DONE' || status.receiving?.status === 'DONE';
+    if (isTerminal) {
+      if (status.substatus === 'REFUNDED') {
+        log(`  Bridge: REFUNDED — funds returned on source chain`);
+      }
+      return status;
+    }
     if (status.status === 'FAILED') {
       throw Object.assign(
         new Error(`Bridge failed: ${status.substatusMessage || 'unknown error'}`),
@@ -280,6 +295,38 @@ export async function pollBridgeStatus(txHash, fromChain, toChain, { timeoutMs =
     new Error(`Bridge status polling timed out after ${timeoutMs / 1000}s. Check manually with: nansen trade bridge-status --tx-hash ${txHash} --from-chain ${fromChain} --to-chain ${toChain}`),
     { code: 'BRIDGE_TIMEOUT' }
   );
+}
+
+/**
+ * Persist a tx → aggregator mapping for cross-chain swaps so `bridge-status`
+ * can pass the right `aggregator` query param without a new CLI flag.
+ * Lives next to saved quotes; cleaned up by the same 1-hour TTL sweep.
+ */
+export function saveTxRecord(txHash, { aggregator, requestId, fromChain, toChain }) {
+  if (!txHash) return;
+  const dir = getQuotesDir();
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const data = { txHash, aggregator, requestId, fromChain, toChain, timestamp: Date.now() };
+  fs.writeFileSync(path.join(dir, `tx-${txHash}.json`), JSON.stringify(data, null, 2), { mode: 0o600 });
+}
+
+/**
+ * Load a previously saved tx record. Returns null if not found or expired (1 hour).
+ */
+export function loadTxRecord(txHash) {
+  if (!txHash) return null;
+  const filePath = path.join(getQuotesDir(), `tx-${txHash}.json`);
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    if (Date.now() - data.timestamp > 3600000) {
+      fs.unlinkSync(filePath);
+      return null;
+    }
+    return data;
+  } catch {
+    return null;
+  }
 }
 
 // ============= Quote Storage =============
@@ -732,7 +779,11 @@ function resolveTradePassword() {
 }
 
 function isNativeToken(mintAddress) {
-  return /^0x[eE]{40}$/.test(mintAddress);
+  if (!mintAddress) return false;
+  if (mintAddress.startsWith('0x')) return /^0x[eE]{40}$/.test(mintAddress);
+  // Solana: WSOL mint (Jupiter/LiFi) and System Program (Relay) both denote native SOL.
+  return mintAddress === 'So11111111111111111111111111111111111111112'
+      || mintAddress === NATIVE_SOL_SYSTEM_MINT;
 }
 
 /**
@@ -767,6 +818,7 @@ export function getWrappedNativeFromWarning(tokenAddress, chain) {
 const KNOWN_DECIMALS = {
   // Solana
   'So11111111111111111111111111111111111111112': 9,   // SOL/WSOL
+  '11111111111111111111111111111111': 9,              // Native SOL (Relay system-mint sentinel)
   'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v': 6, // USDC
   'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB': 6,  // USDT
   // Base (EVM) — lowercase for case-insensitive matching
@@ -912,12 +964,17 @@ export function formatQuote(quote, index) {
   }
   if (quote.tradingFeeInUsd) lines.push(`    Trading Fee:  $${quote.tradingFeeInUsd}`);
   if (quote.networkFeeInUsd) lines.push(`    Network Fee:  $${quote.networkFeeInUsd}`);
-  if (quote.approvalAddress && !isNativeToken(quote.inputMint)) lines.push(`    ⚠ Requires token approval to: ${quote.approvalAddress}`);
+  // Empty string is Relay's "no approval needed" sentinel — gate on truthy + non-empty.
+  if (quote.approvalAddress && quote.approvalAddress !== '' && !isNativeToken(quote.inputMint)) {
+    lines.push(`    ⚠ Requires token approval to: ${quote.approvalAddress}`);
+  }
   const meta = quote.metadata || {};
   if (meta.isCrossChain) {
     if (meta.bridgeTool) lines.push(`    Bridge:       ${meta.bridgeTool}`);
-    if (meta.executionDuration) {
-      const mins = Math.round(meta.executionDuration / 60);
+    // LiFi uses executionDuration; Relay uses estimatedTimeSeconds.
+    const durationSec = meta.executionDuration ?? meta.estimatedTimeSeconds;
+    if (durationSec) {
+      const mins = Math.round(durationSec / 60);
       lines.push(`    Est. Time:    ${mins < 1 ? '< 1 min' : `~${mins} min`}`);
     }
     if (meta.feeCosts?.length) {
@@ -1167,10 +1224,8 @@ CROSS-CHAIN NOTES (when using --to-chain):
         };
         if (isCrossChain) {
           params.toChainIndex = toChainConfig.index;
-          // Opt out of Relay aggregator: CLI bypasses backend /execute so the
-          // Redis aggregator hint is never set, and /bridge/status defaults to
-          // LiFi — polling a Relay txHash there returns NOT_FOUND.
-          params.disabledAggregators = 'relay';
+          // Relay and LiFi are both first-class cross-chain aggregators; backend picks per quote.
+          // bridge-status auto-detects which aggregator produced a tx via the local tx record.
           if (toWallet) {
             params.toWalletAddress = toWallet;
             log(`  Destination wallet: ${toWallet}`);
@@ -1217,7 +1272,8 @@ CROSS-CHAIN NOTES (when using --to-chain):
           log(`  Pin #1:  nansen trade execute --quote ${quoteId} --quote-index 0`);
         }
 
-        if (response.quotes[0]?.approvalAddress && !isNativeToken(response.quotes[0]?.inputMint)) {
+        const firstQuote = response.quotes[0];
+        if (firstQuote?.approvalAddress && firstQuote.approvalAddress !== '' && !isNativeToken(firstQuote.inputMint)) {
           log(`\n  Warning: This token swap requires an ERC-20 approval step.`);
           log(`    The execute command will handle this automatically.`);
         }
@@ -1241,6 +1297,7 @@ CROSS-CHAIN NOTES (when using --to-chain):
       const quoteId = options.quote || options['quote-id'] || args[0];
       const walletName = options.wallet;
       const noSimulate = flags['no-simulate'];
+      const gasless = Boolean(flags.gasless);
 
       if (!quoteId) {
         throw new CommandError(`Usage: nansen trade execute --quote <quoteId> [options]
@@ -1249,6 +1306,7 @@ OPTIONS:
   --quote <id>              Quote ID from 'nansen quote'
   --wallet <name>           Wallet name (default: default wallet)
   --no-simulate             Skip pre-broadcast simulation
+  --gasless                 Relay-only: have Relay's solver pay gas (no WalletConnect)
 
 EXAMPLES:
   nansen trade execute --quote 1708900000000-abc123`, 'MISSING_ARGS');
@@ -1346,6 +1404,22 @@ EXAMPLES:
             continue;
           }
 
+          const isRelay = currentQuote.aggregator === 'relay';
+          if (gasless) {
+            if (!isRelay) {
+              throw new CommandError(
+                `--gasless is only supported for Relay quotes. Selected quote ${quoteName} is from "${currentQuote.aggregator}". Re-run with --quote-index to pin a Relay quote, or omit --gasless.`,
+                'GASLESS_UNSUPPORTED_AGGREGATOR'
+              );
+            }
+            if (isWalletConnect) {
+              throw new CommandError(
+                'Gasless swaps are not supported via WalletConnect (mobile wallets typically auto-broadcast, breaking the gasless flow). Use a local or Privy wallet.',
+                'GASLESS_UNSUPPORTED_WALLET'
+              );
+            }
+          }
+
           log(`\nExecuting trade on ${chainConfig.name}...`);
           if (endIndex - startIndex > 1) {
             log(`  Trying quote ${qi + 1}/${allQuotes.length} (${quoteName})...`);
@@ -1399,7 +1473,8 @@ EXAMPLES:
               }
 
               // Handle approval if needed
-              if (currentQuote.approvalAddress && !isNative) {
+              // Empty-string approvalAddress is Relay's "no approval needed" sentinel — skip.
+              if (currentQuote.approvalAddress && currentQuote.approvalAddress !== '' && !isNative) {
                 const inputAmount = BigInt(currentQuote.inputAmount || currentQuote.inAmount || '0');
                 const existingAllowance = await checkErc20Allowance(
                   chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress
@@ -1449,7 +1524,7 @@ EXAMPLES:
               }
 
               // Pre-flight simulation
-              if (!noSimulate) {
+              if (!noSimulate && !gasless) {
                 const sim = await simulateEvmCall(chain, {
                   from: walletAddress,
                   to: currentQuote.transaction.to,
@@ -1587,7 +1662,8 @@ EXAMPLES:
               }
 
               // Handle approval via WalletConnect if needed
-              if (currentQuote.approvalAddress && !isNative) {
+              // Empty-string approvalAddress is Relay's "no approval needed" sentinel — skip.
+              if (currentQuote.approvalAddress && currentQuote.approvalAddress !== '' && !isNative) {
                 const inputAmount = BigInt(currentQuote.inputAmount || currentQuote.inAmount || '0');
                 const existingAllowance = await checkErc20Allowance(
                   chain, currentQuote.inputMint, wcAddress, currentQuote.approvalAddress
@@ -1635,7 +1711,7 @@ EXAMPLES:
               }
 
               // Pre-flight simulation
-              if (!noSimulate) {
+              if (!noSimulate && !gasless) {
                 const txData = currentQuote.transaction;
                 const sim = await simulateEvmCall(chain, {
                   from: wcAddress,
@@ -1700,13 +1776,24 @@ EXAMPLES:
 
                 // Cross-chain: poll bridge status after source tx success
                 if (quoteData.toChain && quoteData.toChain !== quoteData.chain) {
+                  saveTxRecord(wcResult.txHash, {
+                    aggregator: currentQuote.aggregator,
+                    requestId: currentQuote.metadata?.requestId,
+                    fromChain: quoteData.chain,
+                    toChain: quoteData.toChain,
+                  });
                   log(`\n  Cross-chain bridge in progress (${chainConfig.name} → ${resolveChain(quoteData.toChain).name})...`);
                   try {
-                    const bridgeResult = await pollBridgeStatus(wcResult.txHash, quoteData.chain, quoteData.toChain, { log });
-                    log(`\n  ✓ Bridge completed!`);
-                    if (bridgeResult.receiving?.txHash) {
-                      const toChainConfig = resolveChain(quoteData.toChain);
-                      log(`    Destination tx: ${toChainConfig.explorer}${bridgeResult.receiving.txHash}`);
+                    const bridgeResult = await pollBridgeStatus(wcResult.txHash, quoteData.chain, quoteData.toChain, { log, aggregator: currentQuote.aggregator });
+                    if (bridgeResult.substatus === 'REFUNDED') {
+                      log(`\n  ⚠ Bridge refunded — funds returned on source chain.`);
+                      if (bridgeResult.substatusMessage) log(`    Reason: ${bridgeResult.substatusMessage}`);
+                    } else {
+                      log(`\n  ✓ Bridge completed!`);
+                      if (bridgeResult.receiving?.txHash) {
+                        const toChainConfig = resolveChain(quoteData.toChain);
+                        log(`    Destination tx: ${toChainConfig.explorer}${bridgeResult.receiving.txHash}`);
+                      }
                     }
                   } catch (bridgeErr) {
                     log(`\n  Bridge status: ${bridgeErr.message}`);
@@ -1752,7 +1839,8 @@ EXAMPLES:
                 }
               }
 
-              if (currentQuote.approvalAddress && !isNative) {
+              // Empty-string approvalAddress is Relay's "no approval needed" sentinel — skip.
+              if (currentQuote.approvalAddress && currentQuote.approvalAddress !== '' && !isNative) {
                 // Check if sufficient allowance already exists
                 const inputAmount = BigInt(currentQuote.inputAmount || currentQuote.inAmount || currentQuote.transaction?.value || '0');
                 const existingAllowance = await checkErc20Allowance(
@@ -1808,7 +1896,7 @@ EXAMPLES:
               // Pre-flight simulation (EVM only) — catch logic reverts before spending gas
               // Runs AFTER approval so eth_call sees the current allowance state
               // Simulates WITHOUT gas limit to check swap logic; gas re-estimation is separate
-              if (!noSimulate) {
+              if (!noSimulate && !gasless) {
                 const txData = currentQuote.transaction;
                 const sim = await simulateEvmCall(chain, {
                   from: walletAddress,
@@ -1851,13 +1939,18 @@ EXAMPLES:
               );
             }
 
-            log('  Broadcasting...');
+            log(gasless ? '  Forwarding to Relay solver (gasless)...' : '  Broadcasting...');
             const execParams = {
               signedTransaction,
               chain,
-              simulate: !noSimulate,
+              simulate: !noSimulate && !gasless,
             };
             if (requestId) execParams.requestId = requestId;
+            if (isRelay) execParams.aggregator = 'relay';
+            if (gasless) {
+              execParams.gasless = true;
+              if (currentQuote.metadata?.steps) execParams.steps = currentQuote.metadata.steps;
+            }
 
             const result = await executeTransaction(execParams);
 
@@ -1900,13 +1993,27 @@ EXAMPLES:
 
               // Cross-chain: poll bridge status after source tx success
               if (quoteData.toChain && quoteData.toChain !== quoteData.chain) {
+                saveTxRecord(txId, {
+                  aggregator: currentQuote.aggregator,
+                  requestId: currentQuote.metadata?.requestId,
+                  fromChain: quoteData.chain,
+                  toChain: quoteData.toChain,
+                });
+                if (isRelay && currentQuote.metadata?.requestId) {
+                  log(`    Relay:       https://relay.link/transaction/${currentQuote.metadata.requestId}`);
+                }
                 log(`\n  Cross-chain bridge in progress (${chainConfig.name} → ${resolveChain(quoteData.toChain).name})...`);
                 try {
-                  const bridgeResult = await pollBridgeStatus(txId, quoteData.chain, quoteData.toChain, { log });
-                  log(`\n  ✓ Bridge completed!`);
-                  if (bridgeResult.receiving?.txHash) {
-                    const toChainConfig = resolveChain(quoteData.toChain);
-                    log(`    Destination tx: ${toChainConfig.explorer}${bridgeResult.receiving.txHash}`);
+                  const bridgeResult = await pollBridgeStatus(txId, quoteData.chain, quoteData.toChain, { log, aggregator: currentQuote.aggregator });
+                  if (bridgeResult.substatus === 'REFUNDED') {
+                    log(`\n  ⚠ Bridge refunded — funds returned on source chain.`);
+                    if (bridgeResult.substatusMessage) log(`    Reason: ${bridgeResult.substatusMessage}`);
+                  } else {
+                    log(`\n  ✓ Bridge completed!`);
+                    if (bridgeResult.receiving?.txHash) {
+                      const toChainConfig = resolveChain(quoteData.toChain);
+                      log(`    Destination tx: ${toChainConfig.explorer}${bridgeResult.receiving.txHash}`);
+                    }
                   }
                 } catch (bridgeErr) {
                   log(`\n  Bridge status: ${bridgeErr.message}`);
@@ -1965,9 +2072,18 @@ EXAMPLES:
       }
 
       try {
-        const status = await getBridgeStatus(txHash, fromChain, toChain);
+        // Auto-detect aggregator from a tx record saved at execute time. Fall back
+        // to the backend default (LiFi) when no record exists — preserves backward
+        // compat for users polling LiFi txes from older versions of the CLI.
+        const txRecord = loadTxRecord(txHash);
+        const aggregator = txRecord?.aggregator;
+        const status = await getBridgeStatus(txHash, fromChain, toChain, { aggregator });
         log(`\nBridge Status: ${status.status || 'unknown'}`);
-        if (status.substatus) log(`  Substatus:   ${status.substatus}`);
+        if (status.substatus === 'REFUNDED') {
+          log(`  ⚠ REFUNDED — funds returned on source chain`);
+        } else if (status.substatus) {
+          log(`  Substatus:   ${status.substatus}`);
+        }
         if (status.substatusMessage) log(`  Message:     ${status.substatusMessage}`);
         if (status.tool) log(`  Bridge:      ${status.tool}`);
         if (status.sending?.txHash) {
@@ -1982,7 +2098,11 @@ EXAMPLES:
           if (status.receiving.amount) log(`    Amount:    ${status.receiving.amount}`);
           if (status.receiving.txLink) log(`    Explorer:  ${status.receiving.txLink}`);
         }
-        if (status.lifiExplorerLink) log(`  Li.Fi:       ${status.lifiExplorerLink}`);
+        const explorerLink = status.lifiExplorerLink || status.relayExplorerLink || status.explorerLink;
+        if (explorerLink) log(`  Explorer:    ${explorerLink}`);
+        if (aggregator === 'relay' && txRecord?.requestId) {
+          log(`  Relay:       https://relay.link/transaction/${txRecord.requestId}`);
+        }
         log('');
       } catch (err) {
         if (err instanceof CommandError) throw err;

--- a/src/trading.js
+++ b/src/trading.js
@@ -1997,20 +1997,28 @@ EXAMPLES:
               chain,
               simulate: !noSimulate && !gasless,
             };
-            // The backend's /execute schema is strict:
-            //   - `requestId` is only accepted for Solana submissions (Jupiter/Relay-Solana)
-            //     and for the gasless Relay route — sending it on EVM signed broadcasts errors.
-            //   - `aggregator`, `gasless`, `steps` are only valid on the gasless route.
-            // The Solana branches above already assign `requestId` for non-gasless flows;
-            // for gasless EVM we pull it from quote metadata so Relay's solver can route.
+            // The backend's /execute schema is strict; sending fields it doesn't expect
+            // for the (chain × aggregator × gasless) combination causes 502s or
+            // "Unrecognized keys" rejections. The matrix we've validated against the
+            // live backend:
+            //   - EVM signed (any aggregator): no extra fields. requestId/aggregator
+            //     trigger schema errors.
+            //   - Solana signed (Jupiter/OKX): include requestId for Jupiter Ultra
+            //     intent resolution.
+            //   - Solana signed (Relay): omit requestId — backend tries to look it up
+            //     as a Jupiter intent and 502s.
+            //   - Gasless (EVM): aggregator + gasless + steps + requestId.
+            //   - Gasless (Solana): currently rejected by the backend ("Unrecognized
+            //     keys"); we still send the gasless envelope and let the backend
+            //     surface the error so users notice when support lands.
             if (gasless) {
               execParams.aggregator = 'relay';
               execParams.gasless = true;
               const gaslessRequestId = requestId || currentQuote.metadata?.requestId;
               if (gaslessRequestId) execParams.requestId = gaslessRequestId;
               if (currentQuote.metadata?.steps) execParams.steps = currentQuote.metadata.steps;
-            } else if (requestId) {
-              execParams.requestId = requestId; // Solana non-gasless (Jupiter / Relay-Solana)
+            } else if (requestId && !isRelay) {
+              execParams.requestId = requestId; // Solana Jupiter Ultra
             }
 
             const result = await executeTransaction(execParams);

--- a/src/trading.js
+++ b/src/trading.js
@@ -1062,13 +1062,13 @@ EXAMPLES:
 
 CROSS-CHAIN NOTES (when using --to-chain):
   Supported combos:
-    native → native (ETH <-> SOL) — requires $5+ per trade
+    native → native (ETH <-> SOL)
     USDC → USDC (both directions)
     USDC → native (USDC → ETH or SOL)
     native → USDC (ETH/SOL → USDC)
     non-native → non-native — not supported (use USDC as intermediate)
-  Bridge provider: Li.Fi
-  Typical bridge time: 1-5 minutes
+  Bridge providers: Li.Fi or Relay (selected automatically based on best price)
+  Typical bridge time: seconds to a few minutes (Relay is usually faster)
 `, 'MISSING_ARGS');
       }
 
@@ -1953,15 +1953,20 @@ EXAMPLES:
               chain,
               simulate: !noSimulate && !gasless,
             };
-            // requestId is set on Solana branches above (Jupiter, Relay-Solana). For Relay-EVM
-            // quotes the Solana branches never run, so pull it from quote metadata directly —
-            // Relay's /execute requires requestId for both gasless and signed paths.
-            const effectiveRequestId = requestId || (isRelay ? currentQuote.metadata?.requestId : undefined);
-            if (effectiveRequestId) execParams.requestId = effectiveRequestId;
-            if (isRelay) execParams.aggregator = 'relay';
+            // The backend's /execute schema is strict:
+            //   - `requestId` is only accepted for Solana submissions (Jupiter/Relay-Solana)
+            //     and for the gasless Relay route — sending it on EVM signed broadcasts errors.
+            //   - `aggregator`, `gasless`, `steps` are only valid on the gasless route.
+            // The Solana branches above already assign `requestId` for non-gasless flows;
+            // for gasless EVM we pull it from quote metadata so Relay's solver can route.
             if (gasless) {
+              execParams.aggregator = 'relay';
               execParams.gasless = true;
+              const gaslessRequestId = requestId || currentQuote.metadata?.requestId;
+              if (gaslessRequestId) execParams.requestId = gaslessRequestId;
               if (currentQuote.metadata?.steps) execParams.steps = currentQuote.metadata.steps;
+            } else if (requestId) {
+              execParams.requestId = requestId; // Solana non-gasless (Jupiter / Relay-Solana)
             }
 
             const result = await executeTransaction(execParams);

--- a/src/trading.js
+++ b/src/trading.js
@@ -297,10 +297,15 @@ export async function pollBridgeStatus(txHash, fromChain, toChain, { timeoutMs =
   );
 }
 
+// Tx records keep aggregator metadata for `bridge-status`. They're not stale-able
+// the way quotes are (a finished tx doesn't expire), but cap them to bound disk use.
+const TX_RECORD_TTL_MS = 30 * 24 * 3600 * 1000; // 30 days
+
 /**
  * Persist a tx → aggregator mapping for cross-chain swaps so `bridge-status`
  * can pass the right `aggregator` query param without a new CLI flag.
- * Lives next to saved quotes; cleaned up by the same 1-hour TTL sweep.
+ * Lives next to saved quotes; uses a 30-day TTL (longer than quotes) so users
+ * can still resolve the aggregator hours/days after the swap.
  */
 export function saveTxRecord(txHash, { aggregator, requestId, fromChain, toChain }) {
   if (!txHash) return;
@@ -311,7 +316,7 @@ export function saveTxRecord(txHash, { aggregator, requestId, fromChain, toChain
 }
 
 /**
- * Load a previously saved tx record. Returns null if not found or expired (1 hour).
+ * Load a previously saved tx record. Returns null if not found or older than 30 days.
  */
 export function loadTxRecord(txHash) {
   if (!txHash) return null;
@@ -319,7 +324,7 @@ export function loadTxRecord(txHash) {
   if (!fs.existsSync(filePath)) return null;
   try {
     const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-    if (Date.now() - data.timestamp > 3600000) {
+    if (Date.now() - data.timestamp > TX_RECORD_TTL_MS) {
       fs.unlinkSync(filePath);
       return null;
     }
@@ -371,7 +376,9 @@ export function loadQuote(quoteId) {
 }
 
 /**
- * Remove quotes older than 1 hour.
+ * Remove stale files from the quotes dir. Quote files use a 1-hour TTL because
+ * the price is stale; tx records use a 30-day TTL because a finalized tx hash
+ * is permanent and `bridge-status` needs the aggregator hint long after execute.
  */
 export function cleanupQuotes() {
   const dir = getQuotesDir();
@@ -379,9 +386,10 @@ export function cleanupQuotes() {
   const now = Date.now();
   for (const file of fs.readdirSync(dir)) {
     if (!file.endsWith('.json')) continue;
+    const ttl = file.startsWith('tx-') ? TX_RECORD_TTL_MS : 3600000;
     try {
       const data = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
-      if (now - data.timestamp > 3600000) fs.unlinkSync(path.join(dir, file));
+      if (now - data.timestamp > ttl) fs.unlinkSync(path.join(dir, file));
     } catch { /* ignore */ }
   }
 }
@@ -1945,7 +1953,11 @@ EXAMPLES:
               chain,
               simulate: !noSimulate && !gasless,
             };
-            if (requestId) execParams.requestId = requestId;
+            // requestId is set on Solana branches above (Jupiter, Relay-Solana). For Relay-EVM
+            // quotes the Solana branches never run, so pull it from quote metadata directly —
+            // Relay's /execute requires requestId for both gasless and signed paths.
+            const effectiveRequestId = requestId || (isRelay ? currentQuote.metadata?.requestId : undefined);
+            if (effectiveRequestId) execParams.requestId = effectiveRequestId;
             if (isRelay) execParams.aggregator = 'relay';
             if (gasless) {
               execParams.gasless = true;
@@ -2057,8 +2069,13 @@ EXAMPLES:
       const fromChain = options['from-chain'] || args[1];
       const toChain = options['to-chain'] || args[2];
 
+      const aggregatorOverride = options.aggregator;
+      if (aggregatorOverride && aggregatorOverride !== 'lifi' && aggregatorOverride !== 'relay') {
+        throw new CommandError(`Invalid --aggregator: "${aggregatorOverride}". Use "lifi" or "relay".`, 'INVALID_AGGREGATOR');
+      }
+
       if (!txHash || !fromChain || !toChain) {
-        throw new CommandError(`Usage: nansen trade bridge-status --tx-hash <hash> --from-chain <chain> --to-chain <chain>
+        throw new CommandError(`Usage: nansen trade bridge-status --tx-hash <hash> --from-chain <chain> --to-chain <chain> [--aggregator <lifi|relay>]
 
 Check the status of a cross-chain bridge transaction.
 
@@ -2066,17 +2083,21 @@ OPTIONS:
   --tx-hash <hash>          Source chain transaction hash
   --from-chain <chain>      Source chain (solana or base)
   --to-chain <chain>        Destination chain (solana or base)
+  --aggregator <name>       lifi or relay. Overrides auto-detection from the
+                            local tx record. Use this when polling from a
+                            different machine or after the record has expired.
 
 EXAMPLES:
-  nansen trade bridge-status --tx-hash 0xabc... --from-chain base --to-chain solana`, 'MISSING_ARGS');
+  nansen trade bridge-status --tx-hash 0xabc... --from-chain base --to-chain solana
+  nansen trade bridge-status --tx-hash 0xabc... --from-chain base --to-chain solana --aggregator relay`, 'MISSING_ARGS');
       }
 
       try {
-        // Auto-detect aggregator from a tx record saved at execute time. Fall back
-        // to the backend default (LiFi) when no record exists — preserves backward
-        // compat for users polling LiFi txes from older versions of the CLI.
+        // Resolution order: explicit --aggregator flag → local tx record → backend
+        // default (LiFi). The override matters when polling from a fresh machine
+        // or after the 30-day record TTL expires.
         const txRecord = loadTxRecord(txHash);
-        const aggregator = txRecord?.aggregator;
+        const aggregator = aggregatorOverride || txRecord?.aggregator;
         const status = await getBridgeStatus(txHash, fromChain, toChain, { aggregator });
         log(`\nBridge Status: ${status.status || 'unknown'}`);
         if (status.substatus === 'REFUNDED') {
@@ -2102,6 +2123,10 @@ EXAMPLES:
         if (explorerLink) log(`  Explorer:    ${explorerLink}`);
         if (aggregator === 'relay' && txRecord?.requestId) {
           log(`  Relay:       https://relay.link/transaction/${txRecord.requestId}`);
+        } else if (aggregator === 'relay') {
+          // No local record (cross-machine / expired). Surface the explorer
+          // by tx hash so users can still cross-reference manually.
+          log(`  Relay:       https://relay.link/transaction/${txHash}`);
         }
         log('');
       } catch (err) {

--- a/src/trading.js
+++ b/src/trading.js
@@ -210,15 +210,18 @@ export async function executeTransaction(params, { retries = 2, retryDelayMs = 1
 
 /**
  * Check the status of a cross-chain bridge transaction.
+ * Retries on 502/503 (Cloudflare/upstream gateway hiccups) like executeTransaction.
  * @param {string} txHash - Source chain transaction hash
  * @param {string} fromChain - Source chain name (e.g. 'base')
  * @param {string} toChain - Destination chain name (e.g. 'solana')
  * @param {object} [opts]
  * @param {string} [opts.aggregator] - 'lifi' (default) or 'relay'. Relay txHashes
  *   return NOT_FOUND when polled with the LiFi default, so this must be set.
+ * @param {number} [opts.retries=2] - Retry count for 502/503.
+ * @param {number} [opts.retryDelayMs=1500] - Delay between retries.
  * @returns {Promise<object>} Bridge status
  */
-export async function getBridgeStatus(txHash, fromChain, toChain, { aggregator } = {}) {
+export async function getBridgeStatus(txHash, fromChain, toChain, { aggregator, retries = 2, retryDelayMs = 1500 } = {}) {
   const fromConfig = resolveChain(fromChain);
   const toConfig = resolveChain(toChain);
   const url = new URL('/bridge/status', TRADING_API_URL);
@@ -227,24 +230,40 @@ export async function getBridgeStatus(txHash, fromChain, toChain, { aggregator }
   url.searchParams.set('toChain', toConfig.lifiChainId || toConfig.index);
   if (aggregator) url.searchParams.set('aggregator', aggregator);
 
-  const res = await fetch(url.toString(), { headers: { 'Accept': 'application/json', 'User-Agent': CLIENT_USER_AGENT } });
-  const text = await res.text();
-  let body;
-  try {
-    body = JSON.parse(text);
-  } catch {
-    throw Object.assign(
-      new Error(`Bridge status API returned non-JSON response (status ${res.status}).`),
-      { code: 'BRIDGE_STATUS_ERROR', status: res.status, details: text.slice(0, 200) }
-    );
+  let lastError;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0) await new Promise(r => setTimeout(r, retryDelayMs));
+
+    const res = await fetch(url.toString(), { headers: { 'Accept': 'application/json', 'User-Agent': CLIENT_USER_AGENT } });
+    const text = await res.text();
+    let body;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      // Non-JSON response (typically Cloudflare HTML on 502/503). Don't leak the
+      // HTML body to the user — surface a clean status hint and a retry tip.
+      const hint = res.status === 502 || res.status === 503
+        ? ' Upstream bridge service is temporarily unavailable. Retry in a moment, or check the source-chain explorer to confirm the tx landed.'
+        : '';
+      lastError = Object.assign(
+        new Error(`Bridge status API returned non-JSON response (status ${res.status}).${hint}`),
+        { code: 'BRIDGE_STATUS_ERROR', status: res.status }
+      );
+      if ((res.status === 502 || res.status === 503) && attempt < retries) continue;
+      throw lastError;
+    }
+    if (!res.ok) {
+      const isTransient = res.status === 502 || res.status === 503;
+      lastError = Object.assign(
+        new Error(body.message || `Bridge status check failed with status ${res.status}`),
+        { code: body.code || 'BRIDGE_STATUS_ERROR', status: res.status, details: body.details }
+      );
+      if (isTransient && attempt < retries) continue;
+      throw lastError;
+    }
+    return body;
   }
-  if (!res.ok) {
-    throw Object.assign(
-      new Error(body.message || `Bridge status check failed with status ${res.status}`),
-      { code: body.code || 'BRIDGE_STATUS_ERROR', status: res.status, details: body.details }
-    );
-  }
-  return body;
+  throw lastError;
 }
 
 /**
@@ -1027,6 +1046,13 @@ export function buildTradingCommands(deps = {}) {
       const maxAutoSlippage = options['max-auto-slippage'];
       const swapMode = options['swap-mode'] || 'exactIn';
       const amountUnit = options['amount-unit'];
+      const aggregatorFilter = options.aggregator;
+      if (aggregatorFilter && !['lifi', 'relay', 'jupiter', 'okx'].includes(aggregatorFilter)) {
+        throw new CommandError(
+          `Invalid --aggregator: "${aggregatorFilter}". Use one of: lifi, relay, jupiter, okx.`,
+          'INVALID_AGGREGATOR'
+        );
+      }
 
       if (!chain || !from || !to || !amount) {
         throw new CommandError(`
@@ -1050,6 +1076,8 @@ OPTIONS:
   --auto-slippage           Enable auto slippage calculation
   --max-auto-slippage <pct> Max auto slippage when auto-slippage enabled
   --swap-mode <mode>        exactIn (default) or exactOut
+  --aggregator <name>       Force a specific aggregator (lifi, relay, jupiter, okx).
+                            Filters the quote list client-side; errors if none match.
 
 EXAMPLES:
   nansen trade quote --chain solana --from SOL --to USDC --amount 1000000000
@@ -1260,6 +1288,22 @@ CROSS-CHAIN NOTES (when using --to-chain):
             msg += '\n' + response.warnings.map(w => `  Warning: ${w}`).join('\n');
           }
           throw new CommandError(msg, 'NO_QUOTES');
+        }
+
+        // Client-side filter: if --aggregator is passed, drop everything else.
+        // Done client-side because the backend's aggregator-selection knob
+        // (disabledAggregators) silently accepts unknown values, so a server
+        // filter would mask typos. This way we own the validation.
+        if (aggregatorFilter) {
+          const matching = response.quotes.filter(q => q.aggregator === aggregatorFilter);
+          if (!matching.length) {
+            const seen = [...new Set(response.quotes.map(q => q.aggregator))].join(', ') || 'none';
+            throw new CommandError(
+              `No quotes from aggregator "${aggregatorFilter}" for this pair. Backend returned: ${seen}.`,
+              'AGGREGATOR_NOT_AVAILABLE'
+            );
+          }
+          response.quotes = matching;
         }
 
         log('');


### PR DESCRIPTION
## Summary

Wires the CLI's trading commands to support **Relay** as a cross-chain aggregator alongside Li.Fi for Base↔Solana swaps, end-to-end-verified with a live $0.70 swap ([source](https://basescan.org/tx/0xf6ab514ec1ff316af262c4d45fb88104d7212c4321b97db6ad94b3909f83b1cc) / [destination](https://solscan.io/tx/5jD1xSDYiFL9bEpiRYg2G9ZZgWmvFbPFV87dZfzHtiEMK5afoLRyEKr4hMuMKpWzcDG3cAuiC4uLdG9xGssXfveU)). Removes the `disabledAggregators: 'relay'` gate; handles Relay-specific quirks (Solana System Program mint as native SOL, empty-string `approvalAddress` as "skip approval", REFUNDED bridge status as a non-success terminal state); persists a `txHash → aggregator` record (30-day TTL) so `bridge-status` polls the correct backend without a new flag. Adds a `--gasless` flag on `trade execute` that routes Relay quotes through the solver-subsidized path (local/Privy wallets only — WalletConnect EVM is hard-errored), and a `--aggregator <lifi|relay>` override on `bridge-status` for the cross-machine / post-TTL case. Live testing surfaced two backend `/execute` schema constraints we'd missed (`aggregator` is gasless-only; `requestId` is Solana-only on signed broadcasts) — fixed in commit `f672399`. 21 new unit tests cover native-SOL display, approval-spender edge cases, gasless dispatch + error paths, polling state machine, REFUNDED mapping, tx-record TTL, and `--aggregator` override.

## Checklist

- [x] Tests pass (`npm test`) — 1415 passed, 2 skipped
- [x] `src/schema.json` updated (`--gasless` on execute, `--aggregator` on bridge-status, cross-chain to-chain copy refresh)
- [x] `README.md` updated — added a cross-chain example with `--gasless` so the new flow is discoverable
- [x] Changeset added (`.changeset/relay-cross-chain.md`, minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)