### PR TITLE
docs: add output field documentation for sm/dex-trades and token/screener

### DIFF
--- a/src/schema.json
+++ b/src/schema.json
@@ -37,25 +37,77 @@
                 }
               },
               "output": {
-                "fields": {
-                  "block_timestamp": { "type": "string", "description": "ISO 8601 timestamp of the block containing the trade" },
-                  "chain": { "type": "string", "description": "Blockchain network (e.g. solana, ethereum)" },
-                  "token_bought_address": { "type": "string", "description": "Contract address of the token purchased" },
-                  "token_bought_age_days": { "type": "number", "description": "Age of the purchased token in days since first on-chain activity" },
-                  "token_bought_amount": { "type": "string", "description": "Amount of token purchased (raw units as string to preserve precision)" },
-                  "token_bought_fdv": { "type": "number", "description": "Fully diluted valuation of the purchased token in USD" },
-                  "token_bought_market_cap": { "type": "number", "description": "Circulating market cap of the purchased token in USD" },
-                  "token_bought_symbol": { "type": "string", "description": "Ticker symbol of the purchased token" },
-                  "token_sold_address": { "type": "string", "description": "Contract address of the token sold" },
-                  "token_sold_age_days": { "type": "number", "description": "Age of the sold token in days since first on-chain activity" },
-                  "token_sold_amount": { "type": "string", "description": "Amount of token sold (raw units as string to preserve precision)" },
-                  "token_sold_fdv": { "type": "number", "description": "Fully diluted valuation of the sold token in USD" },
-                  "token_sold_market_cap": { "type": "number", "description": "Circulating market cap of the sold token in USD" },
-                  "token_sold_symbol": { "type": "string", "description": "Ticker symbol of the sold token" },
-                  "trade_value_usd": { "type": "number", "description": "USD value of the trade at time of execution" },
-                  "trader_address": { "type": "string", "description": "On-chain address of the trader" },
-                  "trader_address_label": { "type": "string", "description": "Human-readable Nansen label for the trader address, if available" },
-                  "transaction_hash": { "type": "string", "description": "Transaction hash identifying this trade on-chain" }
+                "block_timestamp": {
+                  "type": "string",
+                  "description": "ISO 8601 timestamp of the block containing the trade"
+                },
+                "chain": {
+                  "type": "string",
+                  "description": "Blockchain network (e.g. solana, ethereum)"
+                },
+                "token_bought_address": {
+                  "type": "string",
+                  "description": "Contract address of the token purchased"
+                },
+                "token_bought_age_days": {
+                  "type": "number",
+                  "description": "Age of the purchased token in days since first on-chain activity"
+                },
+                "token_bought_amount": {
+                  "type": "number",
+                  "description": "Amount of token purchased in human-readable units"
+                },
+                "token_bought_fdv": {
+                  "type": "number",
+                  "description": "Fully diluted valuation of the purchased token in USD"
+                },
+                "token_bought_market_cap": {
+                  "type": "number",
+                  "description": "Circulating market cap of the purchased token in USD"
+                },
+                "token_bought_symbol": {
+                  "type": "string",
+                  "description": "Ticker symbol of the purchased token"
+                },
+                "token_sold_address": {
+                  "type": "string",
+                  "description": "Contract address of the token sold"
+                },
+                "token_sold_age_days": {
+                  "type": "number",
+                  "description": "Age of the sold token in days since first on-chain activity"
+                },
+                "token_sold_amount": {
+                  "type": "number",
+                  "description": "Amount of token sold in human-readable units"
+                },
+                "token_sold_fdv": {
+                  "type": "number",
+                  "description": "Fully diluted valuation of the sold token in USD"
+                },
+                "token_sold_market_cap": {
+                  "type": "number",
+                  "description": "Circulating market cap of the sold token in USD"
+                },
+                "token_sold_symbol": {
+                  "type": "string",
+                  "description": "Ticker symbol of the sold token"
+                },
+                "trade_value_usd": {
+                  "type": "number",
+                  "description": "USD value of the trade at time of execution"
+                },
+                "trader_address": {
+                  "type": "string",
+                  "description": "On-chain address of the trader"
+                },
+                "trader_address_label": {
+                  "type": "string",
+                  "description": "Nansen label for the trader address, if available"
+                },
+                "transaction_hash": {
+                  "type": "string",
+                  "description": "Transaction hash identifying this trade on-chain"
                 }
               }
             },
