### PR TITLE
feat: surface the API's request id

### DIFF
--- a/.changeset/surface-request-id.md
+++ b/.changeset/surface-request-id.md
@@ -1,0 +1,9 @@
+---
+"nansen-cli": minor
+---
+
+Surface the API's request id.
+
+Failed calls now carry `details.requestId` — the value that identifies the call end to end. Quote it when reporting a problem; previously nothing identifying a failed request ever reached the user, which made server errors effectively unreportable. Successful responses expose it alongside the credit and rate-limit figures under the `RESPONSE_META` symbol.
+
+Absent on deployments that do not send the header yet, in which case the field is simply omitted.

--- a/README.md
+++ b/README.md
@@ -188,8 +188,17 @@ nansen research smart-money netflow --chain solana --fields token_symbol,net_flo
 | `UNAUTHORIZED` | Wrong or missing key. Re-auth. |
 | `RATE_LIMITED` | Auto-retried by CLI. `details.rateLimit.resetSeconds` is how long the window needs to drain. |
 | `UNSUPPORTED_FILTER` | Remove the filter and retry. |
+| `SERVER_ERROR` | Not your fault. Quote `details.requestId` when reporting it. |
 
-**Quota metadata.** When the API reports them, `details` carries `credits` (`used`, `remaining`) and `rateLimit` (`limit`, `remaining`, `resetSeconds`) on failures. Any field may be `null`, meaning unknown — never assume zero. A low-balance warning goes to **stderr**, so stdout stays pure JSON.
+**Error metadata.** When the API reports them, `details` carries:
+
+| Field | Meaning |
+|-------|---------|
+| `requestId` | Identifies this call end to end. Quote it in any support report. Opaque — do not parse it. |
+| `credits` | `used`, `remaining` |
+| `rateLimit` | `limit`, `remaining`, `resetSeconds` |
+
+Any field may be absent or `null`, meaning unknown — never assume zero. A low-balance warning goes to **stderr**, so stdout stays pure JSON.
 
 ## Troubleshooting
 

--- a/src/__tests__/response-meta.test.js
+++ b/src/__tests__/response-meta.test.js
@@ -247,6 +247,7 @@ describe('NansenAPI response metadata', () => {
     mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ netflows: [] }) });
 
     const api = new NansenAPI('test-key');
+    api.lastResponseMeta = { requestId: 'req-stale' };
     const result = await api.smartMoneyNetflow({ chains: ['solana'] });
 
     expect(result[RESPONSE_META]).toBeUndefined();
