### PR TITLE
feat(perp-screener): add trader_type, sectors_filter, sm_label and trader_label filters (ECINT-6680)

### DIFF
--- a/.changeset/perp-screener-new-filters.md
+++ b/.changeset/perp-screener-new-filters.md
@@ -1,0 +1,11 @@
+---
+"nansen-cli": minor
+---
+
+Add trader_type, sectors_filter, sm_label_filter, and trader_label_filter filters to `nansen research perp screener` (ECINT-6680).
+
+New CLI options:
+- `--trader-type <type>` — filter by trader type: all, sm, whale, public_figure, high_winrate_hl_perps_trader
+- `--sectors-filter <sectors>` — comma-separated sector:subcategory pairs, e.g. "Crypto:AI,TradFi:Stocks"
+- `--sm-label-filter <labels>` — comma-separated Nansen SM labels (applies when trader-type is all or sm)
+- `--trader-label-filter <labels>` — comma-separated HL perps trader labels (applies when trader-type is all or sm)

--- a/skills/nansen-perp-screener/SKILL.md
+++ b/skills/nansen-perp-screener/SKILL.md
@@ -30,3 +30,62 @@ nansen research perp leaderboard --days 7 --limit 20
 nansen research smart-money perp-trades --limit 20
 # → token_symbol, side, action (Open/Close), value_usd, price_usd, trader_address_label
 ```
+
+## New Filters (ECINT-6680)
+
+### `--trader-type`
+Filter by trader type. Accepted values: `all` (default), `sm`, `whale`, `public_figure`, `high_winrate_hl_perps_trader`.
+
+```bash
+# Show only whale traders
+nansen research perp screener --trader-type whale --limit 10
+
+# Show only smart money traders
+nansen research perp screener --trader-type sm --limit 20
+
+# Show high win-rate HL perps traders
+nansen research perp screener --trader-type high_winrate_hl_perps_trader --limit 20
+```
+
+### `--sm-label-filter`
+Comma-separated Nansen SM labels to filter by. Only applies when `--trader-type` is `all` or `sm`.
+
+```bash
+# Filter to a specific SM label
+nansen research perp screener --trader-type sm --sm-label-filter "30D Smart Trader"
+
+# Multiple labels
+nansen research perp screener --sm-label-filter "30D Smart Trader,Smart LP"
+```
+
+### `--trader-label-filter`
+Comma-separated HL perps trader labels to filter by. Only applies when `--trader-type` is `all` or `sm`.
+
+```bash
+# Filter to HL Perps Whale label
+nansen research perp screener --trader-label-filter "HL Perps Whale"
+```
+
+### `--sectors-filter`
+Comma-separated `category:subcategory` pairs to filter coins by sector.
+
+```bash
+# Filter to AI and DeFi crypto sectors
+nansen research perp screener --sectors-filter "Crypto:AI,Crypto:DeFi" --trader-type whale
+
+# Combine with trader type and limit
+nansen research perp screener --sectors-filter "Crypto:AI,Crypto:DeFi" --trader-type whale --limit 10 --sort volume:desc
+```
+
+## Combined Examples
+
+```bash
+# Whale traders in AI crypto, sorted by volume
+nansen research perp screener --trader-type whale --sectors-filter "Crypto:AI" --sort volume:desc --limit 10
+
+# Smart money with specific label, last 7 days
+nansen research perp screener --trader-type sm --sm-label-filter "30D Smart Trader" --days 7 --limit 20
+
+# All traders in TradFi stocks sector
+nansen research perp screener --sectors-filter "TradFi:Stocks" --sort open_interest:desc --limit 20
+```

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -236,6 +236,11 @@ const MOCK_RESPONSES = {
       { address: '0x123', pnl_usd: 500000 }
     ]
   },
+  perpScreener: {
+    data: [
+      { token_symbol: 'BTC', volume: 1000000, open_interest: 500000, mark_price: 95000 }
+    ]
+  },
   perpLeaderboard: {
     leaders: [
       { address: '0x123', pnl_usd: 200000 }
@@ -1801,6 +1806,74 @@ describe('NansenAPI', () => {
   // =================== Perp Endpoints ===================
 
   describe('Perp', () => {
+    describe('perpScreener', () => {
+      it('should fetch perp screener with correct endpoint', async () => {
+        setupMock(MOCK_RESPONSES.perpScreener);
+
+        const result = await api.perpScreener({});
+
+        const body = expectFetchCalledWith('/api/v1/perp-screener');
+        expect(body.date).toBeDefined();
+        expect(result.data).toBeInstanceOf(Array);
+      });
+
+      it('should include trader_type when provided', async () => {
+        setupMock(MOCK_RESPONSES.perpScreener);
+
+        await api.perpScreener({ traderType: 'whale' });
+
+        const body = expectFetchCalledWith('/api/v1/perp-screener');
+        expect(body.trader_type).toBe('whale');
+      });
+
+      it('should not include trader_type when not provided', async () => {
+        setupMock(MOCK_RESPONSES.perpScreener);
+
+        await api.perpScreener({});
+
+        const body = expectFetchCalledWith('/api/v1/perp-screener');
+        expect(body.trader_type).toBeUndefined();
+      });
+
+      it('should include sectors_filter array when provided', async () => {
+        setupMock(MOCK_RESPONSES.perpScreener);
+
+        await api.perpScreener({ sectorsFilter: ['Crypto:AI', 'Crypto:DeFi'] });
+
+        const body = expectFetchCalledWith('/api/v1/perp-screener');
+        expect(body.sectors_filter).toEqual(['Crypto:AI', 'Crypto:DeFi']);
+      });
+
+      it('should include sm_label_filter when provided', async () => {
+        setupMock(MOCK_RESPONSES.perpScreener);
+
+        await api.perpScreener({ smLabelFilter: ['30D Smart Trader'] });
+
+        const body = expectFetchCalledWith('/api/v1/perp-screener');
+        expect(body.sm_label_filter).toEqual(['30D Smart Trader']);
+      });
+
+      it('should include trader_label_filter when provided', async () => {
+        setupMock(MOCK_RESPONSES.perpScreener);
+
+        await api.perpScreener({ traderLabelFilter: ['HL Perps Whale'] });
+
+        const body = expectFetchCalledWith('/api/v1/perp-screener');
+        expect(body.trader_label_filter).toEqual(['HL Perps Whale']);
+      });
+
+      it('should not include optional fields when not provided', async () => {
+        setupMock(MOCK_RESPONSES.perpScreener);
+
+        await api.perpScreener({});
+
+        const body = expectFetchCalledWith('/api/v1/perp-screener');
+        expect(body.sectors_filter).toBeUndefined();
+        expect(body.sm_label_filter).toBeUndefined();
+        expect(body.trader_label_filter).toBeUndefined();
+      });
+    });
+
     describe('perpLeaderboard', () => {
       it('should fetch perp leaderboard with correct endpoint', async () => {
         setupMock(MOCK_RESPONSES.perpLeaderboard);

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -1823,7 +1823,7 @@ describe('NansenAPI', () => {
         await api.perpScreener({ traderType: 'whale' });
 
         const body = expectFetchCalledWith('/api/v1/perp-screener');
-        expect(body.trader_type).toBe('whale');
+        expect(body.filters.trader_type).toBe('whale');
       });
 
       it('should not include trader_type when not provided', async () => {
@@ -1832,7 +1832,7 @@ describe('NansenAPI', () => {
         await api.perpScreener({});
 
         const body = expectFetchCalledWith('/api/v1/perp-screener');
-        expect(body.trader_type).toBeUndefined();
+        expect(body.filters?.trader_type).toBeUndefined();
       });
 
       it('should include sectors_filter array when provided', async () => {
@@ -1841,7 +1841,7 @@ describe('NansenAPI', () => {
         await api.perpScreener({ sectorsFilter: ['Crypto:AI', 'Crypto:DeFi'] });
 
         const body = expectFetchCalledWith('/api/v1/perp-screener');
-        expect(body.sectors_filter).toEqual(['Crypto:AI', 'Crypto:DeFi']);
+        expect(body.filters.sectors_filter).toEqual(['Crypto:AI', 'Crypto:DeFi']);
       });
 
       it('should include sm_label_filter when provided', async () => {
@@ -1850,7 +1850,7 @@ describe('NansenAPI', () => {
         await api.perpScreener({ smLabelFilter: ['30D Smart Trader'] });
 
         const body = expectFetchCalledWith('/api/v1/perp-screener');
-        expect(body.sm_label_filter).toEqual(['30D Smart Trader']);
+        expect(body.filters.sm_label_filter).toEqual(['30D Smart Trader']);
       });
 
       it('should include trader_label_filter when provided', async () => {
@@ -1859,7 +1859,7 @@ describe('NansenAPI', () => {
         await api.perpScreener({ traderLabelFilter: ['HL Perps Whale'] });
 
         const body = expectFetchCalledWith('/api/v1/perp-screener');
-        expect(body.trader_label_filter).toEqual(['HL Perps Whale']);
+        expect(body.filters.trader_label_filter).toEqual(['HL Perps Whale']);
       });
 
       it('should not include optional fields when not provided', async () => {
@@ -1868,9 +1868,9 @@ describe('NansenAPI', () => {
         await api.perpScreener({});
 
         const body = expectFetchCalledWith('/api/v1/perp-screener');
-        expect(body.sectors_filter).toBeUndefined();
-        expect(body.sm_label_filter).toBeUndefined();
-        expect(body.trader_label_filter).toBeUndefined();
+        expect(body.filters?.sectors_filter).toBeUndefined();
+        expect(body.filters?.sm_label_filter).toBeUndefined();
+        expect(body.filters?.trader_label_filter).toBeUndefined();
       });
     });
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -4757,3 +4757,78 @@ describe('alerts update -- type-specific validation', () => {
     expect(mockApi.alertsUpdate).toHaveBeenCalled();
   });
 });
+
+describe('perp screener CLI handler - new filters (ECINT-6680)', () => {
+  let commands;
+  let mockApi;
+
+  beforeEach(() => {
+    commands = buildCommands({});
+    mockApi = {
+      perpScreener: vi.fn().mockResolvedValue({ data: [] }),
+      perpLeaderboard: vi.fn().mockResolvedValue({ leaders: [] }),
+    };
+  });
+
+  it('dispatches screener with no new options (baseline)', async () => {
+    await commands['perp'](['screener'], mockApi, {}, { days: '7' });
+    expect(mockApi.perpScreener).toHaveBeenCalledWith(expect.objectContaining({
+      days: 7,
+    }));
+    const call = mockApi.perpScreener.mock.calls[0][0];
+    expect(call.traderType).toBeUndefined();
+    expect(call.sectorsFilter).toBeUndefined();
+    expect(call.smLabelFilter).toBeUndefined();
+    expect(call.traderLabelFilter).toBeUndefined();
+  });
+
+  it('passes trader-type through to perpScreener', async () => {
+    await commands['perp'](['screener'], mockApi, {}, { 'trader-type': 'whale' });
+    expect(mockApi.perpScreener).toHaveBeenCalledWith(expect.objectContaining({
+      traderType: 'whale',
+    }));
+  });
+
+  it('splits sectors-filter CSV into array', async () => {
+    await commands['perp'](['screener'], mockApi, {}, { 'sectors-filter': 'Crypto:AI,Crypto:DeFi' });
+    expect(mockApi.perpScreener).toHaveBeenCalledWith(expect.objectContaining({
+      sectorsFilter: ['Crypto:AI', 'Crypto:DeFi'],
+    }));
+  });
+
+  it('splits sm-label-filter CSV into array', async () => {
+    await commands['perp'](['screener'], mockApi, {}, { 'sm-label-filter': '30D Smart Trader,Smart LP' });
+    expect(mockApi.perpScreener).toHaveBeenCalledWith(expect.objectContaining({
+      smLabelFilter: ['30D Smart Trader', 'Smart LP'],
+    }));
+  });
+
+  it('splits trader-label-filter CSV into array', async () => {
+    await commands['perp'](['screener'], mockApi, {}, { 'trader-label-filter': 'HL Perps Whale' });
+    expect(mockApi.perpScreener).toHaveBeenCalledWith(expect.objectContaining({
+      traderLabelFilter: ['HL Perps Whale'],
+    }));
+  });
+
+  it('handles single-value sectors-filter (no comma)', async () => {
+    await commands['perp'](['screener'], mockApi, {}, { 'sectors-filter': 'Crypto:AI' });
+    expect(mockApi.perpScreener).toHaveBeenCalledWith(expect.objectContaining({
+      sectorsFilter: ['Crypto:AI'],
+    }));
+  });
+
+  it('passes all four new options together', async () => {
+    await commands['perp'](['screener'], mockApi, {}, {
+      'trader-type': 'sm',
+      'sectors-filter': 'Crypto:AI',
+      'sm-label-filter': '30D Smart Trader',
+      'trader-label-filter': 'HL Perps Whale',
+    });
+    expect(mockApi.perpScreener).toHaveBeenCalledWith(expect.objectContaining({
+      traderType: 'sm',
+      sectorsFilter: ['Crypto:AI'],
+      smLabelFilter: ['30D Smart Trader'],
+      traderLabelFilter: ['HL Perps Whale'],
+    }));
+  });
+});

--- a/src/api.js
+++ b/src/api.js
@@ -1194,10 +1194,10 @@ export class NansenAPI {
       order_by: orderBy,
       pagination
     };
-    if (traderType !== undefined) body.trader_type = traderType;
-    if (sectorsFilter !== undefined) body.sectors_filter = sectorsFilter;
-    if (smLabelFilter !== undefined) body.sm_label_filter = smLabelFilter;
-    if (traderLabelFilter !== undefined) body.trader_label_filter = traderLabelFilter;
+    if (traderType !== undefined) body.filters.trader_type = traderType;
+    if (sectorsFilter !== undefined) body.filters.sectors_filter = sectorsFilter;
+    if (smLabelFilter !== undefined) body.filters.sm_label_filter = smLabelFilter;
+    if (traderLabelFilter !== undefined) body.filters.trader_label_filter = traderLabelFilter;
     return this.request('/api/v1/perp-screener', body);
   }
 

--- a/src/api.js
+++ b/src/api.js
@@ -1187,13 +1187,18 @@ export class NansenAPI {
   // ============= Perp Endpoints =============
 
   async perpScreener(params = {}) {
-    const { filters = {}, orderBy, pagination, days = 30 } = params;
-    return this.request('/api/v1/perp-screener', {
+    const { filters = {}, orderBy, pagination, days = 30, traderType, sectorsFilter, smLabelFilter, traderLabelFilter } = params;
+    const body = {
       date: buildDateRange(days),
       filters,
       order_by: orderBy,
       pagination
-    });
+    };
+    if (traderType !== undefined) body.trader_type = traderType;
+    if (sectorsFilter !== undefined) body.sectors_filter = sectorsFilter;
+    if (smLabelFilter !== undefined) body.sm_label_filter = smLabelFilter;
+    if (traderLabelFilter !== undefined) body.trader_label_filter = traderLabelFilter;
+    return this.request('/api/v1/perp-screener', body);
   }
 
   async perpLeaderboard(params = {}) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1367,7 +1367,19 @@ export function buildCommands(deps = {}) {
       const days = options.days ? parseInt(options.days) : 30;
 
       const handlers = {
-        'screener': () => apiInstance.perpScreener({ filters, orderBy, pagination, days }),
+        'screener': () => {
+          const traderType = options['trader-type'];
+          const sectorsFilter = options['sectors-filter']
+            ? options['sectors-filter'].split(',').map(s => s.trim()).filter(Boolean)
+            : undefined;
+          const smLabelFilter = options['sm-label-filter']
+            ? options['sm-label-filter'].split(',').map(s => s.trim()).filter(Boolean)
+            : undefined;
+          const traderLabelFilter = options['trader-label-filter']
+            ? options['trader-label-filter'].split(',').map(s => s.trim()).filter(Boolean)
+            : undefined;
+          return apiInstance.perpScreener({ filters, orderBy, pagination, days, traderType, sectorsFilter, smLabelFilter, traderLabelFilter });
+        },
         'leaderboard': () => {
           const withLabels = resolveBooleanOption(options, flags, 'premium-labels');
           return apiInstance.perpLeaderboard({ filters, orderBy, pagination, days, withLabels });

--- a/src/schema.json
+++ b/src/schema.json
@@ -522,7 +522,11 @@
               "options": {
                 "market-cap": {
                   "description": "Filter by market cap group",
-                  "enum": ["lowcap", "midcap", "largecap"]
+                  "enum": [
+                    "lowcap",
+                    "midcap",
+                    "largecap"
+                  ]
                 },
                 "limit": {
                   "default": 25
@@ -555,6 +559,25 @@
               "options": {
                 "days": {
                   "default": 30
+                },
+                "trader-type": {
+                  "description": "Filter by trader type. One of: all, sm, whale, public_figure, high_winrate_hl_perps_trader. Defaults to all.",
+                  "enum": [
+                    "all",
+                    "sm",
+                    "whale",
+                    "public_figure",
+                    "high_winrate_hl_perps_trader"
+                  ]
+                },
+                "sectors-filter": {
+                  "description": "Comma-separated sector:subcategory pairs to filter by, e.g. \"Crypto:AI,TradFi:Stocks\"."
+                },
+                "sm-label-filter": {
+                  "description": "Comma-separated Nansen SM labels to filter by, e.g. \"30D Smart Trader\". Only applies when trader-type is all or sm."
+                },
+                "trader-label-filter": {
+                  "description": "Comma-separated HL perps trader labels to filter by, e.g. \"HL Perps Whale\". Only applies when trader-type is all or sm."
                 }
               }
             },
@@ -616,8 +639,12 @@
               "endpoint": "/api/v1/prediction-market/market-screener",
               "description": "Get Prediction Market Screener",
               "options": {
-                "query": { "default": "" },
-                "sort-by": { "description": "Deprecated: use --sort field:dir instead" },
+                "query": {
+                  "default": ""
+                },
+                "sort-by": {
+                  "description": "Deprecated: use --sort field:dir instead"
+                },
                 "tags": {},
                 "min-liquidity": {},
                 "max-liquidity": {},
@@ -638,8 +665,12 @@
               "endpoint": "/api/v1/prediction-market/event-screener",
               "description": "Get Prediction Market Event Screener",
               "options": {
-                "query": { "default": "" },
-                "sort-by": { "description": "Deprecated: use --sort field:dir instead" },
+                "query": {
+                  "default": ""
+                },
+                "sort-by": {
+                  "description": "Deprecated: use --sort field:dir instead"
+                },
                 "tags": {},
                 "min-liquidity": {},
                 "max-liquidity": {},
@@ -717,104 +748,218 @@
           "endpoint": "/api/v1beta1/tgm/historical-dex-trades",
           "description": "Historical DEX trades for a token at a point in time",
           "options": {
-            "token-address": { "required": true, "description": "Token address" },
-            "from-date": { "required": true, "description": "Start of date range (YYYY-MM-DD)" },
-            "to-date": { "required": true, "description": "End of date range (YYYY-MM-DD)" },
-            "chain": { "default": "solana", "description": "Chain" }
+            "token-address": {
+              "required": true,
+              "description": "Token address"
+            },
+            "from-date": {
+              "required": true,
+              "description": "Start of date range (YYYY-MM-DD)"
+            },
+            "to-date": {
+              "required": true,
+              "description": "End of date range (YYYY-MM-DD)"
+            },
+            "chain": {
+              "default": "solana",
+              "description": "Chain"
+            }
           }
         },
         "historical-pnl-leaderboard": {
           "endpoint": "/api/v1beta1/tgm/historical-pnl-leaderboard",
           "description": "Historical PnL leaderboard for a token",
           "options": {
-            "token-address": { "required": true, "description": "Token address" },
-            "from-date": { "required": true, "description": "Start of date range (YYYY-MM-DD)" },
-            "to-date": { "required": true, "description": "End of date range (YYYY-MM-DD)" },
-            "chain": { "default": "solana", "description": "Chain" }
+            "token-address": {
+              "required": true,
+              "description": "Token address"
+            },
+            "from-date": {
+              "required": true,
+              "description": "Start of date range (YYYY-MM-DD)"
+            },
+            "to-date": {
+              "required": true,
+              "description": "End of date range (YYYY-MM-DD)"
+            },
+            "chain": {
+              "default": "solana",
+              "description": "Chain"
+            }
           }
         },
         "historical-token-flow-summary": {
           "endpoint": "/api/v1beta1/tgm/historical-token-flow-summary",
           "description": "Historical token flow summary (no pagination)",
           "options": {
-            "token-address": { "required": true, "description": "Token address" },
-            "from-date": { "required": true, "description": "Start of date range (YYYY-MM-DD)" },
-            "to-date": { "required": true, "description": "End of date range (YYYY-MM-DD)" },
-            "chain": { "default": "solana", "description": "Chain" }
+            "token-address": {
+              "required": true,
+              "description": "Token address"
+            },
+            "from-date": {
+              "required": true,
+              "description": "Start of date range (YYYY-MM-DD)"
+            },
+            "to-date": {
+              "required": true,
+              "description": "End of date range (YYYY-MM-DD)"
+            },
+            "chain": {
+              "default": "solana",
+              "description": "Chain"
+            }
           }
         },
         "historical-token-quant-scores": {
           "endpoint": "/api/v1beta1/tgm/historical-token-quant-scores",
           "description": "Historical token quantitative scores at a snapshot date",
           "options": {
-            "token-address": { "required": true, "description": "Token address" },
-            "as-of-date": { "required": true, "description": "Snapshot date (YYYY-MM-DD)" },
-            "chain": { "default": "solana", "description": "Chain" }
+            "token-address": {
+              "required": true,
+              "description": "Token address"
+            },
+            "as-of-date": {
+              "required": true,
+              "description": "Snapshot date (YYYY-MM-DD)"
+            },
+            "chain": {
+              "default": "solana",
+              "description": "Chain"
+            }
           }
         },
         "historical-top-holders": {
           "endpoint": "/api/v1beta1/tgm/historical-top-holders",
           "description": "Historical top holders of a token at a snapshot date",
           "options": {
-            "token-address": { "required": true, "description": "Token address" },
-            "as-of-date": { "required": true, "description": "Snapshot date (YYYY-MM-DD)" },
-            "chain": { "default": "solana", "description": "Chain" }
+            "token-address": {
+              "required": true,
+              "description": "Token address"
+            },
+            "as-of-date": {
+              "required": true,
+              "description": "Snapshot date (YYYY-MM-DD)"
+            },
+            "chain": {
+              "default": "solana",
+              "description": "Chain"
+            }
           }
         },
         "historical-who-bought-sold": {
           "endpoint": "/api/v1beta1/tgm/historical-who-bought-sold",
           "description": "Historical buyers/sellers of a token",
           "options": {
-            "token-address": { "required": true, "description": "Token address" },
-            "from-date": { "required": true, "description": "Start of date range (YYYY-MM-DD)" },
-            "to-date": { "required": true, "description": "End of date range (YYYY-MM-DD)" },
-            "buy-or-sell": { "default": "BUY", "description": "BUY or SELL" },
-            "chain": { "default": "solana", "description": "Chain" }
+            "token-address": {
+              "required": true,
+              "description": "Token address"
+            },
+            "from-date": {
+              "required": true,
+              "description": "Start of date range (YYYY-MM-DD)"
+            },
+            "to-date": {
+              "required": true,
+              "description": "End of date range (YYYY-MM-DD)"
+            },
+            "buy-or-sell": {
+              "default": "BUY",
+              "description": "BUY or SELL"
+            },
+            "chain": {
+              "default": "solana",
+              "description": "Chain"
+            }
           }
         },
         "historical-smart-money-balances": {
           "endpoint": "/api/v1beta1/smart-money/historical-token-balances",
           "description": "Historical smart money token balances at a snapshot date (no order_by)",
           "options": {
-            "as-of-date": { "required": true, "description": "Snapshot date (YYYY-MM-DD)" },
-            "chains": { "default": "solana", "description": "Comma-separated chains" }
+            "as-of-date": {
+              "required": true,
+              "description": "Snapshot date (YYYY-MM-DD)"
+            },
+            "chains": {
+              "default": "solana",
+              "description": "Comma-separated chains"
+            }
           }
         },
         "historical-token-screener": {
           "endpoint": "/api/v1beta1/token-screener/historical",
           "description": "Historical token screener over a trailing window",
           "options": {
-            "timeframe-days": { "required": true, "type": "number", "description": "Trailing window size in days" },
-            "to-date": { "required": true, "description": "End date for the window (YYYY-MM-DD)" },
-            "chains": { "default": "solana", "description": "Comma-separated chains" }
+            "timeframe-days": {
+              "required": true,
+              "type": "number",
+              "description": "Trailing window size in days"
+            },
+            "to-date": {
+              "required": true,
+              "description": "End date for the window (YYYY-MM-DD)"
+            },
+            "chains": {
+              "default": "solana",
+              "description": "Comma-separated chains"
+            }
           }
         },
         "historical-wallet-balances": {
           "endpoint": "/api/v1beta1/profiler/address/historical-token-balances",
           "description": "Historical token balances for a wallet at a snapshot date",
           "options": {
-            "address": { "required": true, "description": "Wallet address" },
-            "as-of-date": { "required": true, "description": "Snapshot date (YYYY-MM-DD)" },
-            "chain": { "default": "ethereum", "description": "Chain" }
+            "address": {
+              "required": true,
+              "description": "Wallet address"
+            },
+            "as-of-date": {
+              "required": true,
+              "description": "Snapshot date (YYYY-MM-DD)"
+            },
+            "chain": {
+              "default": "ethereum",
+              "description": "Chain"
+            }
           }
         },
         "historical-tx-lookup": {
           "endpoint": "/api/v1beta1/profiler/historical-transaction-lookup",
           "description": "Lookup a historical transaction by hash",
           "options": {
-            "transaction-hash": { "required": true, "description": "Transaction hash (0x-prefixed, 66 chars)" },
-            "as-of-date": { "required": true, "description": "Reference date for label and pricing resolution (YYYY-MM-DD)" },
-            "block-timestamp": { "description": "Block timestamp (YYYY-MM-DD HH:MM:SS) — skips slow hash-resolution step if provided" },
-            "chain": { "default": "ethereum", "description": "Chain (ethereum, bnb, base)" }
+            "transaction-hash": {
+              "required": true,
+              "description": "Transaction hash (0x-prefixed, 66 chars)"
+            },
+            "as-of-date": {
+              "required": true,
+              "description": "Reference date for label and pricing resolution (YYYY-MM-DD)"
+            },
+            "block-timestamp": {
+              "description": "Block timestamp (YYYY-MM-DD HH:MM:SS) \u2014 skips slow hash-resolution step if provided"
+            },
+            "chain": {
+              "default": "ethereum",
+              "description": "Chain (ethereum, bnb, base)"
+            }
           }
         },
         "historical-wallet-transactions": {
           "endpoint": "/api/v1beta1/profiler/address/historical-transactions",
           "description": "Historical transactions for a wallet at a snapshot date",
           "options": {
-            "address": { "required": true, "description": "Wallet address" },
-            "as-of-date": { "required": true, "description": "Snapshot date (YYYY-MM-DD)" },
-            "chain": { "default": "ethereum", "description": "Chain" }
+            "address": {
+              "required": true,
+              "description": "Wallet address"
+            },
+            "as-of-date": {
+              "required": true,
+              "description": "Snapshot date (YYYY-MM-DD)"
+            },
+            "chain": {
+              "default": "ethereum",
+              "description": "Chain"
+            }
           }
         }
       }
@@ -971,7 +1116,7 @@
             },
             "to-chain": {
               "type": "string",
-              "description": "Destination blockchain for cross-chain swap (solana or base). Omit for same-chain. At least one side must be USDC or a native token (ETH, SOL). Non-native to non-native is not supported — swap to USDC first, then bridge. Bridge providers (Li.Fi or Relay) are selected automatically based on best price. Sub-dollar swaps are supported via Relay."
+              "description": "Destination blockchain for cross-chain swap (solana or base). Omit for same-chain. At least one side must be USDC or a native token (ETH, SOL). Non-native to non-native is not supported \u2014 swap to USDC first, then bridge. Bridge providers (Li.Fi or Relay) are selected automatically based on best price. Sub-dollar swaps are supported via Relay."
             },
             "from": {
               "type": "string",
@@ -1047,7 +1192,7 @@
             },
             "aggregator": {
               "type": "string",
-              "description": "lifi or relay. Overrides auto-detection — use when polling from a different machine or after the 30-day local record TTL has expired."
+              "description": "lifi or relay. Overrides auto-detection \u2014 use when polling from a different machine or after the 30-day local record TTL has expired."
             }
           }
         },
@@ -1101,7 +1246,9 @@
                   "description": "Wallet name (or \"walletconnect\"/\"wc\")"
                 }
               },
-              "chains": ["solana"],
+              "chains": [
+                "solana"
+              ],
               "prerequisites": [
                 "A Solana wallet must be configured. Run: nansen wallet create"
               ]
@@ -1141,7 +1288,9 @@
                   "description": "Wallet name (or \"walletconnect\"/\"wc\")"
                 }
               },
-              "chains": ["solana"]
+              "chains": [
+                "solana"
+              ]
             },
             "cancel": {
               "description": "Cancel an open limit order",
@@ -1156,7 +1305,9 @@
                   "description": "Wallet name (or \"walletconnect\"/\"wc\")"
                 }
               },
-              "chains": ["solana"]
+              "chains": [
+                "solana"
+              ]
             },
             "update": {
               "description": "Update trigger price or slippage on an existing order",
@@ -1179,7 +1330,9 @@
                   "description": "Wallet name (or \"walletconnect\"/\"wc\")"
                 }
               },
-              "chains": ["solana"]
+              "chains": [
+                "solana"
+              ]
             }
           }
         }


### PR DESCRIPTION
## Summary

Adds CLI support for four new filter parameters on the `POST /api/v1/perp-screener` endpoint (ECINT-6680).

## New Filters

### `--trader-type <type`
Filter by trader type. Replaces/deprecates the old `only_smart_money` field on the API side.
Accepted values: `all` (default), `sm`, `whale`, `public_figure`, `high_winrate_hl_perps_trader`

```bash
nansen research perp screener --trader-type whale --limit 10
nansen research perp screener --trader-type sm --limit 20
```

### `--sectors-filter <sectors>`
Comma-separated `category:subcategory` pairs. Filters results to coins in those sectors.
Example: `"Crypto:AI,TradFi:Stocks"` → sent as `["Crypto:AI", "TradFi:Stocks"]`

```bash
nansen research perp screener --sectors-filter "Crypto:AI,Crypto:DeFi" --trader-type whale
```

### `--sm-label-filter <labels>`
Comma-separated Nansen SM labels. Only applies when `--trader-type` is `all` or `sm`.

```bash
nansen research perp screener --trader-type sm --sm-label-filter "30D Smart Trader"
```

### `--trader-label-filter <labels>`
Comma-separated HL perps trader labels. Only applies when `--trader-type` is `all` or `sm`.

```bash
nansen research perp screener --trader-label-filter "HL Perps Whale"
```

## Changes

- `src/api.js`: Updated `perpScreener()` to accept and pass `traderType`, `sectorsFilter`, `smLabelFilter`, `traderLabelFilter`
- `src/cli.js`: Updated perp screener handler to parse new CLI options and forward them (comma-separated strings split to arrays)
- `src/schema.json`: Added new options to `commands.research.subcommands.perp.subcommands.screener.options`
- `skills/nansen-perp-screener/SKILL.md`: Added usage examples for all four new filters
- `src/__tests__/api.test.js`: Added 6 tests for `perpScreener` API method
- `src/__tests__/cli.internal.test.js`: Added 7 tests for CLI handler option wiring

Closes ECINT-6680