### PR TITLE
fix: perp --filter guard + profiler perp-positions --table

### DIFF
--- a/.changeset/fix-perp-filter-and-positions-table.md
+++ b/.changeset/fix-perp-filter-and-positions-table.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+fix: reject --filter on perp commands that don't support it; fix profiler perp-positions --table rendering

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -140,9 +140,16 @@ const MOCK_RESPONSES = {
     win_rate: 0.65
   },
   addressPerpPositions: {
-    positions: [
-      { token: 'BTC', side: 'long', size_usd: 50000 }
-    ]
+    data: {
+      data: {
+        asset_positions: [
+          {
+            position: { coin: 'BTC', szi: '0.00031', entryPx: '72830.0', positionValue: '22.58', unrealizedPnl: '-0.02', leverage: { type: 'cross', value: 2 }, liquidationPx: null },
+            position_type: 'cross',
+          },
+        ],
+      },
+    },
   },
   addressPerpTrades: {
     trades: [
@@ -1032,10 +1039,10 @@ describe('NansenAPI', () => {
         const body = expectFetchCalledWith('/api/v1/profiler/perp-positions');
         expect(body.address).toBe(TEST_DATA.ethereum.address);
         
-        expect(result.positions).toBeInstanceOf(Array);
-        expect(result.positions[0]).toHaveProperty('token', 'BTC');
-        expect(result.positions[0]).toHaveProperty('side', 'long');
-        expect(result.positions[0]).toHaveProperty('size_usd', 50000);
+        expect(result.data.data).toBeInstanceOf(Array);
+        expect(result.data.data[0]).toHaveProperty('coin', 'BTC');
+        expect(result.data.data[0]).toHaveProperty('position_type', 'cross');
+        expect(result.data.data[0]).toHaveProperty('szi', '0.00031');
       });
     });
 

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -141,14 +141,12 @@ const MOCK_RESPONSES = {
   },
   addressPerpPositions: {
     data: {
-      data: {
-        asset_positions: [
-          {
-            position: { coin: 'BTC', szi: '0.00031', entryPx: '72830.0', positionValue: '22.58', unrealizedPnl: '-0.02', leverage: { type: 'cross', value: 2 }, liquidationPx: null },
-            position_type: 'cross',
-          },
-        ],
-      },
+      asset_positions: [
+        {
+          position: { coin: 'BTC', szi: '0.00031', entryPx: '72830.0', positionValue: '22.58', unrealizedPnl: '-0.02', leverage: { type: 'cross', value: 2 }, liquidationPx: null },
+          position_type: 'cross',
+        },
+      ],
     },
   },
   addressPerpTrades: {
@@ -1039,10 +1037,10 @@ describe('NansenAPI', () => {
         const body = expectFetchCalledWith('/api/v1/profiler/perp-positions');
         expect(body.address).toBe(TEST_DATA.ethereum.address);
         
-        expect(result.data.data).toBeInstanceOf(Array);
-        expect(result.data.data[0]).toHaveProperty('coin', 'BTC');
-        expect(result.data.data[0]).toHaveProperty('position_type', 'cross');
-        expect(result.data.data[0]).toHaveProperty('szi', '0.00031');
+        expect(result.data).toBeInstanceOf(Array);
+        expect(result.data[0]).toHaveProperty('coin', 'BTC');
+        expect(result.data[0]).toHaveProperty('position_type', 'cross');
+        expect(result.data[0]).toHaveProperty('szi', '0.00031');
       });
     });
 

--- a/src/api.js
+++ b/src/api.js
@@ -962,8 +962,8 @@ export class NansenAPI {
     });
     // The API returns {asset_positions: [{position: {...}, position_type}]} — flatten
     // to a standard array so the table formatter renders one row per position.
