### PR TITLE
fix(research): warn when unsupported --sort or --page/--limit flags are passed

### DIFF
--- a/.changeset/research-warn-unsupported-flags.md
+++ b/.changeset/research-warn-unsupported-flags.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Warn to stderr when --page/--limit is passed to historical-token-flow-summary or --sort is passed to historical-smart-money-balances, since those endpoints silently ignore those flags.

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -315,6 +315,20 @@ describe('buildResearchCommands handler', () => {
     expect(mockApi.researchTokenFlowSummary).toHaveBeenCalled();
   });
 
+  it('warns to stderr when --page/--limit is passed to historical-token-flow-summary', async () => {
+    mockApi = makeMockApi();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => {});
+    try {
+      await cmds.research(['historical-token-flow-summary'], mockApi, {}, {
+        'token-address': TOKENS.solana, 'from-date': FROM, 'to-date': TO, page: 2, limit: 5,
+      });
+      const warned = stderrSpy.mock.calls.some(([msg]) => msg.includes('--page/--limit') && msg.includes('historical-token-flow-summary'));
+      expect(warned).toBe(true);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
   it('dispatches historical-token-quant-scores with --as-of-date', async () => {
     mockApi = makeMockApi();
     await cmds.research(['historical-token-quant-scores'], mockApi, {}, {
@@ -354,6 +368,20 @@ describe('buildResearchCommands handler', () => {
       chains: ['solana', 'ethereum'],
       asOfDate: AS_OF,
     }));
+  });
+
+  it('warns to stderr when --sort is passed to historical-smart-money-balances', async () => {
+    mockApi = makeMockApi();
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => {});
+    try {
+      await cmds.research(['historical-smart-money-balances'], mockApi, {}, {
+        'as-of-date': AS_OF, sort: 'value_usd:desc',
+      });
+      const warned = stderrSpy.mock.calls.some(([msg]) => msg.includes('--sort') && msg.includes('historical-smart-money-balances'));
+      expect(warned).toBe(true);
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 
   it('dispatches historical-token-screener with --timeframe-days and --to-date', async () => {

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -196,11 +196,16 @@ export function buildResearchCommands(deps = {}) {
           chain: options.chain,
           fromDate, toDate, filters, orderBy, pagination,
         }),
-        'historical-token-flow-summary': () => apiInstance.researchTokenFlowSummary({
-          tokenAddress: options['token-address'] || options.token,
-          chain: options.chain,
-          fromDate, toDate, filters, orderBy,
-        }),
+        'historical-token-flow-summary': () => {
+          if (pagination) {
+            process.stderr.write('⚠️  warning: --page/--limit is ignored by historical-token-flow-summary (endpoint does not support pagination)\n');
+          }
+          return apiInstance.researchTokenFlowSummary({
+            tokenAddress: options['token-address'] || options.token,
+            chain: options.chain,
+            fromDate, toDate, filters, orderBy,
+          });
+        },
         'historical-who-bought-sold': () => apiInstance.researchWhoBoughtSold({
           tokenAddress: options['token-address'] || options.token,
           chain: options.chain,
@@ -240,6 +245,9 @@ export function buildResearchCommands(deps = {}) {
       }
 
       if (sub === 'historical-smart-money-balances') {
+        if (options.sort || options['order-by']) {
+          process.stderr.write('⚠️  warning: --sort is ignored by historical-smart-money-balances (endpoint does not support order_by)\n');
+        }
         requireOptions({ 'as-of-date': asOfDate }, ['as-of-date']);
         return apiInstance.researchSmartMoneyBalances({
           chains: parseChains(options),


### PR DESCRIPTION
## Summary

Two \`nansen research historical-*\` subcommands silently ignored flags without any feedback to the caller:

- **\`historical-token-flow-summary\`** accepted \`--page\`/\`--limit\` in its CLI options but the handler never forwarded them to the API. Callers had no indication their pagination flags were being dropped.
- **\`historical-smart-money-balances\`** accepted \`--sort\` in its CLI options but the handler never forwarded it to the API. Callers had no indication their sort flag was being dropped.

## Fix

Added \`process.stderr.write()\` warnings (matching the existing \`⚠️\` pattern used elsewhere in the codebase) that fire when the unsupported flag is detected:

- \`historical-token-flow-summary\` + \`--page\`/\`--limit\` → warns: \`⚠️  warning: --page/--limit is ignored by historical-token-flow-summary (endpoint does not support pagination)\`
- \`historical-smart-money-balances\` + \`--sort\` → warns: \`⚠️  warning: --sort is ignored by historical-smart-money-balances (endpoint does not support order_by)\`

Warnings go to stderr so they don't pollute JSON stdout output. The API call still succeeds — callers get data, plus a clear signal that the flag had no effect.

## Tests

Added two regression tests in \`src/__tests__/research.test.js\`:

1. Calls \`historical-token-flow-summary\` with \`--page 2 --limit 5\` and asserts a matching warning was written to stderr.
2. Calls \`historical-smart-money-balances\` with \`--sort value_usd:desc\` and asserts a matching warning was written to stderr.

Both new tests pass alongside all 1475 existing tests (2 pre-existing skips unchanged).

## Affected flag combinations

| Subcommand | Silently ignored flag | Now warns |
|---|---|---|
| \`historical-token-flow-summary\` | \`--page\`, \`--limit\` | ✓ |
| \`historical-smart-money-balances\` | \`--sort\`, \`--order-by\` | ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)