@@ -523,23 +575,69 @@
                 }
               },
               "output": {
-                "fields": {
-                  "buy_volume": { "type": "number", "description": "Total buy-side volume in USD over the selected timeframe" },
-                  "chain": { "type": "string", "description": "Blockchain network the token is deployed on" },
-                  "fdv": { "type": "number", "description": "Fully diluted valuation of the token in USD" },
-                  "fdv_mc_ratio": { "type": "number", "description": "Ratio of fully diluted valuation to circulating market cap" },
-                  "inflow_fdv_ratio": { "type": "number", "description": "Smart-money net inflow divided by FDV; measures buying pressure relative to size" },
-                  "liquidity": { "type": "number", "description": "Total on-chain liquidity (DEX pool depth) in USD" },
-                  "market_cap_usd": { "type": "number", "description": "Circulating market cap of the token in USD" },
-                  "netflow": { "type": "number", "description": "Net smart-money flow (inflow minus outflow) in USD over the selected timeframe" },
-                  "outflow_fdv_ratio": { "type": "number", "description": "Smart-money net outflow divided by FDV; measures selling pressure relative to size" },
-                  "price_change": { "type": "number", "description": "Percentage price change over the selected timeframe" },
-                  "price_usd": { "type": "number", "description": "Current token price in USD" },
-                  "sell_volume": { "type": "number", "description": "Total sell-side volume in USD over the selected timeframe" },
-                  "token_address": { "type": "string", "description": "On-chain contract address of the token" },
-                  "token_age_days": { "type": "number", "description": "Age of the token in days since first on-chain activity" },
-                  "token_symbol": { "type": "string", "description": "Ticker symbol of the token" },
-                  "volume": { "type": "number", "description": "Total trading volume (buy + sell) in USD over the selected timeframe" }
+                "buy_volume": {
+                  "type": "number",
+                  "description": "Total buy-side volume in USD over the selected timeframe"
+                },
+                "chain": {
+                  "type": "string",
+                  "description": "Blockchain network the token is deployed on"
+                },
+                "fdv": {
+                  "type": "number",
+                  "description": "Fully diluted valuation of the token in USD"
+                },
+                "fdv_mc_ratio": {
+                  "type": "number",
+                  "description": "Ratio of fully diluted valuation to circulating market cap"
+                },
+                "inflow_fdv_ratio": {
+                  "type": "number",
+                  "description": "Net inflow divided by FDV; measures buying pressure relative to token size"
+                },
+                "liquidity": {
+                  "type": "number",
+                  "description": "Total on-chain liquidity (DEX pool depth) in USD"
+                },
+                "market_cap_usd": {
+                  "type": "number",
+                  "description": "Circulating market cap of the token in USD"
+                },
+                "netflow": {
+                  "type": "number",
+                  "description": "Net flow (inflow minus outflow) in USD over the selected timeframe"
+                },
+                "outflow_fdv_ratio": {
+                  "type": "number",
+                  "description": "Net outflow divided by FDV; measures selling pressure relative to token size"
+                },
+                "price_change": {
+                  "type": "number",
+                  "description": "Fractional price change over the selected timeframe (e.g. 0.05 = 5%)"
+                },
+                "price_usd": {
+                  "type": "number",
+                  "description": "Current token price in USD"
+                },
+                "sell_volume": {
+                  "type": "number",
+                  "description": "Total sell-side volume in USD over the selected timeframe"
+                },
+                "token_address": {
+                  "type": "string",
+                  "description": "On-chain contract address of the token"
+                },
+                "token_age_days": {
+                  "type": "number",
+                  "description": "Age of the token in days since first on-chain activity"
+                },
+                "token_symbol": {
+                  "type": "string",
+                  "description": "Ticker symbol of the token"
+                },
+                "volume": {
+                  "type": "number",
+                  "description": "Total trading volume (buy + sell) in USD over the selected timeframe"
                 }
               }
             },