-    if (result?.data?.data?.asset_positions) {
-      result.data.data = result.data.data.asset_positions.map(p => ({
+    if (result?.data?.asset_positions) {
+      result.data = result.data.asset_positions.map(p => ({
         ...p.position,
         position_type: p.position_type,
       }));

--- a/src/api.js
+++ b/src/api.js
@@ -955,11 +955,20 @@ export class NansenAPI {
     const { address, filters = {}, orderBy } = params;
     // Perp positions work with HL addresses (not validated)
     // Note: This endpoint does NOT support pagination parameter
-    return this.request('/api/v1/profiler/perp-positions', {
+    const result = await this.request('/api/v1/profiler/perp-positions', {
       address,
       filters,
       order_by: orderBy
     });
+    // The API returns {asset_positions: [{position: {...}, position_type}]} — flatten
+    // to a standard array so the table formatter renders one row per position.
+    if (result?.data?.data?.asset_positions) {
+      result.data.data = result.data.data.asset_positions.map(p => ({
+        ...p.position,
+        position_type: p.position_type,
+      }));
+    }
+    return result;
   }
 
   async addressPerpTrades(params = {}) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1090,7 +1090,15 @@ export function buildCommands(deps = {}) {
       const handlers = {
         'netflow': () => apiInstance.smartMoneyNetflow({ chains, filters, orderBy, pagination }),
         'dex-trades': () => apiInstance.smartMoneyDexTrades({ chains, filters, orderBy, pagination }),
-        'perp-trades': () => apiInstance.smartMoneyPerpTrades({ filters, orderBy, pagination, onlyNewPositions: options['only-new-positions'] ?? flags['only-new-positions'] }),
+        'perp-trades': () => {
+          if (Object.keys(filters).length > 0) {
+            throw new NansenError(
+              'smart-money perp-trades does not support --filter (use --only-new-positions to narrow results)',
+              ErrorCode.INVALID_PARAMS,
+            );
+          }
+          return apiInstance.smartMoneyPerpTrades({ filters, orderBy, pagination, onlyNewPositions: options['only-new-positions'] ?? flags['only-new-positions'] });
+        },
         'holdings': () => apiInstance.smartMoneyHoldings({ chains, filters, orderBy, pagination }),
         'dcas': () => apiInstance.smartMoneyDcas({ filters, orderBy, pagination }),
         'historical-holdings': () => apiInstance.smartMoneyHistoricalHoldings({ chains, filters, orderBy, pagination, days }),
@@ -1361,6 +1369,13 @@ export function buildCommands(deps = {}) {
       const orderBy = parseSort(options.sort, options['order-by']);
       const pagination = buildPagination(options);
       const days = options.days ? parseInt(options.days) : 30;
+
+      if (Object.keys(filters).length > 0) {
+        throw new NansenError(
+          'perp screener and leaderboard do not support --filter (Hyperliquid-only endpoints return the full market)',
+          ErrorCode.INVALID_PARAMS,
+        );
+      }
 
       const handlers = {
         'screener': () => apiInstance.perpScreener({ filters, orderBy, pagination, days }),

--- a/src/cli.js
+++ b/src/cli.js
@@ -1074,7 +1074,7 @@ export function buildCommands(deps = {}) {
       const subcommand = args[0] || 'help';
       const chain = options.chain || 'solana';
       const chains = options.chains || [chain];
-      const filters = options.filters || {};
+      const filters = options.filters || options.filter || {};
       const orderBy = parseSort(options.sort, options['order-by']);
       const pagination = buildPagination(options);
 
@@ -1365,21 +1365,24 @@ export function buildCommands(deps = {}) {
 
     'perp': async (args, apiInstance, flags, options) => {
       const subcommand = args[0] || 'help';
-      const filters = options.filters || {};
+      const filters = options.filters || options.filter || {};
       const orderBy = parseSort(options.sort, options['order-by']);
       const pagination = buildPagination(options);
       const days = options.days ? parseInt(options.days) : 30;
 
-      if (Object.keys(filters).length > 0) {
-        throw new NansenError(
-          'perp screener and leaderboard do not support --filter (Hyperliquid-only endpoints return the full market)',
-          ErrorCode.INVALID_PARAMS,
-        );
-      }
+      const rejectFilter = () => {
+        if (Object.keys(filters).length > 0) {
+          throw new NansenError(
+            'perp screener and leaderboard do not support --filter (Hyperliquid-only endpoints return the full market)',
+            ErrorCode.INVALID_PARAMS,
+          );
+        }
+      };
 
       const handlers = {
-        'screener': () => apiInstance.perpScreener({ filters, orderBy, pagination, days }),
+        'screener': () => { rejectFilter(); return apiInstance.perpScreener({ filters, orderBy, pagination, days }); },
         'leaderboard': () => {
+          rejectFilter();
           const withLabels = resolveBooleanOption(options, flags, 'premium-labels');
           return apiInstance.perpLeaderboard({ filters, orderBy, pagination, days, withLabels });
         },


### PR DESCRIPTION
## What

Two bug fixes found during perp dogfooding.

**Fix 1 — `--filter` silently ignored on perp commands (closes #447)**

`perp screener`, `perp leaderboard`, and `smart-money perp-trades` accepted `--filter` without error but silently discarded it — the API doesn't support server-side filtering on these endpoints. Now throws `INVALID_PARAMS` immediately with a clear message, following the same pattern as `historical-token-flow-summary` and `historical-smart-money-balances` (PR #442).

**Fix 2 — `profiler perp-positions --table` renders raw JSON blob (closes #448)**

The `/api/v1/profiler/perp-positions` endpoint returns `{asset_positions: [{position: {...}, position_type}]}` — a nested shape no other `profiler` endpoint uses. The table formatter hit the single-object fallback and dumped the whole response as one blob. Added a response transform in `addressPerpPositions` to flatten `asset_positions[]` into a standard array before the formatter sees it. `--pretty` is unaffected.

Also updates the mock to match the real API response shape (the original mock was wrong since day 1 — `result.positions[]` never matched production).

## Tests

```
Test Files  27 passed (27)
      Tests  1479 passed | 2 skipped (1481)
```

## Checklist
- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] Tests updated to match real API shape
- [x] Changeset added (patch)
- [x] No new `console.log` or hardcoded values