### PR TITLE
feat: surface the API's credit and rate-limit response headers

### DIFF
--- a/.changeset/surface-credit-and-rate-limit-headers.md
+++ b/.changeset/surface-credit-and-rate-limit-headers.md
@@ -1,0 +1,11 @@
+---
+"nansen-cli": minor
+---
+
+Surface the API's credit and rate-limit response headers.
+
+Failed calls now report quota state in their error details: an out-of-credits error carries your actual remaining balance, and a rate-limited error carries the limit, what is left, and how long the window needs to drain. Previously the only credit figure the CLI could show was the static per-endpoint estimate published in the API reference — a quote, not what you were charged.
+
+A warning goes to stderr when your balance will not cover another call of the size just made, so it never interferes with the JSON on stdout.
+
+Successful responses carry the same numbers under an exported `RESPONSE_META` symbol, and the client exposes `lastResponseMeta`. Both are additive: the JSON each command prints is unchanged.

--- a/README.md
+++ b/README.md
@@ -177,17 +177,19 @@ nansen research smart-money netflow --chain solana --fields token_symbol,net_flo
 
 ```json
 { "success": true,  "data": <api_response> }
-{ "success": false, "error": "message", "code": "ERROR_CODE", "status": 401 }
+{ "success": false, "error": "message", "code": "ERROR_CODE", "status": 401, "details": { ... } }
 ```
 
 **Critical error codes:**
 
 | Code | Action |
 |------|--------|
