### PR TITLE
docs(schema): add missing `trade quote` / `trade execute` options

### DIFF
--- a/.changeset/schema-trade-options.md
+++ b/.changeset/schema-trade-options.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Document the missing `trade quote` and `trade execute` options in `src/schema.json`: `--swap-mode`, `--slippage`, `--auto-slippage`, `--max-auto-slippage`, `--quote`, `--quote-index` and `--no-simulate`. These options are already implemented and documented for humans, but were absent from the machine-readable schema.

--- a/src/schema.json
+++ b/src/schema.json
@@ -1557,6 +1557,23 @@
             "aggregator": {
               "type": "string",
               "description": "Force a specific aggregator: lifi, relay, jupiter, or okx. Filters the returned quote list client-side; errors if no quote from that aggregator was returned."
+            },
+            "swap-mode": {
+              "type": "string",
+              "default": "exactIn",
+              "description": "\"exactIn\" (default) to spend exactly --amount of the sell token, or \"exactOut\" to receive exactly --amount of the buy token. Not supported together with --amount-unit percent."
+            },
+            "slippage": {
+              "type": "string",
+              "description": "Slippage tolerance as a decimal between 0 and 1 (e.g. 0.03 for 3%). Values outside that range are rejected."
+            },
+            "auto-slippage": {
+              "type": "boolean",
+              "description": "Let slippage be calculated automatically instead of using a fixed --slippage."
+            },
+            "max-auto-slippage": {
+              "type": "string",
+              "description": "Upper bound applied when --auto-slippage is enabled, as a decimal between 0 and 1 (e.g. 0.03 for 3%)."
             }
           },
           "prerequisites": [
@@ -1566,6 +1583,11 @@
         "execute": {
           "description": "Sign and broadcast a quoted trade",
           "options": {
+            "quote": {
+              "type": "string",
+              "required": true,
+              "description": "Quote ID returned by `nansen trade quote` (alias: --quote-id)."
+            },
             "chain": {
               "type": "string",
               "default": "base",
@@ -1578,6 +1600,14 @@
             "gasless": {
               "type": "boolean",
               "description": "Relay-only: have Relay's solver pay gas + broadcast (user signs only). Requires the selected quote's aggregator to be \"relay\". Not supported via WalletConnect."
+            },
+            "quote-index": {
+              "type": "string",
+              "description": "Pin a specific quote by 0-based index when the cached quote returned several. Must be within range; there is no fallback to the other quotes."
+            },
+            "no-simulate": {
+              "type": "boolean",
+              "description": "Skip the pre-broadcast simulation."
             }
           }
         },


### PR DESCRIPTION
## Problem

`src/schema.json` is missing seven options that `src/trading.js` already reads. Most notably **`--quote`, the required primary argument of `trade execute`, is not in the schema at all**.

`trade execute` — schema lists only `chain`, `wallet`, `gasless`:

| Option | Read at |
|---|---|
| `--quote` (alias `--quote-id`) | `trading.js:1508` |
| `--quote-index` | `trading.js:1539` |
| `--no-simulate` | `trading.js:1510` |

`trade quote` — schema lists `chain`, `to-chain`, `from`, `to`, `amount`, `amount-unit`, `wallet`, `to-wallet`, `aggregator`:

| Option | Read at |
|---|---|
| `--swap-mode` | `trading.js:1191` |
| `--slippage` | `trading.js:1188` |
| `--auto-slippage` | `trading.js:1189` |
| `--max-auto-slippage` | `trading.js:1190` |

All seven are already documented for humans — the `trade execute` usage string at `trading.js:1514` lists `--quote` and `--no-simulate`, and `skills/nansen-trading/SKILL.md:145-169` tabulates every one of them. Only the machine-readable schema is behind.

That matters more here than in a typical CLI: the schema is what an agent reads to learn the interface. Right now an agent driving this CLI cannot discover that `trade execute` needs `--quote`, and cannot discover slippage control on `trade quote` at all.

CONTRIBUTING's PR checklist already asks for exactly this — *"`src/schema.json` updated if new commands or options were added (file is maintained manually — no codegen)"* — so these look like they were simply missed as the options landed.

## Fix

Additive only: 30 lines, no existing entry changed or removed. Descriptions follow the surrounding style and the validation the code actually enforces:

- `--slippage` / `--max-auto-slippage` are documented as a decimal between 0 and 1, matching the range check at `trading.js:1203-1209`
- `--swap-mode` carries `"default": "exactIn"` (per `trading.js:1191`) and notes it is rejected together with `--amount-unit percent` (`trading.js:1266`)
- `--quote` is marked `"required": true`
- `--quote-index` notes it is 0-based with no fallback (`trading.js:1539-1547`)

A patch changeset is included since the schema is user-facing.

## Verification

`schema.json` re-parsed after the edit; `trade.quote` and `trade.execute` option sets now match the options the code reads.