### PR TITLE
feat(cli): surface authoritative credit cost, request ID, and stable error codes from response headers

### DIFF
--- a/.changeset/authoritative-cost-request-id-stable-codes.md
+++ b/.changeset/authoritative-cost-request-id-stable-codes.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Surface richer API response metadata: the `X-Nansen-Credits-Cost` header now drives credit reporting (a concise `Credits: N (this call)` stderr line after each data command, falling back to the cached spec estimate when the header is absent), `requestId` is hoisted to the top level of the JSON error envelope (including `nansen agent` failures, which previously dropped it), and error codes now come from the API's stable `code` field when present — known codes map onto the existing error code enum, unknown ones pass through verbatim instead of being flattened. stdout JSON is unchanged; all new reporting goes to stderr.

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ nansen research smart-money netflow --chain solana --fields token_symbol,net_flo
 
 ```json
 { "success": true,  "data": <api_response> }
-{ "success": false, "error": "message", "code": "ERROR_CODE", "status": 401, "details": { ... } }
+{ "success": false, "error": "message", "code": "ERROR_CODE", "status": 401, "requestId": "...", "details": { ... } }
 ```
 
 **Critical error codes:**
@@ -226,8 +226,8 @@ nansen research smart-money netflow --chain solana --fields token_symbol,net_flo
 
 | Field | Meaning |
 |-------|---------|
-| `requestId` | Identifies this call end to end. Quote it in any support report. Opaque — do not parse it. |
-| `credits` | `used`, `remaining` |
+| `requestId` | Identifies this call end to end. Quote it in any support report. Opaque — do not parse it. Also hoisted to the top level of the error envelope. |
+| `credits` | `used`, `remaining`, `cost` (the authoritative charge for this call) |
 | `rateLimit` | `limit`, `remaining`, `resetSeconds` |
 
 Any field may be absent or `null`, meaning unknown — never assume zero. A low-balance warning goes to **stderr**, so stdout stays pure JSON.

--- a/src/__tests__/agent.test.js
+++ b/src/__tests__/agent.test.js
@@ -256,6 +256,43 @@ describe('agent command', () => {
         expect(err.details.detail).toBe('Internal agent failure');
       }
     });
+
+    it('carries the x-request-id header into error details', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: new Headers({
+          'content-type': 'application/json',
+          'x-request-id': 'req-agent-123',
+        }),
+        json: async () => ({ detail: 'Internal agent failure' }),
+      });
+
+      try {
+        await cmd(['test'], mockApi(), {}, {});
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(NansenError);
+        expect(err.details.requestId).toBe('req-agent-123');
+      }
+    });
+
+    it('uses the stable code field from the error body when present', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ detail: 'Too many requests', code: 'rate_limit_exceeded' }),
+      });
+
+      try {
+        await cmd(['test'], mockApi(), {}, {});
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(NansenError);
+        expect(err.code).toBe(ErrorCode.RATE_LIMITED);
+      }
+    });
   });
 
   // ── Network error ──

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -1687,6 +1687,22 @@ describe('formatError', () => {
     expect(result).not.toHaveProperty('details');
   });
 
+  it('hoists requestId to the top level so it survives details pruning', () => {
+    const error = new NansenError('Server error', 'SERVER_ERROR', 500, {
+      requestId: 'req-deadbeef',
+      attempt: 1,
+    });
+    const result = formatError(error);
+    expect(result.requestId).toBe('req-deadbeef');
+    expect(result.details.requestId).toBe('req-deadbeef');
+  });
+
+  it('omits top-level requestId when the error carries none', () => {
+    const error = new NansenError('Server error', 'SERVER_ERROR', 500, { attempt: 1 });
+    const result = formatError(error);
+    expect(result).not.toHaveProperty('requestId');
+  });
+
   it('should fall back to .data if .details is not set (backward compat)', () => {
     const error = new Error('legacy error');
     error.code = 'LEGACY';

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -2312,6 +2312,26 @@ describe('runCLI', () => {
     expect(result.type).toBe('error');
     expect(exitCode).toBe(1);
   });
+
+  it('writes exactly one credits line to stderr after notices without changing stdout', async () => {
+    const deps = {
+      ...mockDeps(),
+      NansenAPIClass: function MockAPI() {
+        this.lastResponseMeta = {
+          credits: { used: 5, remaining: 100, cost: 7 },
+          notices: { planNotice: 'Plan notice' },
+        };
+        this.lastEndpoint = '/api/v1/smart-money/netflow';
+        this.smartMoneyNetflow = vi.fn().mockResolvedValue({ data: [] });
+      },
+    };
+
+    await runCLI(['smart-money', 'netflow'], deps);
+
+    expect(errors).toEqual(['ℹ️  Plan notice', 'Credits: 7 (this call)']);
+    expect(outputs).toHaveLength(1);
+    expect(JSON.parse(outputs[0])).toEqual({ success: true, data: { data: [] } });
+  });
 });
 
 // =================== P1: --table Output Formatting ===================