@@ -549,7 +647,11 @@
               "options": {
                 "market-cap": {
                   "description": "Filter by market cap group",
-                  "enum": ["lowcap", "midcap", "largecap"]
+                  "enum": [
+                    "lowcap",
+                    "midcap",
+                    "largecap"
+                  ]
                 },
                 "limit": {
                   "default": 25
@@ -643,8 +745,12 @@
               "endpoint": "/api/v1/prediction-market/market-screener",
               "description": "Get Prediction Market Screener",
               "options": {
-                "query": { "default": "" },
-                "sort-by": { "description": "Deprecated: use --sort field:dir instead" },
+                "query": {
+                  "default": ""
+                },
+                "sort-by": {
+                  "description": "Deprecated: use --sort field:dir instead"
+                },
                 "tags": {},
                 "min-liquidity": {},
                 "max-liquidity": {},
@@ -665,8 +771,12 @@
               "endpoint": "/api/v1/prediction-market/event-screener",
               "description": "Get Prediction Market Event Screener",
               "options": {
-                "query": { "default": "" },
-                "sort-by": { "description": "Deprecated: use --sort field:dir instead" },
+                "query": {
+                  "default": ""
+                },
+                "sort-by": {
+                  "description": "Deprecated: use --sort field:dir instead"
+                },
                 "tags": {},
                 "min-liquidity": {},
                 "max-liquidity": {},
@@ -894,7 +1004,7 @@
             },
             "to-chain": {
               "type": "string",
-              "description": "Destination blockchain for cross-chain swap (solana or base). Omit for same-chain. At least one side must be USDC or a native token (ETH, SOL). Non-native to non-native is not supported — swap to USDC first, then bridge. Bridge providers (Li.Fi or Relay) are selected automatically based on best price. Sub-dollar swaps are supported via Relay."
+              "description": "Destination blockchain for cross-chain swap (solana or base). Omit for same-chain. At least one side must be USDC or a native token (ETH, SOL). Non-native to non-native is not supported \u2014 swap to USDC first, then bridge. Bridge providers (Li.Fi or Relay) are selected automatically based on best price. Sub-dollar swaps are supported via Relay."
             },
             "from": {
               "type": "string",
@@ -970,7 +1080,7 @@
             },
             "aggregator": {
               "type": "string",
-              "description": "lifi or relay. Overrides auto-detection — use when polling from a different machine or after the 30-day local record TTL has expired."
+              "description": "lifi or relay. Overrides auto-detection \u2014 use when polling from a different machine or after the 30-day local record TTL has expired."
             }
           }
         },
@@ -1024,7 +1134,9 @@
                   "description": "Wallet name (or \"walletconnect\"/\"wc\")"
                 }
               },
-              "chains": ["solana"],
+              "chains": [
+                "solana"
+              ],
               "prerequisites": [
                 "A Solana wallet must be configured. Run: nansen wallet create"
               ]
@@ -1064,7 +1176,9 @@
                   "description": "Wallet name (or \"walletconnect\"/\"wc\")"
                 }
               },
-              "chains": ["solana"]
+              "chains": [
+                "solana"
+              ]
             },
             "cancel": {
               "description": "Cancel an open limit order",
@@ -1079,7 +1193,9 @@
                   "description": "Wallet name (or \"walletconnect\"/\"wc\")"
                 }
               },
-              "chains": ["solana"]
+              "chains": [
+                "solana"
+              ]
             },
             "update": {
               "description": "Update trigger price or slippage on an existing order",
@@ -1102,7 +1218,9 @@
                   "description": "Wallet name (or \"walletconnect\"/\"wc\")"
                 }
               },
-              "chains": ["solana"]
+              "chains": [
+                "solana"
+              ]
             }
           }
         }

