### PR TITLE
Fix backend quote ID on trade execute

### DIFF
--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -2539,6 +2539,7 @@ describe('Relay aggregator: --gasless flag dispatch', () => {
 
     const quoteId = saveQuote({
       success: true,
+      metadata: { quoteId: 'backend-relay-quote-id' },
       quotes: [{
         aggregator: 'relay',
         inputMint: '11111111111111111111111111111111',
@@ -2567,6 +2568,7 @@ describe('Relay aggregator: --gasless flag dispatch', () => {
     expect(body.requestId).toBe('relay-req-gas');
     expect(body.steps).toEqual([{ kind: 'transaction', items: [{ data: 'opaque-step-blob' }] }]);
     expect(body.simulate).toBe(false); // gasless skips simulation
+    expect(body.quoteId).toBe('backend-relay-quote-id');
 
     delete process.env.NANSEN_WALLET_PASSWORD;
     vi.unstubAllGlobals();
@@ -2833,6 +2835,7 @@ describe('Relay aggregator: EVM execute forwards requestId', () => {
 
     const quoteId = saveQuote({
       success: true,
+      metadata: { quoteId: 'backend-relay-quote-id' },
       quotes: [{
         aggregator: 'relay',
         inputMint: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913', // USDC
@@ -2855,6 +2858,7 @@ describe('Relay aggregator: EVM execute forwards requestId', () => {
     expect(executeBodies[0].requestId).toBeUndefined();
     expect(executeBodies[0].aggregator).toBeUndefined();
     expect(executeBodies[0].gasless).toBeUndefined();
+    expect(executeBodies[0].quoteId).toBe('backend-relay-quote-id');
 
     delete process.env.NANSEN_WALLET_PASSWORD;
     vi.unstubAllGlobals();
@@ -3068,13 +3072,14 @@ describe('Relay aggregator: Solana non-gasless omits requestId', () => {
 
     const quoteId = saveQuote({
       success: true,
+      metadata: { quoteId: 'backend-jupiter-quote-id' },
       quotes: [{
         aggregator: 'jupiter',
         inputMint: 'So11111111111111111111111111111111111111112',
         outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
         inAmount: '1000000000', outAmount: '50000000',
         transaction: txBase64,
-        metadata: { requestId: 'jupiter-ultra-req' },
+        metadata: { requestId: 'jupiter-ultra-req', quoteId: 'aggregator-jupiter-quote-id' },
       }],
     }, 'solana');
 
@@ -3084,6 +3089,51 @@ describe('Relay aggregator: Solana non-gasless omits requestId', () => {
     expect(executeBodies.length).toBeGreaterThanOrEqual(1);
     expect(executeBodies[0].requestId).toBe('jupiter-ultra-req'); // Jupiter Ultra still needs it
     expect(executeBodies[0].aggregator).toBeUndefined();
+    expect(executeBodies[0].quoteId).toBe('backend-jupiter-quote-id');
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back to aggregator metadata quoteId when saved response metadata is missing', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(JSON.parse(opts.body));
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Success', signature: 'SolSig', chainType: 'solana', broadcaster: 'jupiter' })),
+        });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null })) });
+    }));
+
+    const sigCount = Buffer.from([0x01]);
+    const emptySig = Buffer.alloc(64);
+    const message = Buffer.from([0x01, 0x00, 0x01, 0x02, ...Buffer.alloc(32), ...Buffer.alloc(32), ...Buffer.alloc(32), 0x01, 0x01, 0x01, 0x00, 0x04, 0x02, 0x00, 0x00, 0x00]);
+    const txBase64 = Buffer.concat([sigCount, emptySig, message]).toString('base64');
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'jupiter',
+        inputMint: 'So11111111111111111111111111111111111111112',
+        outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        inAmount: '1000000000', outAmount: '50000000',
+        transaction: txBase64,
+        metadata: { requestId: 'jupiter-ultra-req', quoteId: 'aggregator-jupiter-quote-id' },
+      }],
+    }, 'solana');
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    try { await cmds.execute([], null, {}, { quote: quoteId }); } catch { /* ok */ }
+
+    expect(executeBodies.length).toBeGreaterThanOrEqual(1);
+    expect(executeBodies[0].quoteId).toBe('aggregator-jupiter-quote-id');
 
     delete process.env.NANSEN_WALLET_PASSWORD;
     vi.unstubAllGlobals();

--- a/src/trading.js
+++ b/src/trading.js
@@ -159,6 +159,7 @@ export async function getQuote(params) {
  * @param {object} params
  * @param {string} params.signedTransaction - Base64 (Solana) or 0x hex (EVM)
  * @param {string} [params.chain] - Target chain name
+ * @param {string} [params.quoteId] - Backend quote ID for BI correlation
  * @param {string} [params.requestId] - Optional Jupiter request ID (Solana only)
  * @param {boolean} [params.simulate] - Run pre-broadcast simulation
  * @returns {Promise<object>} Execution result
@@ -2018,16 +2019,19 @@ EXAMPLES:
               simulate: !noSimulate && !gasless,
             };
 
-            // Include backend quoteId if available for better BI tracking
-            if (currentQuote.metadata?.quoteId) {
-              execParams.quoteId = currentQuote.metadata.quoteId;
+            // Prefer the backend quote id saved from /quote; per-aggregator ids can
+            // appear on individual quote metadata and are only a fallback.
+            const backendQuoteId =
+              quoteData.response?.metadata?.quoteId ?? currentQuote.metadata?.quoteId;
+            if (backendQuoteId) {
+              execParams.quoteId = backendQuoteId;
             }
             // The backend's /execute schema is strict; sending fields it doesn't expect
             // for the (chain × aggregator × gasless) combination causes 502s or
             // "Unrecognized keys" rejections. The matrix we've validated against the
             // live backend:
-            //   - EVM signed (any aggregator): no extra fields. requestId/aggregator
-            //     trigger schema errors.
+            //   - EVM signed (any aggregator): no aggregator/requestId fields.
+            //     Those trigger schema errors.
             //   - Solana signed (Jupiter/OKX): include requestId for Jupiter Ultra
             //     intent resolution.
             //   - Solana signed (Relay): omit requestId — backend tries to look it up


### PR DESCRIPTION
## Summary

- Prefer the saved backend quote id from quote response metadata when sending trade execute requests.
- Keep aggregator quote metadata as a fallback for older or partial quote payloads.
- Add execute request assertions for gasless, EVM Relay, backend-id precedence, and fallback behavior.

## Checklist

- [x] Tests pass (`npm test`)
- [x] `src/schema.json` updated if new commands or flags were added
- [x] `README.md` updated if new top-level commands or categories were added
- [ ] Changeset added (`.changeset/`) — only required for user-facing changes (new commands, flags, bug fixes, breaking changes)

Notes: targeted tests passed with `npm test -- src/__tests__/trading.test.js`, and `npm run lint` passed. No schema, README, or changeset update was needed for this correction.

Made with [Cursor](https://cursor.com)