### PR TITLE
Fix sync-clawhub workflow permissions and secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
   sync-clawhub:
     needs: publish
     if: needs.publish.outputs.published == 'true'
+    permissions:
+      contents: read
     uses: ./.github/workflows/sync-clawhub.yml
     secrets:
       CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}

--- a/.github/workflows/sync-clawhub.yml
+++ b/.github/workflows/sync-clawhub.yml
@@ -1,7 +1,10 @@
 name: Sync Skills to ClawHub
 
 on:
-  workflow_call: # called from ci.yml publish job after successful npm publish
+  workflow_call:
+    secrets:
+      CLAWHUB_TOKEN:
+        required: true
   workflow_dispatch: # manual trigger if ever needed
 
 jobs:


### PR DESCRIPTION
## Summary
Follow-up to #435 — fixes two issues with the CI hardening:

- Declare `CLAWHUB_TOKEN` as a required secret input on the reusable `sync-clawhub.yml` workflow
- Grant `contents: read` to the caller job so the nested workflow is allowed to check out the repo

## Test plan
- [ ] CI passes (lint + test)
- [ ] Verify sync-clawhub job runs successfully on next publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)