### PR TITLE
feat: add research profiler first-funder command

### DIFF
--- a/.changeset/first-funder-profiler-command.md
+++ b/.changeset/first-funder-profiler-command.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add `research profiler first-funder` command to look up the first wallet that funded an EVM address. The funder is the earliest address to send native gas, resolved across chains, returned with its Nansen label and the funding transaction.

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -130,6 +130,18 @@ const MOCK_RESPONSES = {
       { address: '0x456', relationship: 'funding_source' }
     ]
   },
+  addressFirstFunder: {
+    data: [
+      {
+        wallet_address: '0x28c6c06298d514db089934071355e5743bf21d60',
+        first_funder_address: '0x456',
+        first_funder_name: 'Binance',
+        transaction_hash: '0xabc',
+        block_timestamp: '2021-01-01T00:00:00Z',
+        chain: 'bsc'
+      }
+    ]
+  },
   addressCounterparties: {
     counterparties: [
       { address: '0x789', volume_usd: 100000 }
@@ -980,6 +992,34 @@ describe('NansenAPI', () => {
 
         const body = expectFetchCalledWith('/api/v1/profiler/address/related-wallets');
         expect(body.filters).toBeUndefined();
+      });
+    });
+
+    describe('addressFirstFunder', () => {
+      it('should fetch first funder with chain fixed to all', async () => {
+        setupMock(MOCK_RESPONSES.addressFirstFunder);
+
+        const result = await api.addressFirstFunder({
+          address: TEST_DATA.ethereum.address
+        });
+
+        const body = expectFetchCalledWith('/api/v1/profiler/address/first-funder');
+        expect(body.address).toBe(TEST_DATA.ethereum.address);
+        // Chain is fixed to 'all' regardless of caller input.
+        expect(body.chain).toBe('all');
+        // The endpoint forbids extra fields — send only address + chain.
+        expect(body.order_by).toBeUndefined();
+        expect(body.pagination).toBeUndefined();
+
+        expect(result.data[0]).toHaveProperty('first_funder_name', 'Binance');
+      });
+
+      it('should reject a non-EVM address', async () => {
+        setupMock(MOCK_RESPONSES.addressFirstFunder);
+
+        await expect(
+          api.addressFirstFunder({ address: TEST_DATA.solana.address })
+        ).rejects.toThrow();
       });
     });
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -1960,6 +1960,32 @@ describe('buildCommands', () => {
         expect.objectContaining({ query: 'Vitalik' })
       );
     });
+
+    it('should resolve ENS names for first-funder using an EVM chain', async () => {
+      const ens = await import('../ens.js');
+      vi.spyOn(ens, 'isEnsName').mockReturnValue(true);
+      vi.spyOn(ens, 'resolveAddress').mockResolvedValue({
+        address: '0x0000000000000000000000000000000000000001',
+        ensName: 'vitalik.eth'
+      });
+
+      const mockApi = {
+        addressFirstFunder: vi.fn().mockResolvedValue({ data: [] })
+      };
+
+      const result = await commands['profiler'](['first-funder'], mockApi, {}, { address: 'vitalik.eth' });
+
+      expect(ens.resolveAddress).toHaveBeenCalledWith('vitalik.eth', 'ethereum');
+      expect(mockApi.addressFirstFunder).toHaveBeenCalledWith({
+        address: '0x0000000000000000000000000000000000000001'
+      });
+      expect(result._ens).toEqual({
+        name: 'vitalik.eth',
+        resolvedAddress: '0x0000000000000000000000000000000000000001'
+      });
+
+      vi.restoreAllMocks();
+    });
   });
 
   describe('token command', () => {

--- a/src/api.js
+++ b/src/api.js
@@ -1012,6 +1012,17 @@ export class NansenAPI {
     });
   }
 
