### PR TITLE
docs: add stale global install troubleshooting

### DIFF
--- a/.changeset/slow-tips-cheer.md
+++ b/.changeset/slow-tips-cheer.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Add troubleshooting guidance for stale global installs.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Any field may be absent or `null`, meaning unknown — never assume zero. A low-
 | Symptom | Fix |
 |---------|-----|
 | `command not found` | `npm install -g nansen-cli` |
+| Global install reports an older version | `npm i -g nansen-cli@latest --registry=https://registry.npmjs.org/ --prefer-online`, then check `which -a nansen` for stale binaries |
 | `UNAUTHORIZED` after login | `cat ~/.nansen/config.json` or set `NANSEN_API_KEY` |
 | Empty perp _research_ results | Use `--symbol BTC`, not `--token`. Perps are Hyperliquid-only. |
 | `perp` _trading_ prints the usage banner | Trading needs `--coin BTC` (`--symbol` also works); see the Perpetuals section. |


### PR DESCRIPTION
## Summary
- add troubleshooting guidance for stale global installs
- add a patch changeset so the release flow can cut a follow-up package version

## Context
This is intentionally small so we can verify whether the npm publish path produces an installable 1.36.1 after the bad 1.36.0 registry state.