### PR TITLE
feat(x402): BSC multi-asset payments + Permit2 signing

### DIFF
--- a/.changeset/x402-bsc-multi-asset-permit2.md
+++ b/.changeset/x402-bsc-multi-asset-permit2.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+x402 on BNB Smart Chain: support all four stablecoins the API now advertises (U, USD1, USDT, USDC) and add Permit2 payment signing. Payments route on the 402's `extra.assetTransferMethod` — `eip3009` keeps the existing gasless flow (U, USD1), while `permit2-exact` (USDT, USDC on BSC) signs a Permit2 `PermitWitnessTransferFrom` against the spender contract advertised in the 402. Permit2 entries are skipped with an actionable message when the wallet hasn't made the one-time `approve(Permit2, …)` for the token. Post-payment balance warnings now check the exact token paid with (per-token decimals) instead of one hardcoded token per network.

--- a/src/__tests__/x402-balance.test.js
+++ b/src/__tests__/x402-balance.test.js
@@ -3,8 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { EVM_X402_TOKENS } from '../x402.js';
-import { CHAIN_RPCS } from '../rpc-urls.js';
+import { EVM_X402_TOKENS, EVM_X402_RPCS } from '../x402.js';
 
 describe('EVM_X402_TOKENS registry', () => {
   it('covers Base, X Layer, and BNB Smart Chain', () => {
@@ -13,26 +12,34 @@ describe('EVM_X402_TOKENS registry', () => {
     );
   });
 
-  it('uses 18 decimals for BSC USDT and 6 for the others', () => {
-    expect(EVM_X402_TOKENS['eip155:56'].decimals).toBe(18);
-    expect(EVM_X402_TOKENS['eip155:8453'].decimals).toBe(6);
-    expect(EVM_X402_TOKENS['eip155:196'].decimals).toBe(6);
+  it('lists the four BSC stablecoins with eip3009-capable tokens first', () => {
+    const symbols = EVM_X402_TOKENS['eip155:56'].map(t => t.symbol);
+    expect(symbols).toEqual(['U', 'USD1', 'USDT', 'USDC']);
+  });
+
+  it('uses 18 decimals for every BSC token and 6 elsewhere', () => {
+    for (const t of EVM_X402_TOKENS['eip155:56']) {
+      expect(t.decimals, t.symbol).toBe(18);
+    }
+    expect(EVM_X402_TOKENS['eip155:8453'][0].decimals).toBe(6);
+    expect(EVM_X402_TOKENS['eip155:196'][0].decimals).toBe(6);
   });
 
   it('pins the expected token contracts', () => {
-    expect(EVM_X402_TOKENS['eip155:8453'].token)
+    expect(EVM_X402_TOKENS['eip155:8453'][0].token)
       .toBe('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'); // Base USDC
-    expect(EVM_X402_TOKENS['eip155:56'].token)
-      .toBe('0x55d398326f99059fF775485246999027B3197955'); // BSC USDT
+    const bsc = Object.fromEntries(
+      EVM_X402_TOKENS['eip155:56'].map(t => [t.symbol, t.token]),
+    );
+    expect(bsc.U).toBe('0xcE24439F2D9C6a2289F741120FE202248B666666');
+    expect(bsc.USD1).toBe('0x8d0d000ee44948fc98c9b98a4fa4921476f08b0d');
+    expect(bsc.USDT).toBe('0x55d398326f99059fF775485246999027B3197955');
+    expect(bsc.USDC).toBe('0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d');
   });
 
   it('resolves an RPC URL for every network', () => {
-    for (const [network, cfg] of Object.entries(EVM_X402_TOKENS)) {
-      expect(cfg.rpc, `rpc for ${network}`).toMatch(/^https?:\/\//);
+    for (const network of Object.keys(EVM_X402_TOKENS)) {
+      expect(EVM_X402_RPCS[network], `rpc for ${network}`).toMatch(/^https?:\/\//);
     }
-  });
-
-  it('has a BSC entry in the shared RPC registry', () => {
-    expect(CHAIN_RPCS.bsc).toMatch(/^https?:\/\//);
   });
 });

--- a/src/__tests__/x402-permit2.test.js
+++ b/src/__tests__/x402-permit2.test.js
@@ -1,0 +1,136 @@
+/**
+ * Tests for Permit2 (permit2-exact) x402 payment signing.
+ *
+ * The digest test vector was computed with an independent EIP-712
+ * implementation (Python eth_account) over the same typed data, so it
+ * cross-validates the nested-struct hashing end to end.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createEvmPaymentPayload,
+  createPermit2ExactPayload,
+  hashPermit2WitnessTransfer,
+  PERMIT2_ADDRESS,
+} from '../x402-evm.js';
+import { generateEvmWallet } from '../wallet.js';
+
+const REQUIREMENTS_PERMIT2 = {
+  scheme: 'exact',
+  network: 'eip155:56',
+  asset: '0x1000000000000000000000000000000000000001',
+  amount: '10000000000000000',
+  payTo: '0x3000000000000000000000000000000000000003',
+  maxTimeoutSeconds: 300,
+  extra: {
+    name: 'Test Token',
+    version: '1',
+    assetTransferMethod: 'permit2-exact',
+    signerAddress: '0x4000000000000000000000000000000000000004',
+    spenderAddress: '0x2000000000000000000000000000000000000002',
+  },
+};
+
+describe('hashPermit2WitnessTransfer', () => {
+  it('matches an independently computed EIP-712 digest', () => {
+    // Reference digest computed with Python eth_account over identical input.
+    const digest = hashPermit2WitnessTransfer(56, {
+      permitted: {
+        token: '0x1000000000000000000000000000000000000001',
+        amount: 10000000000000000n,
+      },
+      spender: '0x2000000000000000000000000000000000000002',
+      nonce: 123456789n,
+      deadline: 1750000000n,
+      witness: {
+        to: '0x3000000000000000000000000000000000000003',
+        validAfter: 1749999000n,
+      },
+    });
+    expect('0x' + digest.toString('hex')).toBe(
+      '0x84f21d844cc4f15e21f03e16da32687d28e4a1ce8bca3de73a5b8625f02c390b',
+    );
+  });
+
+  it('uses the canonical Permit2 contract address', () => {
+    expect(PERMIT2_ADDRESS).toBe('0x000000000022D473030F116dDEE9F6B43aC78BA3');
+  });
+});
+
+describe('createPermit2ExactPayload', () => {
+  it('builds a permit2Authorization payload with decimal-string fields', () => {
+    const wallet = generateEvmWallet();
+    const b64 = createPermit2ExactPayload(
+      REQUIREMENTS_PERMIT2, wallet.privateKey, wallet.address, 'https://api.example.com/x',
+    );
+    const payload = JSON.parse(Buffer.from(b64, 'base64').toString());
+
+    expect(payload.x402Version).toBe(2);
+    expect(payload.accepted).toEqual(REQUIREMENTS_PERMIT2);
+    expect(payload.resource).toEqual({ url: 'https://api.example.com/x' });
+
+    const auth = payload.payload.permit2Authorization;
+    expect(auth.from).toBe(wallet.address);
+    expect(auth.spender).toBe('0x2000000000000000000000000000000000000002');
+    expect(auth.permitted).toEqual({
+      token: REQUIREMENTS_PERMIT2.asset,
+      amount: REQUIREMENTS_PERMIT2.amount,
+    });
+    expect(auth.witness.to).toBe(REQUIREMENTS_PERMIT2.payTo);
+    // Wire-format numerics are decimal strings.
+    expect(auth.nonce).toMatch(/^\d+$/);
+    expect(auth.deadline).toMatch(/^\d+$/);
+    expect(auth.witness.validAfter).toMatch(/^\d+$/);
+    // EIP-3009 fields must be absent.
+    expect(payload.payload.authorization).toBeUndefined();
+    expect(payload.payload.signature).toMatch(/^0x[0-9a-f]{130}$/);
+  });
+
+  it('throws when spenderAddress is missing', () => {
+    const wallet = generateEvmWallet();
+    const req = {
+      ...REQUIREMENTS_PERMIT2,
+      extra: { ...REQUIREMENTS_PERMIT2.extra, spenderAddress: undefined },
+    };
+    expect(() =>
+      createPermit2ExactPayload(req, wallet.privateKey, wallet.address, 'u'),
+    ).toThrow(/spenderAddress/);
+  });
+});
+
+describe('createEvmPaymentPayload method routing', () => {
+  it('routes permit2-exact to the Permit2 payload', () => {
+    const wallet = generateEvmWallet();
+    const b64 = createEvmPaymentPayload(
+      REQUIREMENTS_PERMIT2, wallet.privateKey, wallet.address, 'u',
+    );
+    const payload = JSON.parse(Buffer.from(b64, 'base64').toString());
+    expect(payload.payload.permit2Authorization).toBeDefined();
+  });
+
+  it('keeps the EIP-3009 path when assetTransferMethod is eip3009 or absent', () => {
+    const wallet = generateEvmWallet();
+    for (const extra of [
+      { name: 'Test Token', version: '1' },
+      { name: 'Test Token', version: '1', assetTransferMethod: 'eip3009' },
+    ]) {
+      const b64 = createEvmPaymentPayload(
+        { ...REQUIREMENTS_PERMIT2, extra }, wallet.privateKey, wallet.address, 'u',
+      );
+      const payload = JSON.parse(Buffer.from(b64, 'base64').toString());
+      expect(payload.payload.authorization).toBeDefined();
+      expect(payload.payload.permit2Authorization).toBeUndefined();
+    }
+  });
+
+  it('throws on unsupported transfer methods so fallback can continue', () => {
+    const wallet = generateEvmWallet();
+    const req = {
+      ...REQUIREMENTS_PERMIT2,
+      extra: { ...REQUIREMENTS_PERMIT2.extra, assetTransferMethod: 'permit2-upto' },
+    };
+    expect(() =>
+      createEvmPaymentPayload(req, wallet.privateKey, wallet.address, 'u'),
+    ).toThrow(/assetTransferMethod/);
+  });
+});

--- a/src/api.js
+++ b/src/api.js
@@ -493,7 +493,7 @@ export class NansenAPI {
    * an attemptX402Payment() method so adding a new payment provider only requires
    * touching that one method, not hunting inside the retry loop.
    */
-  async _x402Retry(signature, walletLabel, network, url, body, options = {}) {
+  async _x402Retry(signature, walletLabel, network, url, body, options = {}, asset = null) {
     const paidResponse = await fetch(url, {
       method: 'POST',
       headers: {
@@ -514,7 +514,7 @@ export class NansenAPI {
     if (network) {
       try {
         const { checkX402Balance } = await import('./x402.js');
-        const result = await checkX402Balance(network);
+        const result = await checkX402Balance(network, asset);
         if (result !== null && result.balance < 0.25) {
           console.error(`[x402] Warning: ${result.symbol} balance low ($${result.balance.toFixed(2)}). Fund your wallet to avoid interruptions.`);
         }
@@ -651,8 +651,8 @@ export class NansenAPI {
               // 1. Try local wallet with fallback across payment networks
               try {
                 const { createPaymentSignatures } = await import('./x402.js');
-                for await (const { signature, network } of createPaymentSignatures(response, url)) {
-                  const result = await this._x402Retry(signature, `local wallet ${defaultWalletName}`, network, url, body, options);
+                for await (const { signature, network, asset } of createPaymentSignatures(response, url)) {
+                  const result = await this._x402Retry(signature, `local wallet ${defaultWalletName}`, network, url, body, options, asset);
                   if (result !== null) return result;
                   // This payment option was rejected, try next
                 }

--- a/src/x402-evm.js
+++ b/src/x402-evm.js
@@ -25,6 +25,39 @@ const AUTHORIZATION_TYPES = [
   { name: 'nonce', type: 'bytes32' },
 ];
 
+// ============= Permit2 (permit2-exact transfer method) =============
+// Some tokens (e.g. USDT/USDC on BNB Smart Chain) predate EIP-3009, so
+// facilitators settle them through Uniswap's canonical Permit2 contract
+// instead: the payer signs a PermitWitnessTransferFrom and the facilitator's
+// proxy (requirements.extra.spenderAddress) executes the transfer. Requires a
+// one-time on-chain `token.approve(PERMIT2_ADDRESS, ...)` from the payer.
+
+export const PERMIT2_ADDRESS = '0x000000000022D473030F116dDEE9F6B43aC78BA3';
+
+// Permit2's EIP-712 domain has no version field.
+const PERMIT2_DOMAIN_TYPES = [
+  { name: 'name', type: 'string' },
+  { name: 'chainId', type: 'uint256' },
+  { name: 'verifyingContract', type: 'address' },
+];
+
+const TOKEN_PERMISSIONS_TYPES = [
+  { name: 'token', type: 'address' },
+  { name: 'amount', type: 'uint256' },
+];
+
+const WITNESS_TYPES = [
+  { name: 'to', type: 'address' },
+  { name: 'validAfter', type: 'uint256' },
+];
+
+// encodeType for a nested primary type: referenced struct types are appended
+// in alphabetical order per EIP-712 (TokenPermissions before Witness).
+const PERMIT_WITNESS_TYPE_STRING =
+  'PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,Witness witness)' +
+  'TokenPermissions(address token,uint256 amount)' +
+  'Witness(address to,uint256 validAfter)';
+
 /**
  * Encode a type string for EIP-712 typeHash.
  * e.g. "TransferWithAuthorization(address from,address to,uint256 value,...)"
@@ -110,6 +143,38 @@ export function hashTypedData(domain, primaryType, fields, message) {
   ]));
 }
 
+/**
+ * Compute the EIP-712 digest for a Permit2 PermitWitnessTransferFrom.
+ *
+ * Hand-rolled because the generic helpers above only support flat structs:
+ * the primary typeHash must cover the full type string including referenced
+ * structs, and struct-typed fields encode as their structHash.
+ *
+ * @param {number} chainId - EVM chain id (Permit2 domain field)
+ * @param {object} message - { permitted: {token, amount}, spender, nonce, deadline, witness: {to, validAfter} }
+ * @returns {Buffer} 32-byte digest to sign
+ */
+export function hashPermit2WitnessTransfer(chainId, message) {
+  const domainSeparator = hashStruct('EIP712Domain', PERMIT2_DOMAIN_TYPES, {
+    name: 'Permit2',
+    chainId,
+    verifyingContract: PERMIT2_ADDRESS,
+  });
+  const structHash = keccak256(Buffer.concat([
+    keccak256(Buffer.from(PERMIT_WITNESS_TYPE_STRING, 'utf8')),
+    hashStruct('TokenPermissions', TOKEN_PERMISSIONS_TYPES, message.permitted),
+    encodeValue('address', message.spender),
+    encodeValue('uint256', message.nonce),
+    encodeValue('uint256', message.deadline),
+    hashStruct('Witness', WITNESS_TYPES, message.witness),
+  ]));
+  return keccak256(Buffer.concat([
+    Buffer.from([0x19, 0x01]),
+    domainSeparator,
+    structHash,
+  ]));
+}
+
 // ============= x402 EVM Payment =============
 
 /**
@@ -123,7 +188,13 @@ function getChainId(network) {
 }
 
 /**
- * Create an x402 payment payload for EVM (EIP-3009 TransferWithAuthorization).
+ * Create an x402 payment payload for EVM.
+ *
+ * Routes on requirements.extra.assetTransferMethod: absent or "eip3009" signs
+ * an EIP-3009 TransferWithAuthorization (gasless); "permit2-exact" signs a
+ * Permit2 PermitWitnessTransferFrom (requires a prior one-time
+ * token.approve(PERMIT2_ADDRESS, ...)). Other methods throw so the fallback
+ * loop tries the next accepts entry.
  *
  * @param {object} requirements - Parsed PaymentRequirements from 402 response
  * @param {string} privateKeyHex - 32-byte EVM private key as hex
@@ -134,6 +205,14 @@ function getChainId(network) {
 export function createEvmPaymentPayload(requirements, privateKeyHex, walletAddress, resource) {
   const chainId = getChainId(requirements.network);
   const extra = requirements.extra || {};
+
+  const method = extra.assetTransferMethod;
+  if (method === 'permit2-exact') {
+    return createPermit2ExactPayload(requirements, privateKeyHex, walletAddress, resource);
+  }
+  if (method && method !== 'eip3009') {
+    throw new Error(`Unsupported assetTransferMethod: ${method}`);
+  }
 
   // Token name and version from requirements.extra (set by server/facilitator)
   const tokenName = extra.name;
@@ -192,6 +271,71 @@ export function createEvmPaymentPayload(requirements, privateKeyHex, walletAddre
   };
 
   // Add resource as object if provided
+  if (resource) {
+    payload.resource = { url: resource };
+  }
+
+  return Buffer.from(JSON.stringify(payload)).toString('base64');
+}
+
+/**
+ * Create an x402 payment payload via Permit2 PermitWitnessTransferFrom
+ * (assetTransferMethod "permit2-exact").
+ *
+ * The spender is the facilitator's Permit2 proxy advertised in
+ * requirements.extra.spenderAddress; the witness binds the transfer to the
+ * merchant wallet (requirements.payTo). Wire-format numeric fields are
+ * decimal strings.
+ *
+ * @param {object} requirements - Parsed PaymentRequirements from 402 response
+ * @param {string} privateKeyHex - 32-byte EVM private key as hex
+ * @param {string} walletAddress - Signer's EVM address
+ * @param {string} resource - Original request URL
+ * @returns {string} Base64-encoded PaymentPayload for Payment-Signature header
+ */
+export function createPermit2ExactPayload(requirements, privateKeyHex, walletAddress, resource) {
+  const chainId = getChainId(requirements.network);
+  const extra = requirements.extra || {};
+  const spender = extra.spenderAddress;
+  if (!spender) {
+    throw new Error('spenderAddress missing from requirements.extra (required for permit2-exact)');
+  }
+
+  const payTo = requirements.pay_to || requirements.payTo;
+  const now = Math.floor(Date.now() / 1000);
+  // 256-bit random nonce — Permit2 uses an unordered nonce bitmap.
+  const nonce = BigInt('0x' + crypto.randomBytes(32).toString('hex')).toString();
+  const deadline = String(now + 3600);
+  const validAfter = String(now - 60); // allow clock skew
+
+  const message = {
+    permitted: { token: requirements.asset, amount: BigInt(requirements.amount) },
+    spender,
+    nonce: BigInt(nonce),
+    deadline: BigInt(deadline),
+    witness: { to: payTo, validAfter: BigInt(validAfter) },
+  };
+
+  const msgHash = hashPermit2WitnessTransfer(chainId, message);
+  const { r, s, v } = signSecp256k1(msgHash, Buffer.from(privateKeyHex, 'hex'));
+  const signature = '0x' + r.toString('hex') + s.toString('hex') + (27 + v).toString(16);
+
+  const payload = {
+    x402Version: 2,
+    payload: {
+      permit2Authorization: {
+        permitted: { token: requirements.asset, amount: String(requirements.amount) },
+        from: walletAddress,
+        spender,
+        nonce,
+        deadline,
+        witness: { to: payTo, validAfter },
+      },
+      signature,
+    },
+    accepted: requirements,
+  };
+
   if (resource) {
     payload.resource = { url: resource };
   }

--- a/src/x402.js
+++ b/src/x402.js
@@ -59,13 +59,14 @@ function rankRequirements(requirements) {
 const ALLOWANCE_SELECTOR = '0xdd62ed3e';
 
 /**
- * Check whether `owner` has approved Permit2 to spend `token`.
- * Permit2-based payments are doomed without this one-time on-chain approval,
- * so skip those entries early instead of burning a failed verify round-trip.
+ * Check whether `owner` has approved Permit2 to spend at least `amount` of
+ * `token`. Permit2-based payments are doomed without sufficient allowance
+ * (never approved, or a finite approval now below the payment amount), so
+ * skip those entries early instead of burning a failed verify round-trip.
  * Returns true when the allowance is unknown (RPC failure) — let the server
  * decide rather than block a possibly-valid payment.
  */
-async function hasPermit2Allowance(network, token, owner) {
+async function hasPermit2Allowance(network, token, owner, amount) {
   const rpc = getEvmRpcUrl(network);
   if (!rpc) return true;
   try {
@@ -82,7 +83,7 @@ async function hasPermit2Allowance(network, token, owner) {
     });
     const data = await resp.json();
     if (typeof data.result !== 'string') return true;
-    return BigInt(data.result) > 0n;
+    return BigInt(data.result) >= BigInt(amount);
   } catch {
     return true;
   }
@@ -99,12 +100,14 @@ async function buildPaymentForRequirement(requirement, exported, url) {
         requirement.network,
         requirement.asset,
         exported.evm.address,
+        requirement.amount,
       );
       if (!approved) {
         console.error(
-          `[x402] Skipping ${requirement.network} permit2 option: wallet has not ` +
-          `approved Permit2 (${PERMIT2_ADDRESS}) for token ${requirement.asset}. ` +
-          `Send a one-time approve(${PERMIT2_ADDRESS}, <amount>) from the wallet to enable it.`,
+          `[x402] Skipping ${requirement.network} permit2 option: Permit2 ` +
+          `(${PERMIT2_ADDRESS}) allowance for token ${requirement.asset} is ` +
+          `missing or below the payment amount (${requirement.amount}). ` +
+          `Send approve(${PERMIT2_ADDRESS}, <amount>) from the wallet to enable it.`,
         );
         return null;
       }

--- a/src/x402.js
+++ b/src/x402.js
@@ -4,7 +4,7 @@
  * Supports EVM (EIP-3009 on Base) and Solana (SPL TransferChecked).
  */
 
-import { createEvmPaymentPayload, isEvmNetwork } from './x402-evm.js';
+import { createEvmPaymentPayload, isEvmNetwork, PERMIT2_ADDRESS } from './x402-evm.js';
 import {
   createSvmPaymentPayload,
   isSvmNetwork,
@@ -55,12 +55,60 @@ function rankRequirements(requirements) {
   return ranked;
 }
 
+// ERC-20 allowance(owner, spender) selector for the Permit2 preflight.
+const ALLOWANCE_SELECTOR = '0xdd62ed3e';
+
+/**
+ * Check whether `owner` has approved Permit2 to spend `token`.
+ * Permit2-based payments are doomed without this one-time on-chain approval,
+ * so skip those entries early instead of burning a failed verify round-trip.
+ * Returns true when the allowance is unknown (RPC failure) — let the server
+ * decide rather than block a possibly-valid payment.
+ */
+async function hasPermit2Allowance(network, token, owner) {
+  const rpc = getEvmRpcUrl(network);
+  if (!rpc) return true;
+  try {
+    const ownerArg = owner.replace(/^0x/, '').toLowerCase().padStart(64, '0');
+    const spenderArg = PERMIT2_ADDRESS.replace(/^0x/, '').toLowerCase().padStart(64, '0');
+    const resp = await fetch(rpc, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0', id: 1,
+        method: 'eth_call',
+        params: [{ to: token, data: `${ALLOWANCE_SELECTOR}${ownerArg}${spenderArg}` }, 'latest'],
+      }),
+    });
+    const data = await resp.json();
+    if (typeof data.result !== 'string') return true;
+    return BigInt(data.result) > 0n;
+  } catch {
+    return true;
+  }
+}
+
 /**
  * Build a payment signature for a single requirement.
  * @returns {string|null} Base64 payment signature, or null on failure
  */
 async function buildPaymentForRequirement(requirement, exported, url) {
   if (isEvmNetwork(requirement.network)) {
+    if ((requirement.extra || {}).assetTransferMethod === 'permit2-exact') {
+      const approved = await hasPermit2Allowance(
+        requirement.network,
+        requirement.asset,
+        exported.evm.address,
+      );
+      if (!approved) {
+        console.error(
+          `[x402] Skipping ${requirement.network} permit2 option: wallet has not ` +
+          `approved Permit2 (${PERMIT2_ADDRESS}) for token ${requirement.asset}. ` +
+          `Send a one-time approve(${PERMIT2_ADDRESS}, <amount>) from the wallet to enable it.`,
+        );
+        return null;
+      }
+    }
     return createEvmPaymentPayload(
       requirement,
       exported.evm.privateKey,
@@ -132,7 +180,7 @@ export async function* createPaymentSignatures(response, url, options = {}) {
   for (const req of ranked) {
     try {
       const sig = await buildPaymentForRequirement(req, exported, url);
-      if (sig) yield { signature: sig, network: req.network };
+      if (sig) yield { signature: sig, network: req.network, asset: req.asset };
     } catch {
       // This payment option failed to build, try next
       continue;
@@ -161,17 +209,43 @@ export async function createPaymentSignature(response, url, options = {}) {
  * advertises in 402 `accepts` entries. `decimals` matters: USDT on BNB Smart
  * Chain uses 18 decimals, unlike the 6-decimal tokens on Base and X Layer.
  */
+// RPC endpoint per supported x402 EVM network.
+export const EVM_X402_RPCS = {
+  'eip155:8453': CHAIN_RPCS.base,
+  'eip155:196': CHAIN_RPCS.xlayer,
+  'eip155:56': CHAIN_RPCS.bsc,
+};
+
+function getEvmRpcUrl(network) {
+  return EVM_X402_RPCS[network] || null;
+}
+
+// Known payment tokens per network, in the order servers typically advertise
+// them. A network can accept several stablecoins (BSC accepts four); `decimals`
+// is per token — every BSC stablecoin is an 18-decimal BEP-20 deployment,
+// unlike the 6-decimal tokens on Base and X Layer.
 export const EVM_X402_TOKENS = {
-  'eip155:8453': { token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', rpc: CHAIN_RPCS.base,   symbol: 'USDC',  decimals: 6  }, // Base USDC
-  'eip155:196':  { token: '0x779Ded0c9e1022225f8E0630b35a9b54bE713736', rpc: CHAIN_RPCS.xlayer, symbol: 'USDT0', decimals: 6  }, // X Layer USDT0
-  'eip155:56':   { token: '0x55d398326f99059fF775485246999027B3197955', rpc: CHAIN_RPCS.bsc,    symbol: 'USDT',  decimals: 18 }, // BSC USDT
+  'eip155:8453': [
+    { token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', symbol: 'USDC', decimals: 6 }, // Base USDC
+  ],
+  'eip155:196': [
+    { token: '0x779Ded0c9e1022225f8E0630b35a9b54bE713736', symbol: 'USDT0', decimals: 6 }, // X Layer USDT0
+  ],
+  'eip155:56': [
+    { token: '0xcE24439F2D9C6a2289F741120FE202248B666666', symbol: 'U', decimals: 18 }, // United Stables
+    { token: '0x8d0d000ee44948fc98c9b98a4fa4921476f08b0d', symbol: 'USD1', decimals: 18 }, // World Liberty Financial USD
+    { token: '0x55d398326f99059fF775485246999027B3197955', symbol: 'USDT', decimals: 18 }, // Tether USD
+    { token: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d', symbol: 'USDC', decimals: 18 }, // Binance-Peg USD Coin
+  ],
 };
 
 /**
  * Check stablecoin balance for x402 payment wallet on the given network.
+ * Pass the token contract paid with (`asset`) to check that specific token;
+ * otherwise the network's first known token is checked.
  * Returns `{ balance, symbol }` (USD amount + token symbol) or null if check fails.
  */
-export async function checkX402Balance(network) {
+export async function checkX402Balance(network, asset = null) {
   try {
     const { listWallets, exportWallet: _exportWallet } = await import('./wallet.js');
     const wallets = listWallets();
@@ -204,8 +278,12 @@ export async function checkX402Balance(network) {
 
     if (network.startsWith('eip155:')) {
       // Default to Base USDC if the network is unknown so existing wallets keep working.
-      const { token, rpc, symbol, decimals } =
-        EVM_X402_TOKENS[network] || EVM_X402_TOKENS['eip155:8453'];
+      const tokens = EVM_X402_TOKENS[network] || EVM_X402_TOKENS['eip155:8453'];
+      const entry = (asset
+        && tokens.find(t => t.token.toLowerCase() === asset.toLowerCase()))
+        || tokens[0];
+      const { token, symbol, decimals } = entry;
+      const rpc = getEvmRpcUrl(network) || EVM_X402_RPCS['eip155:8453'];
       const addr = walletInfo.evm.replace('0x', '').toLowerCase().padStart(64, '0');
       const resp = await fetch(rpc, {
         method: 'POST',


### PR DESCRIPTION
## What

The Nansen API now advertises **four stablecoins on BNB Smart Chain** — U (United Stables), USD1, USDT, and USDC. This PR makes the CLI able to pay with all of them.

U and USD1 already work with the CLI's existing EIP-3009 flow (the server lists them first for exactly that reason). USDT and USDC on BSC predate EIP-3009, so facilitators settle them through Uniswap's canonical [Permit2](https://github.com/Uniswap/permit2) contract — which needs a different signature type.

## Changes

**`src/x402-evm.js` — Permit2 signing (`permit2-exact`)**
- Payment creation routes on the 402's `extra.assetTransferMethod`: absent/`eip3009` → existing gasless flow; `permit2-exact` → new `createPermit2ExactPayload`; anything else throws so the fallback loop moves to the next accepts entry.
- Signs a `PermitWitnessTransferFrom` against the spender contract advertised in the 402 (`extra.spenderAddress` — never hardcoded), witness bound to the merchant wallet. Nested-struct EIP-712 hashing and the 3-field Permit2 domain are implemented in the repo's existing zero-dependency style.
- **Cross-validated**: the digest test vector was computed with an independent EIP-712 implementation (Python `eth_account`) over identical input — the two agree byte-for-byte.

**`src/x402.js` — allowance preflight + multi-asset registry**
- Permit2 requires a one-time on-chain `token.approve(PERMIT2_ADDRESS, …)` from the payer. Entries are skipped with an actionable message when the allowance is missing, instead of burning a doomed verify round-trip. RPC failures fail open (server decides).
- `EVM_X402_TOKENS` becomes an ordered per-network token list (BSC: U, USD1, USDT, USDC — all 18-decimal BEP-20 deployments); RPC URLs split into `EVM_X402_RPCS`.
- `checkX402Balance(network, asset)` checks the token actually paid with, so low-balance warnings use the right symbol and decimals.

**`src/api.js`** — threads the paid asset through to the balance warning.

## Testing

- New `x402-permit2.test.js` (7 tests): reference digest vector, payload wire shape (decimal-string numerics, no EIP-3009 fields), missing-spender error, method routing (permit2-exact / eip3009 / absent / unsupported).
- Registry tests updated for the multi-asset shape.
- Full suite: 1498 passed.

## Notes

- Wallets holding U or USD1 pay on BSC with no extra steps. Wallets paying USDT/USDC on BSC need the one-time Permit2 approval (requires a little BNB for that single transaction; every payment after is a gasless signature).
- `permit2-upto` is intentionally unsupported for now — the CLI only uses exact-amount payments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
