### PR TITLE
feat(trade): bypass gas check for high-value trades eligible for gasless routing

### DIFF
--- a/.changeset/gasless-high-value-bypass.md
+++ b/.changeset/gasless-high-value-bypass.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Skip native gas pre-check for trades >= $10 USD, where gasless/solver-paid routes (e.g. Relay) are viable. When gas is insufficient on smaller trades, the error now also suggests increasing the trade value as an alternative to topping up gas.

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { validateQuoteInput, fetchNativeBalance, fetchTokenBalance, validateBalance, resolvePercentAmount, validateGasBalance } from '../trade-validation.js';
+import { validateQuoteInput, fetchNativeBalance, fetchTokenBalance, validateBalance, resolvePercentAmount, validateGasBalance, GASLESS_MIN_TRADE_USD } from '../trade-validation.js';
 
 describe('validateQuoteInput', () => {
   const validSolana = {
@@ -872,6 +872,57 @@ describe('validateGasBalance', () => {
 
     const result = await validateGasBalance({ chain: 'solana', walletAddress: 'SomeWallet1111111111111111111111111111111111' });
     expect(result.hasSufficientNative).toBe(true);
+  });
+
+  it('bypasses gas check when trade value is >= GASLESS_MIN_TRADE_USD (gasless eligible)', async () => {
+    // fetch should NOT be called — the check is skipped before any RPC
+    global.fetch = vi.fn();
+
+    const result = await validateGasBalance({
+      chain: 'solana',
+      walletAddress: 'SomeWallet1111111111111111111111111111111111',
+      tradeValueUsd: String(GASLESS_MIN_TRADE_USD),
+    });
+    expect(result.hasSufficientNative).toBe(true);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('bypasses gas check when trade value is well above $10', async () => {
+    global.fetch = vi.fn();
+
+    const result = await validateGasBalance({
+      chain: 'base',
+      walletAddress: '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4',
+      tradeValueUsd: '500',
+    });
+    expect(result.hasSufficientNative).toBe(true);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('still validates gas for trades below GASLESS_MIN_TRADE_USD', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ jsonrpc: '2.0', id: 1, result: { value: 0 } }),
+    });
+
+    await expect(validateGasBalance({
+      chain: 'solana',
+      walletAddress: 'SomeWallet1111111111111111111111111111111111',
+      tradeValueUsd: String(GASLESS_MIN_TRADE_USD - 0.01),
+    })).rejects.toThrow(/Insufficient SOL for gas/);
+  });
+
+  it('error message includes gasless suggestion when gas is low', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ jsonrpc: '2.0', id: 1, result: { value: 0 } }),
+    });
+
+    await expect(validateGasBalance({
+      chain: 'solana',
+      walletAddress: 'SomeWallet1111111111111111111111111111111111',
+      tradeValueUsd: '5.00',
+    })).rejects.toThrow(new RegExp(`\\$${GASLESS_MIN_TRADE_USD}\\+`));
   });
 });
 

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -136,6 +136,10 @@ const FEE_BUFFER = { solana: 0.005, base: 0.00004 };
 const HIGH_PERCENTAGE_THRESHOLD = 95;
 const AUTO_ADJUST_THRESHOLD_PERCENT = 2;
 
+// Trades at or above this USD value can use gasless/solver-paid routes (e.g. Relay),
+// so the native gas pre-check is skipped for them.
+export const GASLESS_MIN_TRADE_USD = 10;
+
 /**
  * Check if an address is USDC or the native token for a chain (case-insensitive for EVM).
  */
@@ -306,11 +310,18 @@ export async function resolvePercentAmount({ chain, from, walletAddress, percent
  *
  * Returns { hasSufficientNative } or throws on validation failure.
  * Best-effort: if RPC fails, returns passing result.
+ *
+ * Gasless bypass: trades >= $10 USD can use solver-paid options (e.g. Relay),
+ * so the gas check is skipped in that case.
  */
-export async function validateGasBalance({ chain, walletAddress }) {
+export async function validateGasBalance({ chain, walletAddress, tradeValueUsd }) {
   const normalizedChain = chain.toLowerCase();
   const minGas = MIN_GAS_AMOUNTS[normalizedChain];
   if (minGas === undefined) return { hasSufficientNative: true };
+
+  // High-value trades can use gasless/solver-paid routes — skip the check.
+  const tradeUsd = parseFloat(tradeValueUsd) || 0;
+  if (tradeUsd >= GASLESS_MIN_TRADE_USD) return { hasSufficientNative: true };
 
   const balance = await fetchNativeBalance(normalizedChain, walletAddress);
 
@@ -323,7 +334,7 @@ export async function validateGasBalance({ chain, walletAddress }) {
 
   const symbol = NATIVE_SYMBOLS[normalizedChain] || 'native token';
   throw new Error(
-    `Insufficient ${symbol} for gas fees. Wallet has ${balance} ${symbol} but needs at least ${minGas} ${symbol}. Fund the wallet before trading.`
+    `Insufficient ${symbol} for gas fees. Wallet has ${balance} ${symbol} but needs at least ${minGas} ${symbol}. Either fund the wallet with ${symbol} or trade a value of $${GASLESS_MIN_TRADE_USD}+ to use gasless options.`
   );
 }
 

--- a/src/trading.js
+++ b/src/trading.js
@@ -1331,8 +1331,10 @@ CROSS-CHAIN NOTES (when using --to-chain):
         response.quotes.forEach((q, i) => log(formatQuote(q, i)));
 
         // Gas balance validation — check that the wallet has enough native token for gas.
+        // High-value trades (>= $10) can use gasless/solver-paid routes and bypass this check.
         try {
-          await validateGasBalance({ chain, walletAddress });
+          const tradeValueUsd = response.quotes[0]?.inUsdValue;
+          await validateGasBalance({ chain, walletAddress, tradeValueUsd });
         } catch (gasErr) {
           throw new CommandError(`Error: ${gasErr.message}`, 'INSUFFICIENT_GAS');
         }


### PR DESCRIPTION
## Summary

- Trades >= \$10 USD now skip the native gas pre-check because solver-paid (gasless) routes like Relay are viable at that value
- The threshold is exported as `GASLESS_MIN_TRADE_USD` from `trade-validation.js` — one place to change it
- When gas validation does fail (trade < \$10 + insufficient gas), the error message now suggests either topping up gas **or** increasing the trade to \$10+ as alternatives

## How it works

`validateGasBalance` accepts an optional `tradeValueUsd` param. If the quote's `inUsdValue` is >= `GASLESS_MIN_TRADE_USD`, the RPC balance check is skipped entirely and the function returns `{ hasSufficientNative: true }`.

The call site in the `quote` handler passes `response.quotes[0].inUsdValue` (already populated from the API response at that point).

## Test plan

- [x] `npm test` passes (1479 tests)
- [x] `npm run lint` passes
- [x] New unit tests cover: bypass at exactly \$10, bypass above \$10, still validates below \$10, error message includes gasless suggestion
- [x] Existing integration test (quote with `inUsdValue: '5.00'`) still correctly rejects on insufficient gas

🤖 Generated with [Claude Code](https://claude.com/claude-code)