@@ -301,6 +302,51 @@ describe('NansenAPI response metadata', () => {
     );
     expect(err.status).toBe(500);
     expect('requestId' in err.details).toBe(false);
+  });
+
+  it('puts the request id on a non-JSON gateway error', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: async () => { throw new SyntaxError('Unexpected token <'); },
+      text: async () => '<html>Bad Gateway</html>',
+      headers: headers({ 'x-request-id': 'req-gateway' }),
+    });
+
+    const api = new NansenAPI('test-key', undefined, { retry: { maxRetries: 0 } });
+    await expect(api.smartMoneyNetflow({ chains: ['solana'] })).rejects.toMatchObject({
+      code: ErrorCode.SERVER_ERROR,
+      status: 502,
+      details: {
+        body: '<html>Bad Gateway</html>',
+        requestId: 'req-gateway',
+      },
+    });
+    expect(api.lastResponseMeta).toEqual({ requestId: 'req-gateway' });
+  });
+
+  it('clears stale metadata when the final retry has none', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: 'First failure' }),
+        headers: headers({ 'x-request-id': 'req-first' }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: 'Final failure' }),
+        headers: headers({}),
+      });
+
+    const api = new NansenAPI('test-key', undefined, {
+      retry: { maxRetries: 1, baseDelayMs: 0, maxDelayMs: 0 },
+    });
+    await expect(api.smartMoneyNetflow({ chains: ['solana'] })).rejects.toMatchObject({
+      details: { attempt: 2 },
+    });
+    expect(api.lastResponseMeta).toBeNull();
   });
 
   it('puts rate-limit state on a 429', async () => {

--- a/src/__tests__/response-meta.test.js
+++ b/src/__tests__/response-meta.test.js
@@ -83,6 +83,20 @@ describe('readResponseMeta', () => {
     expect(readResponseMeta({ headers: headers({}) })).toBeNull();
   });
 
+  it('parses the request id', () => {
+    const meta = readResponseMeta({ headers: headers({ 'x-request-id': 'req-a1b2c3' }) });
+    expect(meta).toEqual({ requestId: 'req-a1b2c3' });
+  });
+
+  it('keeps the request id opaque and trims surrounding whitespace', () => {
+    // Any format the server chooses must survive untouched — gateway ids,
+    // caller-forwarded ids and generated ids all look different.
+    expect(
+      readResponseMeta({ headers: headers({ 'x-request-id': '  8f14e45f-ea0a  ' }) })
+    ).toEqual({ requestId: '8f14e45f-ea0a' });
+    expect(readResponseMeta({ headers: headers({ 'x-request-id': '   ' }) })).toBeNull();
+  });
+
   it('tolerates a response with no headers at all', () => {
     // Most existing success-path mocks look like this.
     expect(readResponseMeta({ ok: true })).toBeNull();
@@ -206,6 +220,7 @@ describe('NansenAPI response metadata', () => {
       ok: true,
       json: async () => ({ netflows: [{ token_symbol: 'TEST' }] }),
       headers: headers({
+        'x-request-id': 'req-a1b2c3',
         'x-nansen-credits-used': '5',
         'x-nansen-credits-remaining': '41230',
         'x-ratelimit-limit': '1500',
@@ -218,6 +233,7 @@ describe('NansenAPI response metadata', () => {
     const result = await api.smartMoneyNetflow({ chains: ['solana'] });
 
     expect(result[RESPONSE_META]).toEqual({
+      requestId: 'req-a1b2c3',
       credits: { used: 5, remaining: 41230 },
       rateLimit: { limit: 1500, remaining: 1499, resetSeconds: 60 },
     });
@@ -250,6 +266,41 @@ describe('NansenAPI response metadata', () => {
       code: ErrorCode.CREDITS_EXHAUSTED,
       details: { credits: { used: 0, remaining: 2 } },
     });
+  });
+
+  it('puts the request id on a server error, where support needs it', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'Internal server error' }),
+      headers: headers({ 'x-request-id': 'req-deadbeef' }),
+    });
+
+    const api = new NansenAPI('test-key', undefined, { retry: { maxRetries: 0 } });
+    await expect(api.smartMoneyNetflow({ chains: ['solana'] })).rejects.toMatchObject({
+      code: ErrorCode.SERVER_ERROR,
+      status: 500,
+      details: { requestId: 'req-deadbeef' },
+    });
+  });
+
+  it('omits requestId entirely when the response carries no id', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'Internal server error' }),
+      headers: headers({}),
+    });
+
+    const api = new NansenAPI('test-key', undefined, { retry: { maxRetries: 0 } });
+    // Capture rather than .catch(assert) — a resolving call would skip the
+    // assertion entirely and pass silently.
+    const err = await api.smartMoneyNetflow({ chains: ['solana'] }).then(
+      () => { throw new Error('expected the call to reject'); },
+      e => e
+    );
+    expect(err.status).toBe(500);
+    expect('requestId' in err.details).toBe(false);
   });
 
   it('puts rate-limit state on a 429', async () => {

--- a/src/__tests__/x402-api-retry.test.js
+++ b/src/__tests__/x402-api-retry.test.js
@@ -17,7 +17,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { NansenAPI } from '../api.js';
+import { NansenAPI, RESPONSE_META } from '../api.js';
 
 function makeApi() {
   return new NansenAPI('test-key', 'https://api.nansen.ai');
@@ -51,13 +51,17 @@ describe('NansenAPI._x402Retry', () => {
     expect(result).toBeNull();
   });
 
-  it('returns the parsed JSON body when the paid response is ok', async () => {
+  it('returns the parsed JSON body with response metadata when the paid response is ok', async () => {
     // Regression for e918bdd: the resolved JSON value (not a Promise) is
     // returned so callers can use strict !== null to detect success.
     const responseData = { data: { token: 'ETH', value: 1234 } };
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => responseData,
+      headers: new Map([
+        ['x-request-id', 'req-paid'],
+        ['x-nansen-credits-remaining', '9'],
+      ]),
     });
 
     const api = makeApi();
@@ -65,6 +69,11 @@ describe('NansenAPI._x402Retry', () => {
       'test-sig', null, null, 'https://api.nansen.ai/test', {},
     );
     expect(result).toBe(responseData);
+    expect(result[RESPONSE_META]).toEqual({
+      requestId: 'req-paid',
+      credits: { used: null, remaining: 9 },
+    });
+    expect(api.lastResponseMeta).toEqual(result[RESPONSE_META]);
   });
 
   it('returns a falsy-but-valid JSON body as-is (regression for 3c25a0d)', async () => {

--- a/src/api.js
+++ b/src/api.js
@@ -721,15 +721,21 @@ export class NansenAPI {
           }
         }
 
-        // Quota state belongs on the error above all: an out-of-credits or
-        // rate-limited failure is exactly when the caller needs to see the
-        // numbers. formatError() surfaces details, so this needs no plumbing.
+        // Quota state and the request id belong on the error above all: an
+        // out-of-credits or rate-limited failure is exactly when the caller
+        // needs the numbers, and a 5xx is worthless to support without the id.
+        // formatError() surfaces details, so this needs no plumbing.
+        //
+        // On a retried call this is the LAST attempt's id — each attempt gets
+        // its own server-side id, and the last one is the failure worth
+        // reporting.
         const meta = readResponseMeta(response);
         this.lastResponseMeta = meta ?? this.lastResponseMeta;
         lastError = new NansenError(message, code, response.status, {
           ...data,
           attempt: attempt + 1,
           retryAfterMs,
+          ...(meta?.requestId && { requestId: meta.requestId }),
           ...(meta?.credits && { credits: meta.credits }),
           ...(meta?.rateLimit && { rateLimit: meta.rateLimit })
         });

--- a/src/api.js
+++ b/src/api.js
@@ -539,7 +539,11 @@ export class NansenAPI {
         }
       } catch { /* balance check is best-effort */ }
     }
-    return await paidResponse.json();
+    const data = await paidResponse.json();
+    const meta = readResponseMeta(paidResponse);
+    this.lastResponseMeta = meta;
+    if (meta && data !== null && typeof data === 'object') data[RESPONSE_META] = meta;
+    return data;
   }
 
   async request(endpoint, body = {}, options = {}) {
@@ -600,11 +604,17 @@ export class NansenAPI {
         data = await response.json();
       } catch (_err) {
         // Non-JSON response (rare, usually server errors)
+        const meta = readResponseMeta(response);
+        this.lastResponseMeta = meta;
         const error = new NansenError(
           `Invalid response from API (status ${response.status})`,
           response.status >= 500 ? ErrorCode.SERVER_ERROR : ErrorCode.UNKNOWN,
           response.status,
-          { body: await response.text().catch(() => null), attempt: attempt + 1 }
+          {
+            body: await response.text().catch(() => null),
+            attempt: attempt + 1,
+            ...(meta?.requestId && { requestId: meta.requestId })
+          }
         );
         
         if (shouldRetry && attempt < maxRetries && response.status >= 500) {
@@ -730,7 +740,7 @@ export class NansenAPI {
         // its own server-side id, and the last one is the failure worth
         // reporting.
         const meta = readResponseMeta(response);
-        this.lastResponseMeta = meta ?? this.lastResponseMeta;
+        this.lastResponseMeta = meta;
         lastError = new NansenError(message, code, response.status, {
           ...data,
           attempt: attempt + 1,
@@ -764,8 +774,8 @@ export class NansenAPI {
       // numbers are per-response and would be stale on a cache hit.
       // Guarded: a response body can be a primitive, which cannot take a property.
       const meta = readResponseMeta(response);
+      this.lastResponseMeta = meta;
       if (meta) {
-        this.lastResponseMeta = meta;
         if (data !== null && typeof data === 'object') data[RESPONSE_META] = meta;
       }
 

--- a/src/response-meta.js
+++ b/src/response-meta.js
@@ -1,17 +1,19 @@
 /**
- * Credit and rate-limit metadata, read from Nansen API response headers.
+ * Request-id, credit, rate-limit, and notice metadata, read from Nansen API
+ * response headers.
  *
- * The API reports what a call actually cost and what quota is left on every
- * response. Until now the CLI dropped those headers on the floor and showed
- * only the static per-endpoint estimate published in the OpenAPI spec (see
- * cost-cache.js), which is a quote rather than a charge.
+ * The API reports what a call actually cost, what quota is left, and an id that
+ * identifies the call end to end. Until now the CLI dropped those headers on the
+ * floor and showed only the static per-endpoint estimate published in the
+ * OpenAPI spec (see cost-cache.js), which is a quote rather than a charge.
  *
  * readResponseMeta(response) — parse the headers, or null if none are present
  * creditWarning(meta)        — stderr warning string when the balance is short, else null
  *
  * Every header is optional. Some auth rails charge no credits, some responses
- * are served before quota is resolved, and older deployments may not send the
- * rate-limit triplet at all — so a missing header means "unknown", never zero.
+ * are served before quota is resolved, and older deployments may send neither
+ * the rate-limit triplet nor the request id — so a missing header means
+ * "unknown", never zero.
  */
 
 /** Header names, as documented in the API reference. */
@@ -23,33 +25,32 @@ const RATE_RESET = 'x-ratelimit-reset';
 const UPGRADE_HINT = 'x-nansen-upgrade-hint';
 const PLAN_NOTICE = 'x-nansen-plan-notice';
 const API_KEY_NOTICE = 'x-nansen-api-key-notice';
+const REQUEST_ID = 'x-request-id';
 
 /**
  * Read a header as a non-negative integer, or null when absent/unparseable.
  * Tolerates any header bag with a .get() — a real Headers, or a Map in tests.
  */
 function intHeader(response, name) {
-  const raw = response?.headers?.get?.(name);
-  if (raw == null || raw === '') return null;
+  const raw = stringHeader(response, name);
+  if (raw === null) return null;
   const value = Number.parseInt(raw, 10);
   return Number.isInteger(value) && value >= 0 ? value : null;
 }
 
 /**
- * Extract credit + rate-limit metadata from a fetch Response.
- * Returns null when the response carries none of it, so callers can skip
- * attaching an object full of nulls.
+ * Read a header as a trimmed non-empty string, or null when absent.
+ * Tolerates any header bag with a .get() — a real Headers, or a Map in tests.
  */
-/**
- * Read a header as a trimmed string, or null when absent/empty.
- */
-function strHeader(response, name) {
+function stringHeader(response, name) {
   const raw = response?.headers?.get?.(name);
-  return (raw != null && raw !== '') ? raw.trim() : null;
+  if (raw == null) return null;
+  const value = String(raw).trim();
+  return value === '' ? null : value;
 }
 
 /**
- * Extract credit, rate-limit, and notice metadata from a fetch Response.
+ * Extract request-id, credit, rate-limit, and notice metadata from a fetch Response.
  * Returns null when the response carries none of it, so callers can skip
  * attaching an object full of nulls.
  */
@@ -59,11 +60,17 @@ export function readResponseMeta(response) {
   const limit = intHeader(response, RATE_LIMIT);
   const rateRemaining = intHeader(response, RATE_REMAINING);
   const resetSeconds = intHeader(response, RATE_RESET);
-  const upgradeHint = strHeader(response, UPGRADE_HINT);
-  const planNotice = strHeader(response, PLAN_NOTICE);
-  const apiKeyNotice = strHeader(response, API_KEY_NOTICE);
+  const upgradeHint = stringHeader(response, UPGRADE_HINT);
+  const planNotice = stringHeader(response, PLAN_NOTICE);
+  const apiKeyNotice = stringHeader(response, API_KEY_NOTICE);
+  const requestId = stringHeader(response, REQUEST_ID);
 
   const meta = {};
+  if (requestId !== null) {
+    // The single value that identifies this call to Nansen support. Opaque —
+    // never parse it or assume a format.
+    meta.requestId = requestId;
+  }
   if (used !== null || remaining !== null) {
     meta.credits = { used, remaining };
   }


### PR DESCRIPTION
**Stacked on #469** — base is `feat/surface-credit-and-rate-limit-headers`, not `main`, so the diff here is just the incremental change. `src/response-meta.js` only exists on that branch. Merge #469 first; GitHub will retarget this to `main` automatically.

## Why

A server error was effectively unreportable. Nothing identifying the failed request ever reached the user, so a bug report could only describe symptoms — no way to find the call in our logs. The API now returns an id on every response; this reads it.

## What changes

`details.requestId` on failures. `formatError()` already surfaces `details`, so no new plumbing:

```json
{ "success": false, "error": "Internal server error", "code": "SERVER_ERROR",
  "status": 500, "details": { "requestId": "req-a1b2c3..." } }
```

Successes carry it alongside the credit and rate-limit figures under the existing `RESPONSE_META` symbol, so default JSON output is still unchanged.

Also factored the header reader into `stringHeader` / `intHeader`, since the id is the first non-numeric header this parses.

## Three decisions worth reviewing

**Opaque, never parsed.** Trimmed, and that is all. Gateway-issued, caller-forwarded and generated ids all look different, and the format is not ours to depend on. A test pins that any format survives untouched.

**Omitted, not `null`, when the header is absent.** This lets the CLI ship ahead of the API deploy — on a deployment that does not send the header, behaviour is exactly what it is today. Consistent with how `credits` and `rateLimit` already behave.

**Last attempt's id on a retried call.** Each attempt gets its own id server-side; the last one is the failure actually being reported. Noted in a comment at the assignment site so it does not read as an oversight.

## Testing

- `npm test` — 1532 passed, 2 skipped, 0 failed
- `npm run lint` — clean
- 4 new tests: parsing, the opaque/whitespace contract, the 500 path, and the absent-header case

While adding the last one I rewrote a `.catch(assert)` into an explicit capture — the original form would have passed silently had the call resolved instead of rejecting.

## Not here

The CLI could **generate and forward** its own `X-Request-Id` — the API echoes a forwarded id back unchanged. That is strictly better for support, because on a timeout or dropped connection there is no response at all, so a server-issued id is unquotable exactly when you most need one. Deliberately a separate change; it alters what we send rather than what we read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
