### PR TITLE
Improve CLI help formatting for command groups

### DIFF
--- a/.changeset/improve-command-help-format.md
+++ b/.changeset/improve-command-help-format.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Improve command group help output with standard usage and one command per line.

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -2220,6 +2220,57 @@ describe('runCLI', () => {
     expect(result.type).toBe('help');
   });
 
+  it('should show command-group help with one command per line', async () => {
+    const result = await runCLI(['research', '--help'], mockDeps());
+    const output = outputs.join('\n');
+    const lines = output.split('\n');
+
+    expect(result).toEqual({ type: 'command-help', command: 'research' });
+    expect(lines.slice(0, 5)).toEqual([
+      'USAGE: nansen research <command> [options]',
+      '',
+      'Research and analytics commands',
+      '',
+      'COMMANDS:'
+    ]);
+    expect(lines).toContain('  portfolio');
+    expect(lines).toContain('  smart-money');
+    expect(lines).toContain('  profiler');
+
+    const commandStart = lines.indexOf('COMMANDS:') + 1;
+    const footerIndex = lines.findIndex((line) => line.startsWith("Run 'nansen research"));
+    const commandLines = lines.slice(commandStart, footerIndex - 1);
+    expect(commandLines.length).toBeGreaterThan(0);
+    expect(commandLines.every((line) => /^  [a-z0-9-]+$/.test(line))).toBe(true);
+    expect(output).toContain("Run 'nansen research <command> --help' for more information on a command.");
+    expect(output).not.toContain('Subcommands:');
+    expect(output).not.toContain(', smart-money');
+  });
+
+  it('should show nested command-group help with one command per line', async () => {
+    const result = await runCLI(['research', 'smart-money', '--help'], mockDeps());
+    const output = outputs.join('\n');
+
+    expect(result).toEqual({ type: 'command-help', command: 'research smart-money' });
+    expect(output).toContain('USAGE: nansen research smart-money <command> [options]');
+    expect(output).toContain('COMMANDS:\n  netflow\n  dex-trades');
+    expect(output).toContain("Run 'nansen research smart-money <command> --help' for more information on a command.");
+    expect(output).not.toContain('Subcommands: netflow, dex-trades');
+  });
+
+  it('should show leaf subcommand help with sectioned formatting', async () => {
+    const result = await runCLI(['research', 'portfolio', 'defi', '--help'], mockDeps());
+    const output = outputs.join('\n');
+
+    expect(result).toEqual({ type: 'subcommand-help', command: 'portfolio', subcommand: 'defi' });
+    expect(output).toContain('USAGE: nansen research portfolio defi [options]');
+    expect(output).toContain('DeFi holdings across protocols');
+    expect(output).toContain('OPTIONS (* required):\n  --wallet*');
+    expect(output).toContain('Cost: 10 credits (Free tier) / 1 credit (Pro tier)');
+    expect(output).toContain('EXAMPLE:\n  nansen research portfolio defi --wallet <val>');
+    expect(output).not.toContain('Params (* required):');
+  });
+
   it('should error on unknown command', async () => {
     const result = await runCLI(['unknown-cmd'], mockDeps());
     expect(result.type).toBe('error');

--- a/src/cli.js
+++ b/src/cli.js
@@ -1599,6 +1599,20 @@ export const RESEARCH_CATEGORY_ALIASES = {
   'pm': 'prediction-market'
 };
 
+function generateCommandGroupHelp(commandPath, cmdSchema) {
+  const lines = [`USAGE: nansen ${commandPath} <command> [options]`];
+
+  if (cmdSchema.description) lines.push('', cmdSchema.description);
+
+  lines.push('', 'COMMANDS:');
+  for (const name of Object.keys(cmdSchema.subcommands)) {
+    lines.push(`  ${name}`);
+  }
+
+  lines.push('', `Run 'nansen ${commandPath} <command> --help' for more information on a command.`);
+  return lines.join('\n');
+}
+
 // Generate help text for a specific subcommand using SCHEMA
 export function generateSubcommandHelp(command, subcommand, prefix = null) {
   const cmdSchema = SCHEMA.commands[command] || SCHEMA.commands.research.subcommands[command];
@@ -1607,8 +1621,21 @@ export function generateSubcommandHelp(command, subcommand, prefix = null) {
   const subSchema = cmdSchema.subcommands?.[subcommand];
   if (!subSchema) return null;
 
-  const lines = [];
-  lines.push(`${command} ${subcommand} — ${subSchema.description || 'No description'}`);
+  const cmdPrefix = prefix || (DEPRECATED_TO_RESEARCH.has(command) ? `research ${command}` : command);
+  const chain = subSchema.options?.chain?.default || 'solana';
+  let example = `nansen ${cmdPrefix} ${subcommand}`;
+  if (subSchema.options) {
+    for (const [name, opt] of Object.entries(subSchema.options)) {
+      if (opt.required) example += ` --${name} <val>`;
+    }
+  }
+  if (subSchema.options?.chain && !subSchema.options.chain.required) {
+    example += ` --chain ${chain}`;
+  }
+
+  const lines = [`USAGE: nansen ${cmdPrefix} ${subcommand} [options]`];
+
+  if (subSchema.description) lines.push('', subSchema.description);
 
   if (subSchema.options) {
     const params = Object.entries(subSchema.options).map(([name, opt]) => {
@@ -1618,31 +1645,18 @@ export function generateSubcommandHelp(command, subcommand, prefix = null) {
       if (opt.enum) parts.push(`[${opt.enum.join('|')}]`);
       return parts.join(' ');
     });
-    lines.push(`Params (* required): ${params.join(', ')}`);
+    lines.push('', 'OPTIONS (* required):', ...params.map((param) => `  ${param}`));
   }
 
   if (subSchema.endpoint) {
     const cost = getCostForEndpoint(subSchema.endpoint);
-    if (cost) lines.push(`Cost: ${cost.free} credit${cost.free === 1 ? '' : 's'} (Free tier) / ${cost.pro} credit${cost.pro === 1 ? '' : 's'} (Pro tier)`);
+    if (cost) lines.push('', `Cost: ${cost.free} credit${cost.free === 1 ? '' : 's'} (Free tier) / ${cost.pro} credit${cost.pro === 1 ? '' : 's'} (Pro tier)`);
   }
 
   if (subSchema.returns?.length) {
-    lines.push(`Returns: ${subSchema.returns.join(', ')}`);
+    lines.push('', 'RETURNS:', ...subSchema.returns.map((field) => `  ${field}`));
   }
-
-  const exampleValues = { address: '0x...', token: '0x...', query: '"term"', symbol: 'BTC', date: '2024-01-01' };
-  const chain = subSchema.options?.chain?.default || 'solana';
-  const cmdPrefix = prefix || (DEPRECATED_TO_RESEARCH.has(command) ? `research ${command}` : command);
-  let example = `nansen ${cmdPrefix} ${subcommand}`;
-  if (subSchema.options) {
-    for (const [name, opt] of Object.entries(subSchema.options)) {
-      if (opt.required) example += ` --${name} ${exampleValues[name] || '<val>'}`;
-    }
-  }
-  if (subSchema.options?.chain && !subSchema.options.chain.required) {
-    example += ` --chain ${chain}`;
-  }
-  lines.push(`Example: ${example}`);
+  lines.push('', 'EXAMPLE:', `  ${example}`);
 
   return lines.join('\n');
 }
@@ -1715,11 +1729,14 @@ export async function runCLI(rawArgs, deps = {}) {
         const researchCat = SCHEMA.commands.research.subcommands[category];
         if (researchCat) {
           const catSchema = researchCat;
-          const lines = [`research ${category} — ${catSchema.description}`];
           if (catSchema.subcommands) {
-            lines.push('Subcommands: ' + Object.keys(catSchema.subcommands).join(', '));
-            lines.push(`Use: nansen research ${category} <subcommand> --help`);
-          } else if (catSchema.options) {
+            output(generateCommandGroupHelp(`research ${category}`, catSchema));
+            notify();
+            return { type: 'command-help', command: `research ${category}` };
+          }
+
+          const lines = [`research ${category} — ${catSchema.description}`];
+          if (catSchema.options) {
             // Leaf historical subcommand: render options + example
             const params = Object.entries(catSchema.options).map(([name, opt]) => {
               const parts = [`--${name}`];
@@ -1753,11 +1770,12 @@ export async function runCLI(rawArgs, deps = {}) {
       const cmdSchemaLookup = command !== 'trade' && command !== 'alerts' && command !== 'agent' && (SCHEMA.commands[command] || SCHEMA.commands.research.subcommands[command]);
       if (command && cmdSchemaLookup) {
         const cmdSchema = cmdSchemaLookup;
-        const lines = [`${command} — ${cmdSchema.description}`];
         if (cmdSchema.subcommands) {
-          lines.push('Subcommands: ' + Object.keys(cmdSchema.subcommands).join(', '));
-          lines.push(`Use: nansen ${command} <subcommand> --help`);
+          output(deprecationNote(command) + generateCommandGroupHelp(command, cmdSchema));
+          notify();
+          return { type: 'command-help', command };
         }
+        const lines = [`${command} — ${cmdSchema.description}`];
         if (cmdSchema.options) {
           const params = Object.entries(cmdSchema.options).map(([name, opt]) => {
             const parts = [`--${name}`];


### PR DESCRIPTION
Render command-group help with standard usage text and one command per line, and section leaf subcommand help into usage, options, returns, and examples.

## Summary

<!-- What does this PR do? -->

**Before fix:**

```console
➜  nansen-cli git:(main) nansen research portfolio defi --help
portfolio defi — DeFi holdings across protocols
Params (* required): --wallet*
Cost: 10 credits (Free tier) / 1 credit (Pro tier)
Example: nansen research portfolio defi --wallet <val>
```

**After fix:**

```console
➜  nansen-cli git:(cli-help) nansen research portfolio defi --help
USAGE: nansen research portfolio defi [options]

DeFi holdings across protocols

OPTIONS (* required):
  --wallet*

Cost: 10 credits (Free tier) / 1 credit (Pro tier)

EXAMPLE:
  nansen research portfolio defi --wallet <val>
```

**Before fix:**

```console
➜  nansen-cli git:(main) nansen research --help
research — Research and analytics commands
Subcommands: portfolio, smart-money, profiler, token, search, perp, prediction-market, points, historical-dex-trades, historical-pnl-leaderboard, historical-token-flow-summary, historical-token-quant-scores, historical-top-holders, historical-who-bought-sold, historical-smart-money-balances, historical-token-screener, historical-wallet-balances, historical-tx-lookup, historical-wallet-transactions
Use: nansen research <subcommand> --help
```

**After fix:**

```console
➜  nansen-cli git:(cli-help) nansen research --help
USAGE: nansen research <command> [options]

Research and analytics commands

COMMANDS:
  portfolio
  smart-money
  profiler
  token
  search
  perp
  prediction-market
  points
  historical-dex-trades
  historical-pnl-leaderboard
  historical-token-flow-summary
  historical-token-quant-scores
  historical-top-holders
  historical-who-bought-sold
  historical-smart-money-balances
  historical-token-screener
  historical-wallet-balances
  historical-tx-lookup
  historical-wallet-transactions

Run 'nansen research <command> --help' for more information on a command.
```

## Checklist

- [x] Tests pass (`npm test`)
- [ ] `src/schema.json` updated if new commands or flags were added
- [ ] `README.md` updated if new top-level commands or categories were added
- [x] Changeset added (`.changeset/`) — only required for user-facing changes (new commands, flags, bug fixes, breaking changes)