--- a/src/schema.json
+++ b/src/schema.json
@@ -647,11 +647,7 @@
               "options": {
                 "market-cap": {
                   "description": "Filter by market cap group",
-                  "enum": [
-                    "lowcap",
-                    "midcap",
-                    "largecap"
-                  ]
+                  "enum": ["lowcap", "midcap", "largecap"]
                 },
                 "limit": {
                   "default": 25
@@ -745,12 +741,8 @@
               "endpoint": "/api/v1/prediction-market/market-screener",
               "description": "Get Prediction Market Screener",
               "options": {
-                "query": {
-                  "default": ""
-                },
-                "sort-by": {
-                  "description": "Deprecated: use --sort field:dir instead"
-                },
+                "query": { "default": "" },
+                "sort-by": { "description": "Deprecated: use --sort field:dir instead" },
                 "tags": {},
                 "min-liquidity": {},
                 "max-liquidity": {},
@@ -771,12 +763,8 @@
               "endpoint": "/api/v1/prediction-market/event-screener",
               "description": "Get Prediction Market Event Screener",
               "options": {
-                "query": {
-                  "default": ""
-                },
-                "sort-by": {
-                  "description": "Deprecated: use --sort field:dir instead"
-                },
+                "query": { "default": "" },
+                "sort-by": { "description": "Deprecated: use --sort field:dir instead" },
                 "tags": {},
                 "min-liquidity": {},
                 "max-liquidity": {},
@@ -853,7 +841,7 @@
       }
     },
     "alerts": {
-      "description": "Smart alert management \u2014 create, update, toggle, delete alerts",
+      "description": "Smart alert management — create, update, toggle, delete alerts",
       "subcommands": {
         "list": {
           "description": "List all alerts",
@@ -1004,7 +992,7 @@
             },
             "to-chain": {
               "type": "string",
-              "description": "Destination blockchain for cross-chain swap (solana or base). Omit for same-chain. At least one side must be USDC or a native token (ETH, SOL). Non-native to non-native is not supported \u2014 swap to USDC first, then bridge. Bridge providers (Li.Fi or Relay) are selected automatically based on best price. Sub-dollar swaps are supported via Relay."
+              "description": "Destination blockchain for cross-chain swap (solana or base). Omit for same-chain. At least one side must be USDC or a native token (ETH, SOL). Non-native to non-native is not supported — swap to USDC first, then bridge. Bridge providers (Li.Fi or Relay) are selected automatically based on best price. Sub-dollar swaps are supported via Relay."
             },
             "from": {
               "type": "string",
@@ -1027,7 +1015,7 @@
             },
             "wallet": {
               "type": "string",
-              "description": "Wallet name (or \"walletconnect\"/\"wc\" for WalletConnect, EVM only). A configured wallet is required \u2014 run `nansen wallet create` if you haven't set one up yet."
+              "description": "Wallet name (or \"walletconnect\"/\"wc\" for WalletConnect, EVM only). A configured wallet is required — run `nansen wallet create` if you haven't set one up yet."
             },
             "to-wallet": {
               "type": "string",
@@ -1080,7 +1068,7 @@
             },
             "aggregator": {
               "type": "string",
-              "description": "lifi or relay. Overrides auto-detection \u2014 use when polling from a different machine or after the 30-day local record TTL has expired."
+              "description": "lifi or relay. Overrides auto-detection — use when polling from a different machine or after the 30-day local record TTL has expired."
             }
           }
         },
@@ -1134,9 +1122,7 @@
                   "description": "Wallet name (or \"walletconnect\"/\"wc\")"
                 }
               },
-              "chains": [
-                "solana"
-              ],
+              "chains": ["solana"],
               "prerequisites": [
                 "A Solana wallet must be configured. Run: nansen wallet create"
               ]
@@ -1176,9 +1162,7 @@
                   "description": "Wallet name (or \"walletconnect\"/\"wc\")"
                 }
               },
-              "chains": [
-                "solana"
-              ]
+              "chains": ["solana"]
             },
             "cancel": {
               "description": "Cancel an open limit order",
@@ -1193,9 +1177,7 @@
                   "description": "Wallet name (or \"walletconnect\"/\"wc\")"
                 }
               },
-              "chains": [
-                "solana"
-              ]
+              "chains": ["solana"]
             },
             "update": {
               "description": "Update trigger price or slippage on an existing order",
@@ -1218,9 +1200,7 @@
                   "description": "Wallet name (or \"walletconnect\"/\"wc\")"
                 }
               },
-              "chains": [
-                "solana"
-              ]
+              "chains": ["solana"]
             }
           }
         }
