### PR TITLE
BI-465: CLI passes anonymous_id and CLI Header to trading BE

### DIFF
--- a/src/__tests__/telemetry.test.js
+++ b/src/__tests__/telemetry.test.js
@@ -162,6 +162,27 @@ describe('telemetry', () => {
       vi.restoreAllMocks();
     });
 
+    it('should generate a new UUID when file is empty', async () => {
+      const writeCalls = [];
+      const origRead = fs.readFileSync;
+      vi.spyOn(fs, 'readFileSync').mockImplementation((p, ...args) => {
+        if (typeof p === 'string' && p.includes('telemetry-id')) return '   \n';
+        return origRead(p, ...args);
+      });
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+      vi.spyOn(fs, 'writeFileSync').mockImplementation((p, data) => {
+        writeCalls.push({ path: p, data });
+      });
+
+      ({ getAnonymousId } = await freshImport());
+      const id = getAnonymousId();
+      expect(id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(writeCalls.length).toBe(1);
+      expect(writeCalls[0].data).toBe(id);
+
+      vi.restoreAllMocks();
+    });
+
     it('should read existing ID from file', async () => {
       const existingId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
       const origRead = fs.readFileSync;

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -11,7 +11,7 @@ import path from 'path';
 import { base58Encode, exportWallet, getWalletConfig, showWallet } from './wallet.js';
 import { signEd25519, base58Decode, parseAmount, getTokenInfo } from './transfer.js';
 import { signSolanaTransaction, resolveTokenAddress } from './trading.js';
-import { validateTokenAddress } from './api.js';
+import { validateTokenAddress, telemetryHeaders, packageVersion } from './api.js';
 import { getWalletConnectAddress, sendSolanaTransactionViaWalletConnect, signSolanaMessageViaWalletConnect } from './walletconnect-trading.js';
 import { retrievePassword } from './keychain.js';
 import { CHAIN_RPCS } from './rpc-urls.js';
@@ -88,8 +88,11 @@ async function loFetch(method, endpoint, { token, body, query } = {}) {
   }
 
   const headers = {
-    'Accept': 'application/json',
     'Content-Type': 'application/json',
+    'Accept': 'application/json',
+    'User-Agent': `nansen-cli/${packageVersion}`,
+    'X-Client-Type': 'nansen-cli',
+    ...telemetryHeaders(),
   };
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -61,10 +61,12 @@ const TELEMETRY_ID_FILE = path.join(
  */
 let _anonymousId;
 export function getAnonymousId() {
-  if (_anonymousId === undefined) {
+  if (!_anonymousId) {
     try {
-      _anonymousId = fs.readFileSync(TELEMETRY_ID_FILE, 'utf8').trim();
-    } catch {
+      const stored = fs.readFileSync(TELEMETRY_ID_FILE, 'utf8').trim();
+      if (stored) _anonymousId = stored;
+    } catch { /* missing or unreadable → generate below */ }
+    if (!_anonymousId) {
       _anonymousId = crypto.randomUUID();
       try {
         fs.mkdirSync(path.dirname(TELEMETRY_ID_FILE), { recursive: true });
@@ -194,6 +196,7 @@ export function trackCommandSucceeded({
     timestamp: new Date().toISOString(),
     path: commandToPath(command),
     properties: {
+      source: `nansen-cli/${cliVersion}`,
       latency: duration_ms / 1000,
       from_cache,
       flags,
@@ -232,6 +235,7 @@ export function trackCommandFailed({
     timestamp: new Date().toISOString(),
     path: commandToPath(command),
     properties: {
+      source: `nansen-cli/${cliVersion}`,
       latency: duration_ms / 1000,
       error_code,
       status,

--- a/src/trading.js
+++ b/src/trading.js
@@ -236,7 +236,14 @@ export async function getBridgeStatus(txHash, fromChain, toChain, { aggregator, 
   for (let attempt = 0; attempt <= retries; attempt++) {
     if (attempt > 0) await new Promise(r => setTimeout(r, retryDelayMs));
 
-    const res = await fetch(url.toString(), { headers: { 'Accept': 'application/json', 'User-Agent': CLIENT_USER_AGENT } });
+    const res = await fetch(url.toString(), {
+      headers: {
+        'Accept': 'application/json',
+        'User-Agent': CLIENT_USER_AGENT,
+        'X-Client-Type': 'nansen-cli',
+        ...telemetryHeaders(),
+      },
+    });
     const text = await res.text();
     let body;
     try {

--- a/src/trading.js
+++ b/src/trading.js
@@ -15,7 +15,7 @@ import { getWalletConnectAddress, sendTransactionViaWalletConnect, sendSolanaTra
 import { retrievePassword } from './keychain.js';
 import { validateQuoteInput, validateBalance, resolvePercentAmount, validateGasBalance } from './trade-validation.js';
 import { CHAIN_RPCS } from './rpc-urls.js';
-import { packageVersion, CommandError } from './api.js';
+import { packageVersion, CommandError, telemetryHeaders } from './api.js';
 
 // ============= Constants =============
 
@@ -121,7 +121,7 @@ export async function getQuote(params) {
     }
   }
 
-  const headers = { 'Accept': 'application/json', 'User-Agent': CLIENT_USER_AGENT };
+  const headers = { 'Accept': 'application/json', 'User-Agent': CLIENT_USER_AGENT, 'X-Client-Type': 'nansen-cli', ...telemetryHeaders() };
 
   const res = await fetch(url.toString(), { headers });
 
@@ -160,6 +160,8 @@ export async function executeTransaction(params, { retries = 2, retryDelayMs = 1
     'Content-Type': 'application/json',
     'Accept': 'application/json',
     'User-Agent': CLIENT_USER_AGENT,
+    'X-Client-Type': 'nansen-cli',
+    ...telemetryHeaders(),
   };
   let lastError;
   for (let attempt = 0; attempt <= retries; attempt++) {


### PR DESCRIPTION
## Summary
CLI trading events lack proper identification in the trading backend due to missing anonymous_id and CLI-specific headers.


## Changes
Here's what changed:

 ` src/telemetry.js `— `getAnonymousId() `guard changed from` === undefined` to `!_anonymousId`, and the file-read is separated from UUID-generation. This ensures `anonymous_id` is never
  null, undefined, or "" — whether the telemetry-id file is missing, unreadable, or empty. Both the telemetry events (trackCommandSucceeded/trackCommandFailed) and the API
  request header (X-Anonymous-Id via telemetryHeaders()) go through this same function.

  `src/__tests__/telemetry.test.js` — Added a test for the empty-file edge case that was previously unhandled.
  
 `src/trading.js`: Import: added `telemetryHeaders` to the existing `api.js` import
`getQuote` headers: added `X-Client-Type + ...telemetryHeaders() `(sends X-Anonymous-Id)
`executeTransaction` headers: same addition


## Checklist

- [ X] Tests pass (`npm test`)
- [ NA] `src/schema.json` updated if new commands or flags were added
- [ NA] `README.md` updated if new top-level commands or categories were added
- [ NA] Changeset added (`.changeset/`) — only required for user-facing changes (new commands, flags, bug fixes, breaking changes)