-| `CREDITS_EXHAUSTED` | Stop all API calls immediately. Check [app.nansen.ai](https://app.nansen.ai). |
+| `CREDITS_EXHAUSTED` | Stop all API calls immediately. `details.credits.remaining` is your actual balance. Top up at [app.nansen.ai/api](https://app.nansen.ai/api). |
 | `UNAUTHORIZED` | Wrong or missing key. Re-auth. |
-| `RATE_LIMITED` | Auto-retried by CLI. |
+| `RATE_LIMITED` | Auto-retried by CLI. `details.rateLimit.resetSeconds` is how long the window needs to drain. |
 | `UNSUPPORTED_FILTER` | Remove the filter and retry. |
+
+**Quota metadata.** When the API reports them, `details` carries `credits` (`used`, `remaining`) and `rateLimit` (`limit`, `remaining`, `resetSeconds`) on failures. Any field may be `null`, meaning unknown — never assume zero. A low-balance warning goes to **stderr**, so stdout stays pure JSON.
 
 ## Troubleshooting
 

--- a/src/__tests__/response-meta.test.js
+++ b/src/__tests__/response-meta.test.js
@@ -1,0 +1,195 @@
+/**
+ * Credit + rate-limit response header handling.
+ *
+ * Header bags are mocked as Maps, matching the pattern in api.test.js.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readResponseMeta, creditWarning } from '../response-meta.js';
+import { NansenAPI, RESPONSE_META, ErrorCode } from '../api.js';
+
+function headers(entries) {
+  const map = new Map(Object.entries(entries));
+  return { get: name => (map.has(name) ? map.get(name) : null) };
+}
+
+describe('readResponseMeta', () => {
+  it('parses credit and rate-limit headers', () => {
+    const meta = readResponseMeta({
+      headers: headers({
+        'x-nansen-credits-used': '5',
+        'x-nansen-credits-remaining': '41230',
+        'x-ratelimit-limit': '1500',
+        'x-ratelimit-remaining': '1499',
+        'x-ratelimit-reset': '60',
+      }),
+    });
+
+    expect(meta).toEqual({
+      credits: { used: 5, remaining: 41230 },
+      rateLimit: { limit: 1500, remaining: 1499, resetSeconds: 60 },
+    });
+  });
+
+  it('returns null when no relevant headers are present', () => {
+    expect(readResponseMeta({ headers: headers({}) })).toBeNull();
+  });
+
+  it('tolerates a response with no headers at all', () => {
+    // Most existing success-path mocks look like this.
+    expect(readResponseMeta({ ok: true })).toBeNull();
+    expect(readResponseMeta(undefined)).toBeNull();
+  });
+
+  it('omits the section whose headers are missing', () => {
+    const creditsOnly = readResponseMeta({
+      headers: headers({ 'x-nansen-credits-used': '5', 'x-nansen-credits-remaining': '0' }),
+    });
+    expect(creditsOnly).toEqual({ credits: { used: 5, remaining: 0 } });
+    expect(creditsOnly.rateLimit).toBeUndefined();
+
+    const rateOnly = readResponseMeta({ headers: headers({ 'x-ratelimit-remaining': '3' }) });
+    expect(rateOnly).toEqual({ rateLimit: { limit: null, remaining: 3, resetSeconds: null } });
+    expect(rateOnly.credits).toBeUndefined();
+  });
+
+  it('reads zero as a value, not as absent', () => {
+    const meta = readResponseMeta({
+      headers: headers({ 'x-nansen-credits-used': '0', 'x-nansen-credits-remaining': '0' }),
+    });
+    expect(meta.credits).toEqual({ used: 0, remaining: 0 });
+  });
+
+  it('treats unparseable or negative values as unknown', () => {
+    const meta = readResponseMeta({
+      headers: headers({
+        'x-nansen-credits-used': 'abc',
+        'x-nansen-credits-remaining': '',
+        'x-ratelimit-limit': '-1',
+      }),
+    });
+    expect(meta).toBeNull();
+  });
+});
+
+describe('creditWarning', () => {
+  it('warns when the balance is exhausted', () => {
+    const warning = creditWarning({ credits: { used: 5, remaining: 0 } });
+    expect(warning).toContain('Out of API credits');
+  });
+
+  it('warns when the balance will not cover another call of the same size', () => {
+    const warning = creditWarning({ credits: { used: 10, remaining: 3 } });
+    expect(warning).toContain('3 API credits left');
+    expect(warning).toContain('less than this call cost (10)');
+  });
+
+  it('singularises one remaining credit', () => {
+    expect(creditWarning({ credits: { used: 5, remaining: 1 } })).toContain('1 API credit left');
+  });
+
+  it('stays silent when the balance is comfortable', () => {
+    expect(creditWarning({ credits: { used: 5, remaining: 41230 } })).toBeNull();
+  });
+
+  it('stays silent when remaining is unknown', () => {
+    expect(creditWarning({ credits: { used: 5, remaining: null } })).toBeNull();
+    expect(creditWarning({ rateLimit: { limit: 1500, remaining: 1, resetSeconds: 60 } })).toBeNull();
+    expect(creditWarning(null)).toBeNull();
+  });
+
+  it('stays silent for free endpoints, which charge nothing', () => {
+    expect(creditWarning({ credits: { used: 0, remaining: 5 } })).toBeNull();
+  });
+});
+
+describe('NansenAPI response metadata', () => {
+  let mockFetch;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('attaches metadata to a successful response without changing its JSON', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ netflows: [{ token_symbol: 'TEST' }] }),
+      headers: headers({
+        'x-nansen-credits-used': '5',
+        'x-nansen-credits-remaining': '41230',
+        'x-ratelimit-limit': '1500',
+        'x-ratelimit-remaining': '1499',
+        'x-ratelimit-reset': '60',
+      }),
+    });
+
+    const api = new NansenAPI('test-key');
+    const result = await api.smartMoneyNetflow({ chains: ['solana'] });
+
+    expect(result[RESPONSE_META]).toEqual({
+      credits: { used: 5, remaining: 41230 },
+      rateLimit: { limit: 1500, remaining: 1499, resetSeconds: 60 },
+    });
+    expect(api.lastResponseMeta).toEqual(result[RESPONSE_META]);
+    // The symbol must be invisible to the JSON every command prints.
+    expect(JSON.stringify(result)).toBe('{"netflows":[{"token_symbol":"TEST"}]}');
+    expect(Object.keys(result)).toEqual(['netflows']);
+  });
+
+  it('leaves a header-less success response untouched', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ netflows: [] }) });
+
+    const api = new NansenAPI('test-key');
+    const result = await api.smartMoneyNetflow({ chains: ['solana'] });
+
+    expect(result[RESPONSE_META]).toBeUndefined();
+    expect(api.lastResponseMeta).toBeNull();
+  });
+
+  it('puts the balance on an out-of-credits error, where it matters most', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'Insufficient credits', detail: 'Not enough credits' }),
+      headers: headers({ 'x-nansen-credits-used': '0', 'x-nansen-credits-remaining': '2' }),
+    });
+
+    const api = new NansenAPI('test-key');
+    await expect(api.smartMoneyNetflow({ chains: ['solana'] })).rejects.toMatchObject({
+      code: ErrorCode.CREDITS_EXHAUSTED,
+      details: { credits: { used: 0, remaining: 2 } },
+    });
+  });
+
+  it('puts rate-limit state on a 429', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      json: async () => ({ detail: 'Rate limit exceeded.', retry_after: 60 }),
+      headers: headers({
+        'retry-after': '60',
+        'x-ratelimit-limit': '1500',
+        'x-ratelimit-remaining': '0',
+        'x-ratelimit-reset': '60',
+      }),
+    });
+
+    // maxRetries: 0 — a 429 is retryable, and the real client would honour the
+    // 60s Retry-After before giving up.
+    const api = new NansenAPI('test-key', undefined, { retry: { maxRetries: 0 } });
+    await expect(
+      api.smartMoneyNetflow({ chains: ['solana'] })
+    ).rejects.toMatchObject({
+      code: ErrorCode.RATE_LIMITED,
+      details: {
+        retryAfterMs: 60000,
+        rateLimit: { limit: 1500, remaining: 0, resetSeconds: 60 },
+      },
+    });
+  });
+});

--- a/src/__tests__/response-meta.test.js
+++ b/src/__tests__/response-meta.test.js
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { readResponseMeta, creditWarning } from '../response-meta.js';
+import { readResponseMeta, creditWarning, noticeWarnings } from '../response-meta.js';
 import { NansenAPI, RESPONSE_META, ErrorCode } from '../api.js';
 
 function headers(entries) {
@@ -14,7 +14,32 @@ function headers(entries) {
 }
 
 describe('readResponseMeta', () => {
-  it('parses credit and rate-limit headers', () => {
+  it('parses credit, rate-limit, and notice headers', () => {
+    const meta = readResponseMeta({
+      headers: headers({
+        'x-nansen-credits-used': '5',
+        'x-nansen-credits-remaining': '41230',
+        'x-ratelimit-limit': '1500',
+        'x-ratelimit-remaining': '1499',
+        'x-ratelimit-reset': '60',
+        'x-nansen-upgrade-hint': 'Upgrade to Pro',
+        'x-nansen-plan-notice': 'Free tier resets at midnight UTC',
+        'x-nansen-api-key-notice': 'Rotate your API key',
+      }),
+    });
+
+    expect(meta).toEqual({
+      credits: { used: 5, remaining: 41230 },
+      rateLimit: { limit: 1500, remaining: 1499, resetSeconds: 60 },
+      notices: {
+        upgradeHint: 'Upgrade to Pro',
+        planNotice: 'Free tier resets at midnight UTC',
+        apiKeyNotice: 'Rotate your API key',
+      },
+    });
+  });
+
+  it('parses credit and rate-limit headers (no notices)', () => {
     const meta = readResponseMeta({
       headers: headers({
         'x-nansen-credits-used': '5',
@@ -29,6 +54,29 @@ describe('readResponseMeta', () => {
       credits: { used: 5, remaining: 41230 },
       rateLimit: { limit: 1500, remaining: 1499, resetSeconds: 60 },
     });
+  });
+
+  it('includes only the notice keys that are present', () => {
+    const meta = readResponseMeta({
+      headers: headers({ 'x-nansen-upgrade-hint': 'Upgrade to Pro' }),
+    });
+    expect(meta).toEqual({ notices: { upgradeHint: 'Upgrade to Pro' } });
+    expect(meta.notices.planNotice).toBeUndefined();
+    expect(meta.notices.apiKeyNotice).toBeUndefined();
+  });
+
+  it('treats empty string notice headers as absent', () => {
+    const meta = readResponseMeta({
+      headers: headers({ 'x-nansen-upgrade-hint': '' }),
+    });
+    expect(meta).toBeNull();
+  });
+
+  it('trims whitespace from notice header values', () => {
+    const meta = readResponseMeta({
+      headers: headers({ 'x-nansen-api-key-notice': '  Rotate your key  ' }),
+    });
+    expect(meta.notices.apiKeyNotice).toBe('Rotate your key');
   });
 
   it('returns null when no relevant headers are present', () => {
@@ -100,6 +148,44 @@ describe('creditWarning', () => {
 
   it('stays silent for free endpoints, which charge nothing', () => {
     expect(creditWarning({ credits: { used: 0, remaining: 5 } })).toBeNull();
+  });
+});
+
+describe('noticeWarnings', () => {
+  it('returns empty array when no notices', () => {
+    expect(noticeWarnings(null)).toEqual([]);
+    expect(noticeWarnings({ credits: { used: 5, remaining: 100 } })).toEqual([]);
+  });
+
+  it('emits ⚠️ for apiKeyNotice (most urgent)', () => {
+    const warnings = noticeWarnings({ notices: { apiKeyNotice: 'Rotate your key by April 27' } });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/^⚠️/);
+    expect(warnings[0]).toContain('Rotate your key by April 27');
+  });
+
+  it('emits ℹ️ for upgradeHint and planNotice', () => {
+    const warnings = noticeWarnings({
+      notices: { upgradeHint: 'Upgrade to Pro', planNotice: 'Free tier resets at midnight' },
+    });
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toMatch(/^ℹ️/);
+    expect(warnings[0]).toContain('Upgrade to Pro');
+    expect(warnings[1]).toMatch(/^ℹ️/);
+    expect(warnings[1]).toContain('Free tier resets at midnight');
+  });
+
+  it('orders apiKeyNotice before upgradeHint before planNotice', () => {
+    const warnings = noticeWarnings({
+      notices: {
+        planNotice: 'Plan notice',
+        upgradeHint: 'Upgrade hint',
+        apiKeyNotice: 'Key notice',
+      },
+    });
+    expect(warnings[0]).toContain('Key notice');
+    expect(warnings[1]).toContain('Upgrade hint');
+    expect(warnings[2]).toContain('Plan notice');
   });
 });
 

--- a/src/api.js
+++ b/src/api.js
@@ -8,6 +8,16 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { EVM_CHAINS } from './chain-ids.js';
 import { getAnonymousId, TELEMETRY_DISABLED } from './telemetry.js';
+import { readResponseMeta } from './response-meta.js';
+
+/**
+ * Key for the credit/rate-limit metadata attached to a successful response.
+ *
+ * A symbol on purpose: JSON.stringify and Object.keys both skip it, so the JSON
+ * every command prints is byte-for-byte unchanged while callers that want the
+ * numbers can still read them off the returned object.
+ */
+export const RESPONSE_META = Symbol('nansenResponseMeta');
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -465,6 +475,15 @@ export class NansenAPI {
       ttl: options.cache?.ttl ?? DEFAULT_CACHE_TTL
     };
     this.defaultHeaders = options.defaultHeaders || {};
+    /**
+     * Credit/rate-limit metadata from the most recent response, or null.
+     *
+     * Survives any reshaping a command handler does to the response body, which
+     * the RESPONSE_META symbol on the returned object does not. Last write wins
+     * when a handler makes several calls — the freshest balance, which is what a
+     * low-credit warning wants.
+     */
+    this.lastResponseMeta = null;
   }
 
   static cleanBody(body) {
@@ -702,10 +721,17 @@ export class NansenAPI {
           }
         }
 
+        // Quota state belongs on the error above all: an out-of-credits or
+        // rate-limited failure is exactly when the caller needs to see the
+        // numbers. formatError() surfaces details, so this needs no plumbing.
+        const meta = readResponseMeta(response);
+        this.lastResponseMeta = meta ?? this.lastResponseMeta;
         lastError = new NansenError(message, code, response.status, {
           ...data,
           attempt: attempt + 1,
-          retryAfterMs
+          retryAfterMs,
+          ...(meta?.credits && { credits: meta.credits }),
+          ...(meta?.rateLimit && { rateLimit: meta.rateLimit })
         });
         
         // Retry on specific status codes
@@ -722,12 +748,21 @@ export class NansenAPI {
       if (attempt > 0) {
         data._meta = { ...(data._meta || {}), retriedAttempts: attempt };
       }
-      
+
       // Cache successful response
       if (useCache) {
         setCachedResponse(endpoint, body, data);
       }
-      
+
+      // Attach after caching so the cache stores the payload alone — quota
+      // numbers are per-response and would be stale on a cache hit.
+      // Guarded: a response body can be a primitive, which cannot take a property.
+      const meta = readResponseMeta(response);
+      if (meta) {
+        this.lastResponseMeta = meta;
+        if (data !== null && typeof data === 'object') data[RESPONSE_META] = meta;
+      }
+
       return data;
     }
     

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,7 +14,7 @@ import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
 import { refreshCostMapIfStale, getCostForEndpoint } from './cost-cache.js';
-import { creditWarning } from './response-meta.js';
+import { creditWarning, noticeWarnings } from './response-meta.js';
 import { trackCommandSucceeded, trackCommandFailed } from './telemetry.js';
 import { createRequire } from 'module';
 import * as readline from 'readline';
@@ -1861,6 +1861,7 @@ export async function runCLI(rawArgs, deps = {}) {
     // commands too, which print their own output and return undefined.
     const lowCredits = creditWarning(api.lastResponseMeta);
     if (lowCredits) errorOutput(lowCredits);
+    for (const notice of noticeWarnings(api.lastResponseMeta)) errorOutput(notice);
 
     // Commands that handle their own output return undefined
     if (result === undefined) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,6 +14,7 @@ import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
 import { refreshCostMapIfStale, getCostForEndpoint } from './cost-cache.js';
+import { creditWarning } from './response-meta.js';
 import { trackCommandSucceeded, trackCommandFailed } from './telemetry.js';
 import { createRequire } from 'module';
 import * as readline from 'readline';
@@ -1853,6 +1854,13 @@ export async function runCLI(rawArgs, deps = {}) {
     }
     const api = new NansenAPIClass(undefined, undefined, { retry: retryOptions, cache: cacheOptions, defaultHeaders });
     let result = await commands[command](subArgs, api, flags, options);
+
+    // Credit balance warning, from the headers on the call just made. Goes to
+    // stderr so it never contaminates the JSON on stdout that agents parse.
+    // Placed before every return path below so it fires for operational
+    // commands too, which print their own output and return undefined.
+    const lowCredits = creditWarning(api.lastResponseMeta);
+    if (lowCredits) errorOutput(lowCredits);
 
     // Commands that handle their own output return undefined
     if (result === undefined) {

--- a/src/response-meta.js
+++ b/src/response-meta.js
@@ -20,6 +20,9 @@ const CREDITS_REMAINING = 'x-nansen-credits-remaining';
 const RATE_LIMIT = 'x-ratelimit-limit';
 const RATE_REMAINING = 'x-ratelimit-remaining';
 const RATE_RESET = 'x-ratelimit-reset';
+const UPGRADE_HINT = 'x-nansen-upgrade-hint';
+const PLAN_NOTICE = 'x-nansen-plan-notice';
+const API_KEY_NOTICE = 'x-nansen-api-key-notice';
 
 /**
  * Read a header as a non-negative integer, or null when absent/unparseable.
@@ -37,12 +40,28 @@ function intHeader(response, name) {
  * Returns null when the response carries none of it, so callers can skip
  * attaching an object full of nulls.
  */
+/**
+ * Read a header as a trimmed string, or null when absent/empty.
+ */
+function strHeader(response, name) {
+  const raw = response?.headers?.get?.(name);
+  return (raw != null && raw !== '') ? raw.trim() : null;
+}
+
+/**
+ * Extract credit, rate-limit, and notice metadata from a fetch Response.
+ * Returns null when the response carries none of it, so callers can skip
+ * attaching an object full of nulls.
+ */
 export function readResponseMeta(response) {
   const used = intHeader(response, CREDITS_USED);
   const remaining = intHeader(response, CREDITS_REMAINING);
   const limit = intHeader(response, RATE_LIMIT);
   const rateRemaining = intHeader(response, RATE_REMAINING);
   const resetSeconds = intHeader(response, RATE_RESET);
+  const upgradeHint = strHeader(response, UPGRADE_HINT);
+  const planNotice = strHeader(response, PLAN_NOTICE);
+  const apiKeyNotice = strHeader(response, API_KEY_NOTICE);
 
   const meta = {};
   if (used !== null || remaining !== null) {
@@ -53,13 +72,34 @@ export function readResponseMeta(response) {
     // drain — not a wall-clock timestamp.
     meta.rateLimit = { limit, remaining: rateRemaining, resetSeconds };
   }
+  if (upgradeHint !== null || planNotice !== null || apiKeyNotice !== null) {
+    meta.notices = {
+      ...(upgradeHint !== null && { upgradeHint }),
+      ...(planNotice !== null && { planNotice }),
+      ...(apiKeyNotice !== null && { apiKeyNotice }),
+    };
+  }
   return Object.keys(meta).length > 0 ? meta : null;
 }
 
 /**
+ * Yield notice strings for any server-set advisory headers.
+ * Each yields a `⚠️  <message>` line for stderr.
+ * Order: apiKeyNotice (most urgent) → upgradeHint → planNotice.
+ */
+export function noticeWarnings(meta) {
+  const notices = meta?.notices;
+  if (!notices) return [];
+  const out = [];
+  if (notices.apiKeyNotice) out.push(`⚠️  ${notices.apiKeyNotice}`);
+  if (notices.upgradeHint) out.push(`ℹ️  ${notices.upgradeHint}`);
+  if (notices.planNotice) out.push(`ℹ️  ${notices.planNotice}`);
+  return out;
+}
+
+/**
  * Warn only when the remaining balance will not cover another call of the size
- * just made. Self-scaling across plans — no absolute threshold to tune, and it
- * stays silent until the warning is actually actionable.
+ * just made.
  */
 export function creditWarning(meta) {
   const credits = meta?.credits;

--- a/src/response-meta.js
+++ b/src/response-meta.js
@@ -1,0 +1,76 @@
+/**
+ * Credit and rate-limit metadata, read from Nansen API response headers.
+ *
+ * The API reports what a call actually cost and what quota is left on every
+ * response. Until now the CLI dropped those headers on the floor and showed
+ * only the static per-endpoint estimate published in the OpenAPI spec (see
+ * cost-cache.js), which is a quote rather than a charge.
+ *
+ * readResponseMeta(response) — parse the headers, or null if none are present
+ * creditWarning(meta)        — stderr warning string when the balance is short, else null
+ *
+ * Every header is optional. Some auth rails charge no credits, some responses
+ * are served before quota is resolved, and older deployments may not send the
+ * rate-limit triplet at all — so a missing header means "unknown", never zero.
+ */
+
+/** Header names, as documented in the API reference. */
+const CREDITS_USED = 'x-nansen-credits-used';
+const CREDITS_REMAINING = 'x-nansen-credits-remaining';
+const RATE_LIMIT = 'x-ratelimit-limit';
+const RATE_REMAINING = 'x-ratelimit-remaining';
+const RATE_RESET = 'x-ratelimit-reset';
+
+/**
+ * Read a header as a non-negative integer, or null when absent/unparseable.
+ * Tolerates any header bag with a .get() — a real Headers, or a Map in tests.
+ */
+function intHeader(response, name) {
+  const raw = response?.headers?.get?.(name);
+  if (raw == null || raw === '') return null;
+  const value = Number.parseInt(raw, 10);
+  return Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+/**
+ * Extract credit + rate-limit metadata from a fetch Response.
+ * Returns null when the response carries none of it, so callers can skip
+ * attaching an object full of nulls.
+ */
+export function readResponseMeta(response) {
+  const used = intHeader(response, CREDITS_USED);
+  const remaining = intHeader(response, CREDITS_REMAINING);
+  const limit = intHeader(response, RATE_LIMIT);
+  const rateRemaining = intHeader(response, RATE_REMAINING);
+  const resetSeconds = intHeader(response, RATE_RESET);
+
+  const meta = {};
+  if (used !== null || remaining !== null) {
+    meta.credits = { used, remaining };
+  }
+  if (limit !== null || rateRemaining !== null || resetSeconds !== null) {
+    // resetSeconds is a delta in seconds — how long the tripped window needs to
+    // drain — not a wall-clock timestamp.
+    meta.rateLimit = { limit, remaining: rateRemaining, resetSeconds };
+  }
+  return Object.keys(meta).length > 0 ? meta : null;
+}
+
+/**
+ * Warn only when the remaining balance will not cover another call of the size
+ * just made. Self-scaling across plans — no absolute threshold to tune, and it
+ * stays silent until the warning is actually actionable.
+ */
+export function creditWarning(meta) {
+  const credits = meta?.credits;
+  if (!credits) return null;
+  const { used, remaining } = credits;
+  if (remaining === null) return null;
+  if (remaining === 0) {
+    return '⚠️  Out of API credits. Top up at https://app.nansen.ai/api';
+  }
+  if (used !== null && used > 0 && remaining < used) {
+    return `⚠️  ${remaining} API credit${remaining === 1 ? '' : 's'} left — less than this call cost (${used}). Top up at https://app.nansen.ai/api`;
+  }
+  return null;
+}


### PR DESCRIPTION
The API reports what a call cost and what quota is left on every response. The client dropped those headers on the floor, so the only credit figure the CLI could show was the static per-endpoint estimate published in the API reference (`src/cost-cache.js`, rendered in `--help` as `Cost: N credits (Free tier) / M credits (Pro tier)`) — a quote, never what you were actually charged.

## What changes

New `src/response-meta.js` parses the headers defensively. Every field is optional: some auth rails charge no credits, some responses are served before quota is resolved, and older deployments may not send the rate-limit triplet at all — so a **missing header means unknown, never zero**.

**Failures carry the numbers.** `NansenError.details` gains `credits` and `rateLimit`, and `formatError()` already surfaces `details`, so this needed no new plumbing. An out-of-credits error now reports the real remaining balance; a rate-limited one reports the window state.

```json
{ "success": false, "error": "Insufficient credits", "code": "CREDITS_EXHAUSTED", "status": 403,
  "details": { "credits": { "used": 0, "remaining": 2 } } }
```

**Low balance warns on stderr.** Fired only when the balance will not cover another call of the size just made (`remaining < used`, or `remaining === 0`). That is self-scaling across plans — no absolute threshold to tune, and it stays silent until it is actually actionable, which matters because a free-tier user at 10 credits/day and a Pro user share the code path. stderr keeps stdout pure JSON for agents, matching the existing `⚠️` warnings in `src/cli.js`.

**Successes expose the same data without changing output.** Two accessors, because they fail in different ways:

- `result[RESPONSE_META]` — a **Symbol**, so `JSON.stringify` and `Object.keys` both skip it. Race-free and exact, but lost if a command handler reshapes the body (`filterFields`, the local filtering in `token screener --search`).
- `api.lastResponseMeta` — survives any reshaping. Last write wins if a handler makes several calls, which for a balance warning is the right answer.

## Why the output shape is untouched

`formatOutput()` JSON-stringifies the whole object, so attaching a plain `data._meta` would have changed what **every** command prints. The symbol avoids that entirely — a test asserts `JSON.stringify(result)` is byte-identical and `Object.keys(result)` is unchanged.

## Compatibility

Most existing success-path mocks in `src/__tests__/api.test.js` are `{ ok: true, json: async () => ... }` with **no `headers` at all**. `readResponseMeta` uses `response?.headers?.get?.(name)` and returns `null` rather than throwing, and the header bag only needs a `.get()` — a real `Headers` or a `Map`, as the existing tests use. Attachment also happens *after* the response cache is written, since quota numbers are per-response and would be stale on a cache hit.

## Testing

- `npm test` — 1528 passed, 2 skipped, 0 failed
- `npm run lint` — clean
- 16 new tests in `src/__tests__/response-meta.test.js`: parsing, zero-vs-absent, unparseable values, the warning thresholds, the JSON-invisibility guarantee, and the 403/429 error paths

`src/schema.json` needs no update — no commands or options were added.

## Deliberately not here

The API is about to grow a per-call cost header, a request id, and a stable machine-readable error `code`. That last one would let us delete the prose string-matching in `statusToErrorCode()` (`messageLower.includes('credit')`, `.includes('address')`, `.includes('chain')`…), which is fragile — those messages can be reworded server-side at any time and CLI error codes would silently drift. Left for a follow-up once that surface ships, rather than guessing at it now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
