### PR TITLE
fix: actionable error when a whole command is passed as one argument

### DIFF
--- a/.changeset/actionable-unknown-command-quoting.md
+++ b/.changeset/actionable-unknown-command-quoting.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Unknown-command errors now detect when a whole multi-word command was passed as a single argument (a common shell-quoting mistake, e.g. `nansen "trade --help"` or an unquoted variable under zsh) and point at the likely cause instead of a bare "Unknown command".

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -248,8 +248,33 @@ describe('CLI Smoke Tests', () => {
 
   it('should handle unknown subcommand gracefully', () => {
     const { stdout } = runCLI('smart-money unknown-subcommand');
-    
+
     const result = JSON.parse(stdout);
     expect(result.data.error).toContain('Unknown subcommand');
+  });
+
+  // Regression: trade-group commands must exit 0 when invoked back-to-back.
+  // A prior report saw intermittent exit 1 here; the real cause was shell
+  // word-splitting in the repro (zsh does not split an unquoted `$var`, so
+  // `node index.js $c` fed "trade --help" as a single unknown-command token).
+  // With correct argv, `trade --help` must reliably exit 0, including in rapid
+  // succession.
+  it('trade --help exits 0 on repeated rapid invocations', () => {
+    for (let i = 0; i < 5; i++) {
+      const { exitCode } = runCLI('trade --help');
+      expect(exitCode).toBe(0);
+    }
+  });
+
+  // A whole command passed as one argument (e.g. `nansen "trade --help"`) is
+  // genuinely unknown and must fail loudly with an actionable shell-quoting
+  // hint, not a silent-looking spurious exit.
+  it('gives an actionable error when a whole command is one argument', () => {
+    const { stdout, exitCode } = runCLI('"trade --help"');
+
+    expect(exitCode).toBe(1);
+    const result = JSON.parse(stdout);
+    expect(result.error).toContain('Unknown command');
+    expect(result.error).toContain('shell quoting');
   });
 });

--- a/src/cli.js
+++ b/src/cli.js
@@ -1955,8 +1955,15 @@ export async function runCLI(rawArgs, deps = {}) {
   const chain = options.chain || null;
 
   if (!commands[command]) {
+    // A command token containing whitespace almost always means a multi-word
+    // invocation was passed as a single argument — e.g. `nansen "trade --help"`,
+    // or an unquoted shell variable under zsh (which, unlike bash, does not
+    // word-split `$var`). Point the user straight at the cause instead of a bare
+    // "Unknown command" that reads like a spurious failure.
     const errorData = {
-      error: `Unknown command: ${command}`,
+      error: /\s/.test(command)
+        ? `Unknown command: "${command}". This looks like multiple words passed as one argument — check your shell quoting (use \`nansen trade --help\`, not \`nansen "trade --help"\`).`
+        : `Unknown command: ${command}`,
       available: Object.keys(commands)
     };
     const formatted = formatOutput(errorData, { pretty, table });


### PR DESCRIPTION
## What

When an unknown-command token contains whitespace, the CLI now names the likely cause — a multi-word invocation passed as a single argument — instead of a bare `Unknown command`.

```
$ nansen "trade --help"
{"error":"Unknown command: \"trade --help\". This looks like multiple words passed as one argument — check your shell quoting (use `nansen trade --help`, not `nansen \"trade --help\"`).", ...}
```

Single-word typos are unchanged (stay terse).

## Why

A report described `trade`-group commands "intermittently exiting 1 in rapid succession." Root cause was **not** a race in the update-check / cost-map paths — it was shell word-splitting in the reproduction. Under **zsh**, an unquoted `$c` is not word-split (unlike bash/sh), so:

```
for c in "help" "trade --help" "help"; do node src/index.js $c; done
```

fed `"trade --help"` to the CLI as a **single argument** → a genuinely unknown command → correct `exit(1)`, every time. The same loop under bash/sh (and CI) splits into two args and exits 0. The `exit(1)` is correct; the problem was that the failure was baffling — especially since the error envelope goes to stdout (by design), so a redirected stdout made it look like a silent spurious exit.

This makes that failure self-diagnosing.

## Tests

- `trade --help` (correct argv) exits 0 across repeated rapid invocations
- a whole command passed as one argument exits 1 with the shell-quoting hint

`npm test` → all pass (incl. 2 new); `npm run lint` clean. Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)