--- a/src/__tests__/cost-cache.test.js
+++ b/src/__tests__/cost-cache.test.js
@@ -40,9 +40,10 @@ describe('creditsCharged', () => {
     expect(result).toEqual({ cost: 7, source: 'header' });
   });
 
-  it('falls back to the used header when cost is unknown', () => {
+  it('falls back to the spec estimate when the cost header is absent', () => {
+    seedCache({ '/api/v1/foo': { free: 3, pro: 5 } });
     const result = creditsCharged({ credits: { used: 5, remaining: 100, cost: null } }, '/api/v1/foo');
-    expect(result).toEqual({ cost: 5, source: 'header' });
+    expect(result).toEqual({ estimate: { free: 3, pro: 5 }, source: 'estimate' });
   });
 
   it('treats a zero charge as a value, not as absent', () => {
@@ -60,6 +61,7 @@ describe('creditsCharged', () => {
   it('returns null when neither headers nor an estimate exist', () => {
     expect(creditsCharged(null, '/api/v1/unknown')).toBeNull();
     expect(creditsCharged(null, null)).toBeNull();
+    expect(creditsCharged({ credits: { used: 5, cost: null } }, '/api/v1/unknown')).toBeNull();
     expect(creditsCharged({ rateLimit: { limit: 1, remaining: 1, resetSeconds: 1 } }, null)).toBeNull();
   });
 });

--- a/src/__tests__/cost-cache.test.js
+++ b/src/__tests__/cost-cache.test.js
@@ -1,0 +1,65 @@
+/**
+ * creditsCharged — authoritative header cost vs spec-derived estimate.
+ *
+ * cost-cache.js resolves ~/.nansen at import time, so each test re-imports the
+ * module with HOME pointed at a fresh temp dir (same pattern as keychain.test.js).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import os from 'os';
+import fs from 'fs';
+import path from 'path';
+
+describe('creditsCharged', () => {
+  let tempDir;
+  let originalEnv;
+  let creditsCharged;
+
+  beforeEach(async () => {
+    originalEnv = { ...process.env };
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nansen-cost-cache-test-'));
+    process.env.HOME = tempDir;
+    vi.resetModules();
+    ({ creditsCharged } = await import('../cost-cache.js'));
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function seedCache(costs) {
+    const dir = path.join(tempDir, '.nansen');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'cost-map.json'), JSON.stringify({ costs, fetchedAt: Date.now() }));
+  }
+
+  it('prefers the header cost over any estimate', () => {
+    seedCache({ '/api/v1/foo': { free: 3, pro: 5 } });
+    const result = creditsCharged({ credits: { used: 5, remaining: 100, cost: 7 } }, '/api/v1/foo');
+    expect(result).toEqual({ cost: 7, source: 'header' });
+  });
+
+  it('falls back to the used header when cost is unknown', () => {
+    const result = creditsCharged({ credits: { used: 5, remaining: 100, cost: null } }, '/api/v1/foo');
+    expect(result).toEqual({ cost: 5, source: 'header' });
+  });
+
+  it('treats a zero charge as a value, not as absent', () => {
+    seedCache({ '/api/v1/foo': { free: 3, pro: 5 } });
+    const result = creditsCharged({ credits: { used: null, remaining: 100, cost: 0 } }, '/api/v1/foo');
+    expect(result).toEqual({ cost: 0, source: 'header' });
+  });
+
+  it('falls back to the spec estimate when no headers arrived', () => {
+    seedCache({ '/api/v1/foo': { free: 3, pro: 5 } });
+    const result = creditsCharged(null, '/api/v1/foo');
+    expect(result).toEqual({ estimate: { free: 3, pro: 5 }, source: 'estimate' });
+  });
+
+  it('returns null when neither headers nor an estimate exist', () => {
+    expect(creditsCharged(null, '/api/v1/unknown')).toBeNull();
+    expect(creditsCharged(null, null)).toBeNull();
+    expect(creditsCharged({ rateLimit: { limit: 1, remaining: 1, resetSeconds: 1 } }, null)).toBeNull();
+  });
+});

--- a/src/__tests__/response-meta.test.js
+++ b/src/__tests__/response-meta.test.js
@@ -117,9 +117,13 @@ describe('readResponseMeta', () => {
 
   it('reads zero as a value, not as absent', () => {
     const meta = readResponseMeta({
-      headers: headers({ 'x-nansen-credits-used': '0', 'x-nansen-credits-remaining': '0' }),
+      headers: headers({
+        'x-nansen-credits-used': '0',
+        'x-nansen-credits-remaining': '0',
+        'x-nansen-credits-cost': '0',
+      }),
     });
-    expect(meta.credits).toEqual({ used: 0, remaining: 0, cost: null });
+    expect(meta.credits).toEqual({ used: 0, remaining: 0, cost: 0 });
   });
 
   it('parses the authoritative cost header', () => {
@@ -152,7 +156,9 @@ describe('readResponseMeta', () => {
       headers: headers({
         'x-nansen-credits-used': 'abc',
         'x-nansen-credits-remaining': '',
+        'x-nansen-credits-cost': '7.5',
         'x-ratelimit-limit': '-1',
+        'x-ratelimit-remaining': '3credits',
       }),
     });
     expect(meta).toBeNull();
@@ -423,6 +429,27 @@ describe('NansenAPI response metadata', () => {
       },
     });
   });
+
+  it.each([
+    [401, null, 'unauthorized', ErrorCode.UNAUTHORIZED, 'Not logged in. Run: nansen login'],
+    [403, 'test-key', 'insufficient_credits', ErrorCode.CREDITS_EXHAUSTED, 'No retry will help'],
+    [422, 'test-key', 'unsupported_filter', ErrorCode.UNSUPPORTED_FILTER, 'not supported for this token/chain'],
+  ])('enhances messages for stable body code %s', async (status, apiKey, code, expectedCode, message) => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status,
+      json: async () => ({ message: 'Request rejected', code }),
+      headers: headers({}),
+    });
+
+    const api = new NansenAPI(apiKey, undefined, { retry: { maxRetries: 0 } });
+    const error = await api.smartMoneyNetflow({}).then(
+      () => { throw new Error('expected the call to reject'); },
+      value => value,
+    );
+    expect(error.code).toBe(expectedCode);
+    expect(error.message).toContain(message);
+  });
 });
 
 describe('statusToErrorCode', () => {
@@ -432,6 +459,7 @@ describe('statusToErrorCode', () => {
     expect(statusToErrorCode(401, { code: 'unauthorized' })).toBe(ErrorCode.UNAUTHORIZED);
     expect(statusToErrorCode(404, { code: 'not_found' })).toBe(ErrorCode.NOT_FOUND);
     expect(statusToErrorCode(403, { code: 'forbidden' })).toBe(ErrorCode.FORBIDDEN);
+    expect(statusToErrorCode(422, { code: 'unsupported_filter' })).toBe(ErrorCode.UNSUPPORTED_FILTER);
     expect(statusToErrorCode(422, { code: 'validation_error' })).toBe(ErrorCode.INVALID_PARAMS);
   });
 
@@ -466,5 +494,7 @@ describe('statusToErrorCode', () => {
     expect(statusToErrorCode(429, { code: '   ' })).toBe(ErrorCode.RATE_LIMITED);
     expect(statusToErrorCode(429, { code: 42 })).toBe(ErrorCode.RATE_LIMITED);
     expect(statusToErrorCode(400, { code: null, message: 'bad chain' })).toBe(ErrorCode.INVALID_CHAIN);
+    expect(statusToErrorCode(403, { code: '', detail: { code: 'insufficient_credits' } })).toBe(ErrorCode.CREDITS_EXHAUSTED);
+    expect(statusToErrorCode(422, { code: 42, detail: { code: 'unsupported_filter' } })).toBe(ErrorCode.UNSUPPORTED_FILTER);
   });
 });

--- a/src/__tests__/response-meta.test.js
+++ b/src/__tests__/response-meta.test.js
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { readResponseMeta, creditWarning, noticeWarnings } from '../response-meta.js';
-import { NansenAPI, RESPONSE_META, ErrorCode } from '../api.js';
+import { NansenAPI, RESPONSE_META, ErrorCode, statusToErrorCode } from '../api.js';
 
 function headers(entries) {
   const map = new Map(Object.entries(entries));
@@ -29,7 +29,7 @@ describe('readResponseMeta', () => {
     });
 
     expect(meta).toEqual({
-      credits: { used: 5, remaining: 41230 },
+      credits: { used: 5, remaining: 41230, cost: null },
       rateLimit: { limit: 1500, remaining: 1499, resetSeconds: 60 },
       notices: {
         upgradeHint: 'Upgrade to Pro',
@@ -51,7 +51,7 @@ describe('readResponseMeta', () => {
     });
 
     expect(meta).toEqual({
-      credits: { used: 5, remaining: 41230 },
+      credits: { used: 5, remaining: 41230, cost: null },
       rateLimit: { limit: 1500, remaining: 1499, resetSeconds: 60 },
     });
   });
@@ -107,7 +107,7 @@ describe('readResponseMeta', () => {
     const creditsOnly = readResponseMeta({
       headers: headers({ 'x-nansen-credits-used': '5', 'x-nansen-credits-remaining': '0' }),
     });
-    expect(creditsOnly).toEqual({ credits: { used: 5, remaining: 0 } });
+    expect(creditsOnly).toEqual({ credits: { used: 5, remaining: 0, cost: null } });
     expect(creditsOnly.rateLimit).toBeUndefined();
 
     const rateOnly = readResponseMeta({ headers: headers({ 'x-ratelimit-remaining': '3' }) });
@@ -119,7 +119,32 @@ describe('readResponseMeta', () => {
     const meta = readResponseMeta({
       headers: headers({ 'x-nansen-credits-used': '0', 'x-nansen-credits-remaining': '0' }),
     });
-    expect(meta.credits).toEqual({ used: 0, remaining: 0 });
+    expect(meta.credits).toEqual({ used: 0, remaining: 0, cost: null });
+  });
+
+  it('parses the authoritative cost header', () => {
+    const meta = readResponseMeta({
+      headers: headers({
+        'x-nansen-credits-used': '5',
+        'x-nansen-credits-remaining': '100',
+        'x-nansen-credits-cost': '7',
+      }),
+    });
+    expect(meta.credits).toEqual({ used: 5, remaining: 100, cost: 7 });
+  });
+
+  it('reports cost as unknown when only used/remaining arrive', () => {
+    const meta = readResponseMeta({
+      headers: headers({ 'x-nansen-credits-used': '5', 'x-nansen-credits-remaining': '100' }),
+    });
+    expect(meta.credits.cost).toBeNull();
+  });
+
+  it('keeps the credits section when only the cost header arrives', () => {
+    const meta = readResponseMeta({
+      headers: headers({ 'x-nansen-credits-cost': '3' }),
+    });
+    expect(meta).toEqual({ credits: { used: null, remaining: null, cost: 3 } });
   });
 
   it('treats unparseable or negative values as unknown', () => {
@@ -162,6 +187,15 @@ describe('creditWarning', () => {
 
   it('stays silent for free endpoints, which charge nothing', () => {
     expect(creditWarning({ credits: { used: 0, remaining: 5 } })).toBeNull();
+  });
+
+  it('trusts the cost header over used when they disagree', () => {
+    // cost says the next call of this size needs 10; used says 2 was deducted.
+    const warning = creditWarning({ credits: { used: 2, remaining: 5, cost: 10 } });
+    expect(warning).toContain('less than this call cost (10)');
+    // And the reverse: an authoritative cheap cost silences the warning even
+    // if used alone would have tripped it.
+    expect(creditWarning({ credits: { used: 10, remaining: 5, cost: 2 } })).toBeNull();
   });
 });
 
@@ -234,7 +268,7 @@ describe('NansenAPI response metadata', () => {
 
     expect(result[RESPONSE_META]).toEqual({
       requestId: 'req-a1b2c3',
-      credits: { used: 5, remaining: 41230 },
+      credits: { used: 5, remaining: 41230, cost: null },
       rateLimit: { limit: 1500, remaining: 1499, resetSeconds: 60 },
     });
     expect(api.lastResponseMeta).toEqual(result[RESPONSE_META]);
@@ -266,6 +300,20 @@ describe('NansenAPI response metadata', () => {
     await expect(api.smartMoneyNetflow({ chains: ['solana'] })).rejects.toMatchObject({
       code: ErrorCode.CREDITS_EXHAUSTED,
       details: { credits: { used: 0, remaining: 2 } },
+    });
+  });
+
+  it('puts the authoritative cost on a 4xx error', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'Insufficient credits' }),
+      headers: headers({ 'x-nansen-credits-cost': '7', 'x-nansen-credits-remaining': '2' }),
+    });
+
+    const api = new NansenAPI('test-key');
+    await expect(api.smartMoneyNetflow({ chains: ['solana'] })).rejects.toMatchObject({
+      details: { credits: { used: null, remaining: 2, cost: 7 } },
     });
   });
 
@@ -374,5 +422,49 @@ describe('NansenAPI response metadata', () => {
         rateLimit: { limit: 1500, remaining: 0, resetSeconds: 60 },
       },
     });
+  });
+});
+
+describe('statusToErrorCode', () => {
+  it('maps known server codes onto the ErrorCode enum', () => {
+    expect(statusToErrorCode(429, { code: 'rate_limit_exceeded' })).toBe(ErrorCode.RATE_LIMITED);
+    expect(statusToErrorCode(403, { code: 'insufficient_credits' })).toBe(ErrorCode.CREDITS_EXHAUSTED);
+    expect(statusToErrorCode(401, { code: 'unauthorized' })).toBe(ErrorCode.UNAUTHORIZED);
+    expect(statusToErrorCode(404, { code: 'not_found' })).toBe(ErrorCode.NOT_FOUND);
+    expect(statusToErrorCode(403, { code: 'forbidden' })).toBe(ErrorCode.FORBIDDEN);
+    expect(statusToErrorCode(422, { code: 'validation_error' })).toBe(ErrorCode.INVALID_PARAMS);
+  });
+
+  it('reads a nested detail.code', () => {
+    expect(statusToErrorCode(429, { detail: { code: 'rate_limit_exceeded' } })).toBe(ErrorCode.RATE_LIMITED);
+  });
+
+  it('passes unknown server codes through verbatim', () => {
+    // Growth contract: a code the CLI has never seen is tolerated, never
+    // thrown on, never flattened to INVALID_PARAMS.
+    expect(statusToErrorCode(400, { code: 'brand_new_code' })).toBe('brand_new_code');
+    expect(statusToErrorCode(400, { code: '  padded_code  ' })).toBe('padded_code');
+  });
+
+  it('keeps a 402 as PAYMENT_REQUIRED whatever the body says', () => {
+    // The x402 auto-payment flow keys on PAYMENT_REQUIRED; an unknown server
+    // code on a 402 must not break auto-pay.
+    expect(statusToErrorCode(402, { code: 'some_future_code' })).toBe(ErrorCode.PAYMENT_REQUIRED);
+    expect(statusToErrorCode(402, { code: 'insufficient_credits' })).toBe(ErrorCode.PAYMENT_REQUIRED);
+    expect(statusToErrorCode(402, {})).toBe(ErrorCode.PAYMENT_REQUIRED);
+  });
+
+  it('falls back to status + prose when no code field is present', () => {
+    expect(statusToErrorCode(400, { message: 'invalid address checksum' })).toBe(ErrorCode.INVALID_ADDRESS);
+    expect(statusToErrorCode(403, { message: 'Insufficient credits' })).toBe(ErrorCode.CREDITS_EXHAUSTED);
+    expect(statusToErrorCode(429, {})).toBe(ErrorCode.RATE_LIMITED);
+    expect(statusToErrorCode(500, {})).toBe(ErrorCode.SERVER_ERROR);
+  });
+
+  it('ignores empty or non-string code fields', () => {
+    expect(statusToErrorCode(429, { code: '' })).toBe(ErrorCode.RATE_LIMITED);
+    expect(statusToErrorCode(429, { code: '   ' })).toBe(ErrorCode.RATE_LIMITED);
+    expect(statusToErrorCode(429, { code: 42 })).toBe(ErrorCode.RATE_LIMITED);
+    expect(statusToErrorCode(400, { code: null, message: 'bad chain' })).toBe(ErrorCode.INVALID_CHAIN);
   });
 });

--- a/src/__tests__/x402-api-retry.test.js
+++ b/src/__tests__/x402-api-retry.test.js
@@ -71,7 +71,7 @@ describe('NansenAPI._x402Retry', () => {
     expect(result).toBe(responseData);
     expect(result[RESPONSE_META]).toEqual({
       requestId: 'req-paid',
-      credits: { used: null, remaining: 9 },
+      credits: { used: null, remaining: 9, cost: null },
     });
     expect(api.lastResponseMeta).toEqual(result[RESPONSE_META]);
   });

--- a/src/api.js
+++ b/src/api.js
@@ -126,6 +126,7 @@ const SERVER_CODE_MAP = {
   unauthorized: ErrorCode.UNAUTHORIZED,
   forbidden: ErrorCode.FORBIDDEN,
   not_found: ErrorCode.NOT_FOUND,
+  unsupported_filter: ErrorCode.UNSUPPORTED_FILTER,
   validation_error: ErrorCode.INVALID_PARAMS,
   invalid_params: ErrorCode.INVALID_PARAMS,
 };
@@ -142,8 +143,9 @@ const SERVER_CODE_MAP = {
 export function statusToErrorCode(status, data = {}) {
   if (status === 402) return ErrorCode.PAYMENT_REQUIRED;
 
-  const rawCode = data?.code ?? data?.detail?.code;
-  if (typeof rawCode === 'string' && rawCode.trim() !== '') {
+  const rawCode = [data?.code, data?.detail?.code]
+    .find(value => typeof value === 'string' && value.trim() !== '');
+  if (rawCode !== undefined) {
     const serverCode = rawCode.trim();
     return SERVER_CODE_MAP[serverCode] ?? serverCode;
   }

--- a/src/api.js
+++ b/src/api.js
@@ -116,12 +116,41 @@ export class NansenError extends Error {
 }
 
 /**
- * Map HTTP status codes to error codes
+ * Stable snake_case codes the server sends in error bodies, mapped to the
+ * ErrorCode values downstream consumers already key on.
+ */
+const SERVER_CODE_MAP = {
+  rate_limit_exceeded: ErrorCode.RATE_LIMITED,
+  insufficient_credits: ErrorCode.CREDITS_EXHAUSTED,
+  payment_required: ErrorCode.PAYMENT_REQUIRED,
+  unauthorized: ErrorCode.UNAUTHORIZED,
+  forbidden: ErrorCode.FORBIDDEN,
+  not_found: ErrorCode.NOT_FOUND,
+  validation_error: ErrorCode.INVALID_PARAMS,
+  invalid_params: ErrorCode.INVALID_PARAMS,
+};
+
+/**
+ * Map an error response to an error code.
+ *
+ * Order matters: a 402 is always PAYMENT_REQUIRED (the x402 auto-payment flow
+ * keys on it, whatever the body says); then a stable `code` field from the
+ * server body wins over prose matching — known codes map onto the ErrorCode
+ * enum, unknown ones pass through verbatim so new server codes are tolerated,
+ * never flattened; bodies without a code fall back to status + prose.
  */
 export function statusToErrorCode(status, data = {}) {
+  if (status === 402) return ErrorCode.PAYMENT_REQUIRED;
+
+  const rawCode = data?.code ?? data?.detail?.code;
+  if (typeof rawCode === 'string' && rawCode.trim() !== '') {
+    const serverCode = rawCode.trim();
+    return SERVER_CODE_MAP[serverCode] ?? serverCode;
+  }
+
   const message = data?.message || data?.error || '';
   const messageLower = message.toLowerCase();
-  
+
   switch (status) {
     case 400:
     case 422:
@@ -484,6 +513,8 @@ export class NansenAPI {
      * low-credit warning wants.
      */
     this.lastResponseMeta = null;
+    /** API path of the most recent request(), for pairing lastResponseMeta with a cost estimate. */
+    this.lastEndpoint = null;
   }
 
   static cleanBody(body) {
@@ -547,6 +578,7 @@ export class NansenAPI {
   }
 
   async request(endpoint, body = {}, options = {}) {
+    this.lastEndpoint = endpoint;
     const url = `${this.baseUrl}${endpoint}`;
     const { maxRetries, baseDelayMs, maxDelayMs, retryOnStatus } = this.retryOptions;
     const shouldRetry = options.retry !== false; // Allow disabling retry per-request

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,7 +15,7 @@ import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from './comman
 import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
-import { refreshCostMapIfStale, getCostForEndpoint } from './cost-cache.js';
+import { refreshCostMapIfStale, getCostForEndpoint, creditsCharged } from './cost-cache.js';
 import { creditWarning, noticeWarnings } from './response-meta.js';
 import { trackCommandSucceeded, trackCommandFailed } from './telemetry.js';
 import { createRequire } from 'module';
@@ -390,6 +390,10 @@ export function formatError(error) {
     code: error.code || 'UNKNOWN',
     status: error.status || null,
   };
+  // Hoisted so the id survives even if details is omitted or later pruned.
+  if (details?.requestId) {
+    result.requestId = details.requestId;
+  }
   if (details != null && !(typeof details === 'object' && !Array.isArray(details) && Object.keys(details).length === 0)) {
     result.details = details;
   }
@@ -1982,6 +1986,15 @@ export async function runCLI(rawArgs, deps = {}) {
     const lowCredits = creditWarning(api.lastResponseMeta);
     if (lowCredits) errorOutput(lowCredits);
     for (const notice of noticeWarnings(api.lastResponseMeta)) errorOutput(notice);
+
+    // What this call cost — authoritative header when the API sent one, else
+    // the cached spec estimate. stderr only, so stdout JSON stays pure.
+    const charged = creditsCharged(api.lastResponseMeta, api.lastEndpoint);
+    if (charged?.source === 'header') {
+      errorOutput(`Credits: ${charged.cost} (this call)`);
+    } else if (charged?.source === 'estimate') {
+      errorOutput(`Credits: ~${charged.estimate.free} free / ${charged.estimate.pro} pro (estimated)`);
+    }
 
     // Commands that handle their own output return undefined
     if (result === undefined) {

--- a/src/commands/agent.js
+++ b/src/commands/agent.js
@@ -6,6 +6,7 @@
 import crypto from 'crypto';
 import { NansenError, ErrorCode, statusToErrorCode, telemetryHeaders, packageVersion } from '../api.js';
 import { getCostForEndpoint } from '../cost-cache.js';
+import { readResponseMeta } from '../response-meta.js';
 
 /**
  * Build standard request headers, matching apiInstance.request() conventions.
@@ -25,7 +26,7 @@ function buildHeaders(apiInstance) {
  * Throw a NansenError with the same structure as apiInstance.request() errors.
  * Includes `details` field for consistency with other commands.
  */
-function throwApiError(message, status, serverDetail) {
+function throwApiError(message, status, serverDetail, errData = null, requestId = null) {
   // Match the friendly wrapper messages from apiInstance.request()
   let friendlyMessage = message;
   if (status === 401) {
@@ -36,9 +37,14 @@ function throwApiError(message, status, serverDetail) {
 
   throw new NansenError(
     friendlyMessage,
-    statusToErrorCode(status),
+    statusToErrorCode(status, errData || {}),
     status,
-    { detail: serverDetail || message, attempt: 1, retryAfterMs: null },
+    {
+      detail: serverDetail || message,
+      attempt: 1,
+      retryAfterMs: null,
+      ...(requestId && { requestId }),
+    },
   );
 }
 
@@ -273,16 +279,20 @@ EXAMPLES:
       if (!response.ok) {
         clearTimeout(timer);
         let serverDetail;
+        let errData = null;
         if (response.headers.get('content-type')?.includes('application/json')) {
           try {
-            const errData = await response.json();
+            errData = await response.json();
             serverDetail = errData.detail || errData.message;
           } catch { /* ignore parse failure */ }
         }
+        const meta = readResponseMeta(response);
         throwApiError(
           serverDetail || `Agent returned ${response.status}`,
           response.status,
           serverDetail,
+          errData,
+          meta?.requestId,
         );
       }
 

--- a/src/cost-cache.js
+++ b/src/cost-cache.js
@@ -30,12 +30,12 @@ export function getCostForEndpoint(endpoint) {
 /**
  * What did (or would) this call cost?
  *
- * Prefers the authoritative charge from the response headers (cost, falling
- * back to used), then the spec-derived estimate for the endpoint, else null.
+ * Prefers the authoritative cost response header, then the spec-derived
+ * estimate for the endpoint, else null.
  * Returns { cost, source: 'header' } or { estimate: { free, pro }, source: 'estimate' }.
  */
 export function creditsCharged(meta, endpoint) {
-  const charged = meta?.credits?.cost ?? meta?.credits?.used;
+  const charged = meta?.credits?.cost;
   if (charged != null) return { cost: charged, source: 'header' };
   const estimate = endpoint ? getCostForEndpoint(endpoint) : null;
   if (estimate != null) return { estimate, source: 'estimate' };

--- a/src/cost-cache.js
+++ b/src/cost-cache.js
@@ -28,6 +28,21 @@ export function getCostForEndpoint(endpoint) {
 }
 
 /**
+ * What did (or would) this call cost?
+ *
+ * Prefers the authoritative charge from the response headers (cost, falling
+ * back to used), then the spec-derived estimate for the endpoint, else null.
+ * Returns { cost, source: 'header' } or { estimate: { free, pro }, source: 'estimate' }.
+ */
+export function creditsCharged(meta, endpoint) {
+  const charged = meta?.credits?.cost ?? meta?.credits?.used;
+  if (charged != null) return { cost: charged, source: 'header' };
+  const estimate = endpoint ? getCostForEndpoint(endpoint) : null;
+  if (estimate != null) return { estimate, source: 'estimate' };
+  return null;
+}
+
+/**
  * Fetches the OpenAPI spec and writes the cost map to disk if the cache is
  * missing or older than 24h. Awaited inline — only blocks on cold/stale cache.
  * Silent on any error.

--- a/src/response-meta.js
+++ b/src/response-meta.js
@@ -19,6 +19,7 @@
 /** Header names, as documented in the API reference. */
 const CREDITS_USED = 'x-nansen-credits-used';
 const CREDITS_REMAINING = 'x-nansen-credits-remaining';
+const CREDITS_COST = 'x-nansen-credits-cost';
 const RATE_LIMIT = 'x-ratelimit-limit';
 const RATE_REMAINING = 'x-ratelimit-remaining';
 const RATE_RESET = 'x-ratelimit-reset';
@@ -57,6 +58,7 @@ function stringHeader(response, name) {
 export function readResponseMeta(response) {
   const used = intHeader(response, CREDITS_USED);
   const remaining = intHeader(response, CREDITS_REMAINING);
+  const cost = intHeader(response, CREDITS_COST);
   const limit = intHeader(response, RATE_LIMIT);
   const rateRemaining = intHeader(response, RATE_REMAINING);
   const resetSeconds = intHeader(response, RATE_RESET);
@@ -71,8 +73,10 @@ export function readResponseMeta(response) {
     // never parse it or assume a format.
     meta.requestId = requestId;
   }
-  if (used !== null || remaining !== null) {
-    meta.credits = { used, remaining };
+  if (used !== null || remaining !== null || cost !== null) {
+    // cost is the server's authoritative pre-flight price for this call;
+    // used is what was actually deducted. They can disagree (e.g. free rails).
+    meta.credits = { used, remaining, cost };
   }
   if (limit !== null || rateRemaining !== null || resetSeconds !== null) {
     // resetSeconds is a delta in seconds — how long the tripped window needs to
@@ -111,13 +115,15 @@ export function noticeWarnings(meta) {
 export function creditWarning(meta) {
   const credits = meta?.credits;
   if (!credits) return null;
-  const { used, remaining } = credits;
+  const { used, remaining, cost } = credits;
   if (remaining === null) return null;
   if (remaining === 0) {
     return '⚠️  Out of API credits. Top up at https://app.nansen.ai/api';
   }
-  if (used !== null && used > 0 && remaining < used) {
-    return `⚠️  ${remaining} API credit${remaining === 1 ? '' : 's'} left — less than this call cost (${used}). Top up at https://app.nansen.ai/api`;
+  // The cost header is the authoritative charge; used is the fallback.
+  const charged = cost ?? used;
+  if (charged !== null && charged > 0 && remaining < charged) {
+    return `⚠️  ${remaining} API credit${remaining === 1 ? '' : 's'} left — less than this call cost (${charged}). Top up at https://app.nansen.ai/api`;
   }
   return null;
 }

--- a/src/response-meta.js
+++ b/src/response-meta.js
@@ -35,8 +35,8 @@ const REQUEST_ID = 'x-request-id';
 function intHeader(response, name) {
   const raw = stringHeader(response, name);
   if (raw === null) return null;
-  const value = Number.parseInt(raw, 10);
-  return Number.isInteger(value) && value >= 0 ? value : null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
 }
 
 /**


### PR DESCRIPTION
Adds authoritative per-request credit cost from response headers (falling back to the spec-derived estimate when absent), echoes the request ID in error output for easier support, and reads the server stable error code field instead of classifying by prose matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)