### PR TITLE
fix(postinstall): drop shell:true on Windows child_process calls

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -41,9 +41,19 @@ function hasTTY() {
   return process.stdin.isTTY && process.stderr.isTTY;
 }
 
+// npx is a .cmd shim on Windows, and Node refuses to spawn .cmd/.bat without a
+// shell (CVE-2024-27980). Go through cmd.exe explicitly rather than enabling
+// `shell: true`, which would hand the whole command line to the shell parser.
+const IS_WIN = process.platform === "win32";
+
+function npxInvocation(args) {
+  return IS_WIN ? ["cmd.exe", ["/c", "npx", ...args]] : ["npx", args];
+}
+
 function hasNpx() {
   try {
-    execFileSync("npx", ["--version"], { stdio: "ignore", shell: process.platform === "win32" });
+    const [cmd, cmdArgs] = npxInvocation(["--version"]);
+    execFileSync(cmd, cmdArgs, { stdio: "ignore", shell: false });
     return true;
   } catch {
     return false;
@@ -86,7 +96,7 @@ function prompt(question) {
 
 function runCommand(cmd, args) {
   return new Promise((resolve) => {
-    const child = spawn(cmd, args, { stdio: "inherit", shell: process.platform === "win32" });
+    const child = spawn(cmd, args, { stdio: "inherit", shell: false });
     child.on("close", (code) => resolve(code === 0));
     child.on("error", () => resolve(false));
   });
@@ -113,7 +123,7 @@ async function installSkill() {
   }
 
   log(`Installing Nansen skill...`);
-  const ok = await runCommand("npx", ["-y", "skills", "add", SKILL_REPO]);
+  const ok = await runCommand(...npxInvocation(["-y", "skills", "add", SKILL_REPO]));
   if (!ok) {
     log(`${YELLOW}Skill installation failed. You can retry with: npx skills add ${SKILL_REPO}${RESET}`);
   }


### PR DESCRIPTION
Follow-up to #472, which we closed as won't-fix (no reachable injection, and it broke `npx` on Windows). This does the cleanup that was actually worth doing.

## Problem
`scripts/postinstall.js` passed `shell: process.platform === "win32"` to both `execFileSync` and `spawn`. On Windows that hands the full command line to the `cmd.exe` parser instead of exec'ing the binary directly.

No attacker-controlled value reaches these calls today — every argument is a module-level constant (`SKILL_REPO`, `TEST_QUERY`, `CLI_ENTRY`). So this is hardening, not a live vulnerability. It's worth doing anyway because this script runs on every `npm install` of a public package, which is the highest-leverage file in the repo.

## Change
- `shell: false` on all `child_process` calls.
- `npx` on Windows now goes through `cmd.exe /c npx` explicitly. This is required: since CVE-2024-27980 (Node >= 18.20.2 / 20.12.2 / 21.7.3), Node refuses to spawn `.cmd`/`.bat` shims without a shell and throws `EINVAL`. Simply flipping to `shell: false` — as #472 did — silently breaks skill installation on Windows.
- POSIX path is unchanged.

## Verification
- `node --check scripts/postinstall.js` passes.
- Postinstall runs clean end-to-end on Linux (non-TTY path).
- `execFileSync("npx", ["--version"], { shell: false })` confirmed working on POSIX.
- Windows `cmd.exe /c` path is **not** covered by local testing — worth a sanity check from anyone on Windows before merge.