+  async addressFirstFunder(params = {}) {
+    const { address } = params;
+    // EVM addresses only; the funder is resolved across chains server-side, so
+    // chain is fixed to 'all' and the endpoint forbids any extra fields.
+    if (address) requireValidAddress(address, 'ethereum');
+    return this.request('/api/v1/profiler/address/first-funder', {
+      address,
+      chain: 'all'
+    });
+  }
+
   async addressCounterparties(params = {}) {
     const { address, chain = 'ethereum', filters = {}, orderBy, pagination, days = 30 } = params;
     if (address) requireValidAddress(address, chain);

--- a/src/cli.js
+++ b/src/cli.js
@@ -1173,6 +1173,7 @@ export function buildCommands(deps = {}) {
         'search': () => apiInstance.entitySearch({ query: options.query }),
         'historical-balances': () => apiInstance.addressHistoricalBalances({ address, chain, filters, orderBy, pagination, days }),
         'related-wallets': () => apiInstance.addressRelatedWallets({ address, chain, orderBy, pagination }),
+        'first-funder': () => apiInstance.addressFirstFunder({ address }),
         'counterparties': () => apiInstance.addressCounterparties({ address, chain, filters, orderBy, pagination, days }),
         'pnl-summary': () => apiInstance.addressPnlSummary({ address, chain, orderBy, pagination, days }),
         'perp-positions': () => apiInstance.addressPerpPositions({ address, filters, orderBy, pagination }),
@@ -1219,7 +1220,7 @@ export function buildCommands(deps = {}) {
           return compareWallets(apiInstance, { addresses: addrs, chain, days });
         },
         'help': () => ({
-          commands: ['balance', 'labels', 'transactions', 'pnl', 'search', 'historical-balances', 'related-wallets', 'counterparties', 'pnl-summary', 'perp-positions', 'perp-trades', 'dex-trades', 'batch', 'trace', 'compare'],
+          commands: ['balance', 'labels', 'transactions', 'pnl', 'search', 'historical-balances', 'related-wallets', 'first-funder', 'counterparties', 'pnl-summary', 'perp-positions', 'perp-trades', 'dex-trades', 'batch', 'trace', 'compare'],
           description: 'Wallet profiling endpoints',
           example: 'nansen research profiler compare --addresses "0xABC...,0xDEF..." --chain ethereum'
         })

--- a/src/cli.js
+++ b/src/cli.js
@@ -1147,7 +1147,8 @@ export function buildCommands(deps = {}) {
       let ensName;
       if (address && isEnsName(address)) {
         try {
-          const resolved = await resolveAddress(address, chain);
+          const ensChain = subcommand === 'first-funder' ? 'ethereum' : chain;
+          const resolved = await resolveAddress(address, ensChain);
           address = resolved.address;
           ensName = resolved.ensName;
         } catch (err) {

--- a/src/schema.json
+++ b/src/schema.json
@@ -564,6 +564,15 @@
                 }
               }
             },
+            "first-funder": {
+              "endpoint": "/api/v1/profiler/address/first-funder",
+              "description": "Find the first wallet that funded an EVM address",
+              "options": {
+                "address": {
+                  "required": true
+                }
+              }
+            },
             "pnl": {
               "endpoint": "/api/v1/profiler/address/pnl",
               "description": "PnL and trade performance",


### PR DESCRIPTION
## Summary

Adds `nansen research profiler first-funder`, wrapping `POST /api/v1/profiler/address/first-funder`.

The first funder is the earliest address to send **native gas** to an EVM address — the gas-funder / funding source. It's resolved **across chains**, so the returned `chain` is whichever chain funded first (often not the one you'd guess). The result includes the funder's Nansen label and the funding transaction.

## Behavior

- **EVM-only.** Non-EVM addresses (e.g. Solana) are rejected client-side.
- `chain` is fixed to `all` server-side; only `address` + `chain` are sent (the endpoint forbids extra fields, so no `order_by` / `pagination`).
- Empty result (e.g. a wallet never funded with native gas on any supported chain) returns a clean empty list.

## Files

- `src/api.js` — `addressFirstFunder`
- `src/cli.js` — subcommand handler + help list
- `src/schema.json` — command schema entry
- `src/__tests__/api.test.js` — mock + tests
- changeset (minor)

## Verification

- `eslint` clean, 210/210 vitest pass.
- Live E2E vs prod:
  - `0x2782…` → `kaigegg.eth` on **bsc**, 1 credit (cross-chain confirmed)
  - Solana address → rejected client-side
  - native-gas-less wallet → clean empty `data: []`

🤖 Generated with [Claude Code](https://claude.com/claude-code)