@@ -1312,7 +1292,7 @@
       }
     },
     "agent": {
-      "description": "Nansen AI research agent \u2014 ask questions about wallets, tokens, and on-chain activity",
+      "description": "Nansen AI research agent — ask questions about wallets, tokens, and on-chain activity",
       "options": {
         "expert": {
           "type": "boolean",

--- a/src/schema.json
+++ b/src/schema.json
@@ -35,6 +35,28 @@
                 "chain": {
                   "default": "solana"
                 }
+              },
+              "output": {
+                "fields": {
+                  "block_timestamp": { "type": "string", "description": "ISO 8601 timestamp of the block containing the trade" },
+                  "chain": { "type": "string", "description": "Blockchain network (e.g. solana, ethereum)" },
+                  "token_bought_address": { "type": "string", "description": "Contract address of the token purchased" },
+                  "token_bought_age_days": { "type": "number", "description": "Age of the purchased token in days since first on-chain activity" },
+                  "token_bought_amount": { "type": "string", "description": "Amount of token purchased (raw units as string to preserve precision)" },
+                  "token_bought_fdv": { "type": "number", "description": "Fully diluted valuation of the purchased token in USD" },
+                  "token_bought_market_cap": { "type": "number", "description": "Circulating market cap of the purchased token in USD" },
+                  "token_bought_symbol": { "type": "string", "description": "Ticker symbol of the purchased token" },
+                  "token_sold_address": { "type": "string", "description": "Contract address of the token sold" },
+                  "token_sold_age_days": { "type": "number", "description": "Age of the sold token in days since first on-chain activity" },
+                  "token_sold_amount": { "type": "string", "description": "Amount of token sold (raw units as string to preserve precision)" },
+                  "token_sold_fdv": { "type": "number", "description": "Fully diluted valuation of the sold token in USD" },
+                  "token_sold_market_cap": { "type": "number", "description": "Circulating market cap of the sold token in USD" },
+                  "token_sold_symbol": { "type": "string", "description": "Ticker symbol of the sold token" },
+                  "trade_value_usd": { "type": "number", "description": "USD value of the trade at time of execution" },
+                  "trader_address": { "type": "string", "description": "On-chain address of the trader" },
+                  "trader_address_label": { "type": "string", "description": "Human-readable Nansen label for the trader address, if available" },
+                  "transaction_hash": { "type": "string", "description": "Transaction hash identifying this trade on-chain" }
+                }
               }
             },
             "perp-trades": {
@@ -498,6 +520,26 @@
                 "include-stablecoins": {
                   "description": "Whether to include stablecoins in screener results (default true on API side)",
                   "default": true
+                }
+              },
+              "output": {
+                "fields": {
+                  "buy_volume": { "type": "number", "description": "Total buy-side volume in USD over the selected timeframe" },
+                  "chain": { "type": "string", "description": "Blockchain network the token is deployed on" },
+                  "fdv": { "type": "number", "description": "Fully diluted valuation of the token in USD" },
+                  "fdv_mc_ratio": { "type": "number", "description": "Ratio of fully diluted valuation to circulating market cap" },
+                  "inflow_fdv_ratio": { "type": "number", "description": "Smart-money net inflow divided by FDV; measures buying pressure relative to size" },
+                  "liquidity": { "type": "number", "description": "Total on-chain liquidity (DEX pool depth) in USD" },
+                  "market_cap_usd": { "type": "number", "description": "Circulating market cap of the token in USD" },
+                  "netflow": { "type": "number", "description": "Net smart-money flow (inflow minus outflow) in USD over the selected timeframe" },
+                  "outflow_fdv_ratio": { "type": "number", "description": "Smart-money net outflow divided by FDV; measures selling pressure relative to size" },
+                  "price_change": { "type": "number", "description": "Percentage price change over the selected timeframe" },
+                  "price_usd": { "type": "number", "description": "Current token price in USD" },
+                  "sell_volume": { "type": "number", "description": "Total sell-side volume in USD over the selected timeframe" },
+                  "token_address": { "type": "string", "description": "On-chain contract address of the token" },
+                  "token_age_days": { "type": "number", "description": "Age of the token in days since first on-chain activity" },
+                  "token_symbol": { "type": "string", "description": "Ticker symbol of the token" },
+                  "volume": { "type": "number", "description": "Total trading volume (buy + sell) in USD over the selected timeframe" }
                 }
               }
             },


### PR DESCRIPTION
## Summary

Documents the undocumented API response fields for two commands that were silently returning extra fields with no schema coverage.

Output fields follow the same flat `{ "type", "description" }` pattern used by `options` and `globalOptions` entries throughout schema.json.

### Changes

Added `output` blocks to `src/schema.json` for:

**`research smart-money dex-trades`** — 18 fields:
`block_timestamp`, `chain`, `trader_address`, `trader_address_label`, `transaction_hash`, `token_bought_address`, `token_bought_symbol`, `token_bought_amount`, `token_bought_fdv`, `token_bought_market_cap`, `token_bought_age_days`, `token_sold_address`, `token_sold_symbol`, `token_sold_amount`, `token_sold_fdv`, `token_sold_market_cap`, `token_sold_age_days`, `trade_value_usd`

**`research token screener`** — 16 fields:
`token_address`, `token_symbol`, `chain`, `price_usd`, `price_change`, `buy_volume`, `sell_volume`, `volume`, `market_cap_usd`, `fdv`, `fdv_mc_ratio`, `liquidity`, `netflow`, `inflow_fdv_ratio`, `outflow_fdv_ratio`, `token_age_days`

### Fixes applied after initial review
- Removed nested `fields` wrapper — output is now a flat map matching existing schema patterns
- `token_bought_amount` / `token_sold_amount`: type `string` → `number` (API returns float, not raw base units)
- `price_change`: description clarified as decimal fraction (e.g. 0.05 = 5%), not percentage
- `inflow_fdv_ratio` / `outflow_fdv_ratio`: removed unsupported smart-money qualifier

### Testing
- JSON valid: confirmed
- Lint: clean
- Tests: 1429 passed across 25 files

### Constraints
- Only `src/schema.json` modified
- No existing schema entries changed — additions only