### PR TITLE
fix: quote/execute --help exit 0 with usage

### DIFF
--- a/.changeset/fix-quote-help-exit-code.md
+++ b/.changeset/fix-quote-help-exit-code.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix `nansen quote --help`, `nansen trade quote --help`, and `nansen execute --help` to print the trade usage and exit with code 0 instead of erroring with exit code 1.

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -66,6 +66,26 @@ describe('CLI Smoke Tests', () => {
     expect(stdout).toContain('wallet');
   });
 
+  // Regression for #155: --help on a handler command (quote/execute) used to fall
+  // through to command execution, which errored on missing args and exited 1.
+  it('quote --help exits 0 and shows trade usage', () => {
+    const { stdout, exitCode } = runCLI('quote --help');
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('nansen trade');
+    expect(stdout).toContain('quote');
+  });
+
+  it('trade quote --help exits 0', () => {
+    const { exitCode } = runCLI('trade quote --help');
+    expect(exitCode).toBe(0);
+  });
+
+  it('execute --help exits 0', () => {
+    const { exitCode } = runCLI('execute --help');
+    expect(exitCode).toBe(0);
+  });
+
   it('should show schema', () => {
     const { stdout, exitCode } = runCLI('schema');
     

--- a/src/cli.js
+++ b/src/cli.js
@@ -745,6 +745,51 @@ Skills: npx skills add nansen-ai/nansen-cli (agent-optimised docs per command gr
 Telemetry: anonymous usage stats collected. Disable: DO_NOT_TRACK=1
 `;
 
+// Usage text for the `trade` command group. Shared by the trade handler and the
+// --help path in runCLI, so `nansen trade`, `nansen trade <sub> --help`, and the
+// deprecated top-level `quote`/`execute --help` all show the same usage.
+export const TRADE_USAGE = `nansen trade — DEX trading commands
+
+SUBCOMMANDS:
+  quote          Get a swap quote (price, route, fees)
+  execute        Sign and broadcast a quoted swap
+  bridge-status  Check cross-chain bridge transaction status
+  limit-order    Limit order management (Solana only)
+
+USAGE:
+  nansen trade quote --chain <chain> --from <token> --to <token> --amount <units> [--wallet <name>]
+  nansen trade quote --chain <chain> --to-chain <chain> --from <token> --to <token> --amount <units>
+  nansen trade execute --quote <quoteId> [--wallet <name>]
+  nansen trade bridge-status --tx-hash <hash> --from-chain <chain> --to-chain <chain>
+  nansen trade limit-order <create|list|cancel|update> [options]
+
+EXAMPLES:
+  nansen trade quote --chain solana --from SOL --to USDC --amount 1000000000
+  nansen trade quote --chain base --from ETH --to USDC --amount 1000000000000000000
+  nansen trade quote --chain base --to-chain solana --from USDC --to USDC --amount 1000000
+  nansen trade execute --quote 1708900000000-abc123
+  nansen trade bridge-status --tx-hash 0xabc... --from-chain base --to-chain solana
+  nansen trade limit-order create --from SOL --to USDC --amount 1.5 --trigger-mint SOL --trigger-condition below --trigger-price 80
+  nansen trade limit-order list
+
+WALLET:
+  --wallet <name>   Use a named wallet, or "walletconnect" / "wc" for WalletConnect.
+                    Defaults to the default local wallet if omitted.
+
+SYMBOLS:
+  Common tokens resolve automatically: SOL, ETH, USDC, USDT, WETH
+  Raw addresses are also accepted.
+
+CROSS-CHAIN NOTES (when using --to-chain):
+  Supported combos:
+    native → native (ETH <-> SOL)
+    USDC → USDC (both directions)
+    USDC → native (USDC → ETH or SOL)
+    native → USDC (ETH/SOL → USDC)
+    non-native → non-native — not supported (use USDC as intermediate)
+  Bridge providers: Li.Fi or Relay (selected automatically based on best price)
+  Typical bridge time: 1-5 minutes`;
+
 // Helper to prompt for input (exported for mocking)
 export async function prompt(question, hidden = false) {
   return new Promise((resolve) => {
@@ -1517,47 +1562,7 @@ export function buildCommands(deps = {}) {
   cmds['trade'] = async (args, apiInstance, flags, options) => {
     const sub = args[0];
     if (!sub || sub === 'help') {
-      log(`nansen trade — DEX trading commands
-
-SUBCOMMANDS:
-  quote          Get a swap quote (price, route, fees)
-  execute        Sign and broadcast a quoted swap
-  bridge-status  Check cross-chain bridge transaction status
-  limit-order    Limit order management (Solana only)
-
-USAGE:
-  nansen trade quote --chain <chain> --from <token> --to <token> --amount <units> [--wallet <name>]
-  nansen trade quote --chain <chain> --to-chain <chain> --from <token> --to <token> --amount <units>
-  nansen trade execute --quote <quoteId> [--wallet <name>]
-  nansen trade bridge-status --tx-hash <hash> --from-chain <chain> --to-chain <chain>
-  nansen trade limit-order <create|list|cancel|update> [options]
-
-EXAMPLES:
-  nansen trade quote --chain solana --from SOL --to USDC --amount 1000000000
-  nansen trade quote --chain base --from ETH --to USDC --amount 1000000000000000000
-  nansen trade quote --chain base --to-chain solana --from USDC --to USDC --amount 1000000
-  nansen trade execute --quote 1708900000000-abc123
-  nansen trade bridge-status --tx-hash 0xabc... --from-chain base --to-chain solana
-  nansen trade limit-order create --from SOL --to USDC --amount 1.5 --trigger-mint SOL --trigger-condition below --trigger-price 80
-  nansen trade limit-order list
-
-WALLET:
-  --wallet <name>   Use a named wallet, or "walletconnect" / "wc" for WalletConnect.
-                    Defaults to the default local wallet if omitted.
-
-SYMBOLS:
-  Common tokens resolve automatically: SOL, ETH, USDC, USDT, WETH
-  Raw addresses are also accepted.
-
-CROSS-CHAIN NOTES (when using --to-chain):
-  Supported combos:
-    native → native (ETH <-> SOL)
-    USDC → USDC (both directions)
-    USDC → native (USDC → ETH or SOL)
-    native → USDC (ETH/SOL → USDC)
-    non-native → non-native — not supported (use USDC as intermediate)
-  Bridge providers: Li.Fi or Relay (selected automatically based on best price)
-  Typical bridge time: 1-5 minutes`);
+      log(TRADE_USAGE);
       return;
     }
     if (sub === 'limit-order') {
@@ -1806,7 +1811,16 @@ export async function runCLI(rawArgs, deps = {}) {
         return { type: 'command-help', command };
       }
     }
-    // Commands with handlers (e.g. quote, execute) show their own usage
+    // The trade group (and the deprecated top-level quote/execute aliases) use
+    // handler-based usage rather than schema help. Show it and exit 0, instead of
+    // falling through to command execution, which would error on missing required
+    // args and exit 1.
+    if (command === 'trade' || DEPRECATED_TO_TRADE.has(command)) {
+      output(deprecationNote(command) + TRADE_USAGE);
+      notify();
+      return { type: 'command-help', command };
+    }
+    // 'help' and unknown commands: full banner + command list
     if (command === 'help' || !commands[command]) {
       output(BANNER + HELP);
       notify();


### PR DESCRIPTION
Summary
`nansen quote --help` exited with code 1 instead of 0 (#155). Same for
`nansen trade quote --help` and `nansen execute --help`.

Root cause: in `runCLI`'s help block, commands backed by a handler
(`quote`/`execute`/`trade`) match no help branch and fall through to *executing*
the command with `--help` set which then throws on missing required args and
exits 1.

Fix: in the help block, the trade group (and the deprecated top-level
`quote`/`execute` aliases) now print usage and return exit 0 instead of falling
through to execution. Extracted the trade usage text into a shared `TRADE_USAGE`
const so the handler and the help path stay in sync.

Fixes #155

How I tested
Added regression tests in `src/__tests__/cli.test.js` asserting exit code 0 for
  `quote --help`, `trade quote --help`, `execute --help`.
Manually: `quote --help` / `trade quote --help` / `execute --help` → exit 0;
  `quote` (no args) still exits 1 (no regression).
`npm run lint` clean. Tests green on CI (Linux). Locally on Windows, 3 unrelated
  suites (`package.test.js`, `index.test.js`) fail on environment issues (`npm pack
  ... 2>/dev/null`; index.js self-import libuv assertion) — not touched by this PR.

Checklist
- [x] Tests pass / added tests with the fix
- [x] `npm run lint` passes
- [x] Changeset added (patch)
- [ ] `src/schema.json` — n/a, no new command/flag
- [ ] README — n/a
