### PR TITLE
feat: add offline `auth status` and `doctor` diagnostics

### DIFF
--- a/.changeset/offline-auth-status-and-doctor.md
+++ b/.changeset/offline-auth-status-and-doctor.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add `nansen auth status` and `nansen doctor`. `auth status` is fully offline: it reports whether an API key is configured and where it comes from (env var vs config file, masked), the active base URL, x402 wallet readiness, and OS keychain availability. `doctor` runs health checks over the whole setup — Node version, config file validity and permissions, wallet storage and password hygiene (flags the insecure `.credentials` file), keychain availability, Privy env credentials, caches, and telemetry — with an actionable fix per finding, plus a safe unauthenticated connectivity probe (no credits consumed; skip it with `--offline`). `--json` returns machine-readable checks.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ Any field may be absent or `null`, meaning unknown — never assume zero. A low-
 |---------|-----|
 | `command not found` | `npm install -g nansen-cli` |
 | Global install reports an older version | `npm i -g nansen-cli@latest --registry=https://registry.npmjs.org/ --prefer-online`, then check `which -a nansen` for stale binaries |
-| `UNAUTHORIZED` after login | `cat ~/.nansen/config.json` or set `NANSEN_API_KEY` |
+| `UNAUTHORIZED` after login | `nansen auth status` shows which key is active and where it comes from; re-run `nansen login` or set `NANSEN_API_KEY` |
+| Anything else misbehaving | `nansen doctor` checks your whole setup (auth, wallets, caches, connectivity) with a fix per finding |
 | Empty perp _research_ results | Use `--symbol BTC`, not `--token`. Perps are Hyperliquid-only. |
 | `perp` _trading_ prints the usage banner | Trading needs `--coin BTC` (`--symbol` also works); see the Perpetuals section. |
 | `UNSUPPORTED_FILTER` on token holders | Remove `--smart-money` — not all tokens have that data. |

--- a/skills/nansen-wallet-keychain-migration/SKILL.md
+++ b/skills/nansen-wallet-keychain-migration/SKILL.md
@@ -31,24 +31,26 @@ Use this skill when a user already has a nansen-cli wallet set up with the
 ## Detect current state
 
 `wallet show` only displays addresses and does NOT load or check the password.
-To detect the actual password situation, check for stored password sources:
+To detect the actual password situation, check the stored password source directly:
 
 ```bash
-# 1. Check if a wallet exists at all
-nansen wallet list 2>&1
+# 1. Where is the password stored? Offline, decrypts nothing, prints no secrets
+nansen auth status --pretty     # → x402.password.source: "env" | "keychain" | "file" | null
 
-# 2. Check for insecure password stores
+# 2. Full setup check — flags the insecure .credentials file with a fix
+nansen doctor --offline
+
+# 3. Legacy pattern doctor does not cover: password written to ~/.nansen/.env
 ls -la ~/.nansen/.env 2>/dev/null && echo "FOUND: ~/.nansen/.env (insecure)"
-ls -la ~/.nansen/wallets/.credentials 2>/dev/null && echo "FOUND: .credentials file (insecure)"
-
-# 3. Try an operation that requires the password (without setting env var)
-nansen wallet export default 2>&1
 ```
 
-Interpret the `export` output:
-- `⚠ Password loaded from ~/.nansen/wallets/.credentials` on stderr → needs migration (Path B)
-- Export succeeds silently → password is in keychain, no migration needed
-- `PASSWORD_REQUIRED` JSON error → password not persisted anywhere (Path C or D)
+Interpret `x402.password.source`:
+- `"file"` → password in `.credentials` file, needs migration (Path B)
+- `"keychain"` → already secure, no migration needed
+- `null` → password not persisted anywhere (Path C or D)
+- `"env"` → `NANSEN_WALLET_PASSWORD` is set; check where it is being exported from (a `.env` file → Path A)
+
+Do NOT use `nansen wallet export` to probe the password state — it prints private keys.
 
 ## Migration paths
 

--- a/src/__tests__/doctor.test.js
+++ b/src/__tests__/doctor.test.js
@@ -121,12 +121,30 @@ describe('doctor', () => {
       expect(status.config_file.exists).toBe(false);
     });
 
-    it('survives a corrupt config file', () => {
+    it('surfaces a corrupt config file instead of a clean "not logged in"', () => {
       fs.mkdirSync(nansenDir(), { recursive: true });
       fs.writeFileSync(path.join(nansenDir(), 'config.json'), 'not json{');
       const status = getAuthStatus(deps());
       expect(status.logged_in).toBe(false);
       expect(status.config_file.exists).toBe(true);
+      expect(status.config_file.error).toBe('parse');
+    });
+
+    it('surfaces an unreadable config file distinctly', () => {
+      writeConfig({ apiKey: 'nk_1234567890abcdef' });
+      fs.chmodSync(path.join(nansenDir(), 'config.json'), 0o000);
+      try {
+        const status = getAuthStatus(deps());
+        expect(status.logged_in).toBe(false);
+        expect(status.config_file.error).toBe('unreadable');
+      } finally {
+        fs.chmodSync(path.join(nansenDir(), 'config.json'), 0o600);
+      }
+    });
+
+    it('reports no config error for a healthy config file', () => {
+      writeConfig({ apiKey: 'nk_1234567890abcdef' });
+      expect(getAuthStatus(deps()).config_file.error).toBeNull();
     });
 
     it('reports x402 wallet readiness', () => {
@@ -212,8 +230,39 @@ describe('doctor', () => {
     it('errors on a corrupt config file', () => {
       fs.mkdirSync(nansenDir(), { recursive: true });
       fs.writeFileSync(path.join(nansenDir(), 'config.json'), 'not json{');
-      const checks = runDoctorChecks(deps());
-      expect(findCheck(checks, 'config-file').status).toBe('error');
+      const check = findCheck(runDoctorChecks(deps()), 'config-file');
+      expect(check.status).toBe('error');
+      expect(check.message).toContain('not valid JSON');
+      expect(check.fix).toContain('nansen login');
+    });
+
+    it('distinguishes an unreadable config file from a corrupt one', () => {
+      writeConfig({ apiKey: 'nk_1234567890abcdef' });
+      fs.chmodSync(path.join(nansenDir(), 'config.json'), 0o000);
+      try {
+        const check = findCheck(runDoctorChecks(deps()), 'config-file');
+        expect(check.status).toBe('error');
+        expect(check.message).toContain('cannot be read');
+        // "nansen login" would not fix a permission problem
+        expect(check.fix).not.toContain('nansen login');
+      } finally {
+        fs.chmodSync(path.join(nansenDir(), 'config.json'), 0o600);
+      }
+    });
+
+    it('distinguishes unreadable wallet files from corrupt ones', () => {
+      writeWallet('good');
+      fs.writeFileSync(path.join(walletsDir(), 'corrupt.json'), 'not json{');
+      fs.writeFileSync(path.join(walletsDir(), 'locked.json'), JSON.stringify({ provider: 'local' }));
+      fs.chmodSync(path.join(walletsDir(), 'locked.json'), 0o000);
+      try {
+        const checks = runDoctorChecks(deps());
+        const fileChecks = checks.filter(c => c.id === 'wallet-file');
+        expect(fileChecks.find(c => c.message.includes('corrupt.json')).message).toContain('not valid JSON');
+        expect(fileChecks.find(c => c.message.includes('locked.json')).message).toContain('cannot be read');
+      } finally {
+        fs.chmodSync(path.join(walletsDir(), 'locked.json'), 0o600);
+      }
     });
 
     it('warns on insecure config file permissions', () => {

--- a/src/__tests__/doctor.test.js
+++ b/src/__tests__/doctor.test.js
@@ -1,0 +1,519 @@
+/**
+ * Tests for src/doctor.js — offline auth status and doctor diagnostics.
+ * All state lives in a temp HOME; the keychain is stubbed via the
+ * retrievePasswordFn seam, so nothing touches the real machine or network.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { getAuthStatus, runDoctorChecks, runConnectivityChecks, formatDoctorReport, maskKey } from '../doctor.js';
+import { buildCommands, HELP, SCHEMA } from '../cli.js';
+
+describe('doctor', () => {
+  let tempDir;
+  let env;
+
+  // deps that make every check deterministic: isolated HOME, no env
+  // credentials, no keychain (linux resolves via PATH, which the controlled
+  // env leaves unset), no repo-local dev config.json
+  const deps = (overrides = {}) => ({
+    env,
+    retrievePasswordFn: () => ({ password: null, source: null }),
+    devConfigPath: path.join(tempDir, 'nonexistent-dev-config.json'),
+    platform: 'linux',
+    ...overrides,
+  });
+
+  const nansenDir = () => path.join(tempDir, '.nansen');
+  const walletsDir = () => path.join(nansenDir(), 'wallets');
+
+  const writeConfig = (config) => {
+    fs.mkdirSync(nansenDir(), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(nansenDir(), 'config.json'), JSON.stringify(config), { mode: 0o600 });
+  };
+
+  const writeWallet = (name, wallet = { provider: 'local' }) => {
+    fs.mkdirSync(walletsDir(), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(walletsDir(), `${name}.json`), JSON.stringify({ name, ...wallet }), { mode: 0o600 });
+  };
+
+  const writeWalletConfig = (config) => {
+    fs.mkdirSync(walletsDir(), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(walletsDir(), 'config.json'), JSON.stringify(config), { mode: 0o600 });
+  };
+
+  const findCheck = (checks, id) => checks.find(c => c.id === id);
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nansen-doctor-test-'));
+    env = { HOME: tempDir };
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('maskKey', () => {
+    it('masks long keys to first and last 4 chars', () => {
+      expect(maskKey('nk_1234567890abcdef')).toBe('nk_1…cdef');
+    });
+
+    it('fully masks short keys', () => {
+      expect(maskKey('short')).toBe('****');
+      // first4+last4 of an 8-11 char key would disclose most of it
+      expect(maskKey('12345678')).toBe('****');
+      expect(maskKey('12345678901')).toBe('****');
+      expect(maskKey('123456789012')).toBe('1234…9012');
+    });
+
+    it('returns null for empty or non-string input', () => {
+      expect(maskKey('')).toBeNull();
+      expect(maskKey(null)).toBeNull();
+      expect(maskKey(undefined)).toBeNull();
+    });
+  });
+
+  describe('getAuthStatus', () => {
+    it('reports logged out with no config anywhere', () => {
+      const status = getAuthStatus(deps());
+      expect(status.logged_in).toBe(false);
+      expect(status.api_key).toEqual({ present: false, source: null, masked: null });
+      expect(status.config_file.exists).toBe(false);
+      expect(status.config_file.path).toBe(path.join(nansenDir(), 'config.json'));
+      expect(status.base_url).toEqual({ value: 'https://api.nansen.ai', source: 'default' });
+      expect(status.offline).toBe(true);
+    });
+
+    it('reports config-file key with masked value', () => {
+      writeConfig({ apiKey: 'nk_1234567890abcdef', baseUrl: 'https://api.nansen.ai' });
+      const status = getAuthStatus(deps());
+      expect(status.logged_in).toBe(true);
+      expect(status.api_key.source).toBe('config');
+      expect(status.api_key.masked).toBe('nk_1…cdef');
+      expect(status.config_file.exists).toBe(true);
+      // Never leak the full key anywhere in the payload
+      expect(JSON.stringify(status)).not.toContain('nk_1234567890abcdef');
+    });
+
+    it('env var overrides config-file key', () => {
+      writeConfig({ apiKey: 'nk_config_key_0000' });
+      env.NANSEN_API_KEY = 'nk_env_key_1111';
+      const status = getAuthStatus(deps());
+      expect(status.api_key.source).toBe('env');
+      expect(status.api_key.masked).toBe('nk_e…1111');
+    });
+
+    it('reports base URL override from env', () => {
+      env.NANSEN_BASE_URL = 'https://api.example.dev';
+      const status = getAuthStatus(deps());
+      expect(status.base_url).toEqual({ value: 'https://api.example.dev', source: 'env' });
+    });
+
+    it('reports dev-config as a distinct key source', () => {
+      const devConfigPath = path.join(tempDir, 'dev-config.json');
+      fs.writeFileSync(devConfigPath, JSON.stringify({ apiKey: 'nk_dev_key_123456' }));
+      const status = getAuthStatus(deps({ devConfigPath }));
+      expect(status.logged_in).toBe(true);
+      expect(status.api_key.source).toBe('dev-config');
+      // The standard config file genuinely does not exist — no contradiction
+      expect(status.config_file.exists).toBe(false);
+    });
+
+    it('survives a corrupt config file', () => {
+      fs.mkdirSync(nansenDir(), { recursive: true });
+      fs.writeFileSync(path.join(nansenDir(), 'config.json'), 'not json{');
+      const status = getAuthStatus(deps());
+      expect(status.logged_in).toBe(false);
+      expect(status.config_file.exists).toBe(true);
+    });
+
+    it('reports x402 wallet readiness', () => {
+      writeWallet('trading');
+      writeWallet('privy-1', { provider: 'privy' });
+      writeWalletConfig({ defaultWallet: 'trading', passwordHash: null });
+      const status = getAuthStatus(deps({
+        retrievePasswordFn: () => ({ password: 'pw', source: 'keychain' }),
+      }));
+      expect(status.x402.configured).toBe(true);
+      expect(status.x402.wallet_count).toBe(2);
+      expect(status.x402.default_wallet).toBe('trading');
+      expect(status.x402.default_wallet_provider).toBe('local');
+      expect(status.x402.password).toEqual({ available: true, source: 'keychain', keychain_available: false });
+    });
+
+    it('reports no x402 setup when wallets dir is missing', () => {
+      const status = getAuthStatus(deps());
+      expect(status.x402.configured).toBe(false);
+      expect(status.x402.wallet_count).toBe(0);
+      expect(status.x402.default_wallet).toBeNull();
+      expect(status.x402.password).toEqual({ available: false, source: null, keychain_available: false });
+    });
+
+    it('reports keychain availability from the platform toolchain', () => {
+      // linux: available iff secret-tool is on PATH
+      const binDir = path.join(tempDir, 'bin');
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.writeFileSync(path.join(binDir, 'secret-tool'), '');
+      env.PATH = binDir;
+      expect(getAuthStatus(deps({ platform: 'linux' })).x402.password.keychain_available).toBe(true);
+      env.PATH = path.join(tempDir, 'empty');
+      expect(getAuthStatus(deps({ platform: 'linux' })).x402.password.keychain_available).toBe(false);
+      expect(getAuthStatus(deps({ platform: 'win32' })).x402.password.keychain_available).toBe(false);
+    });
+  });
+
+  describe('runDoctorChecks', () => {
+    it('passes the node version check when at or above the engine requirement', () => {
+      const checks = runDoctorChecks(deps({ nodeVersion: 'v20.0.0', engines: { node: '>=20.0.0' } }));
+      expect(findCheck(checks, 'node-version').status).toBe('ok');
+    });
+
+    it('fails the node version check below the engine requirement', () => {
+      const checks = runDoctorChecks(deps({ nodeVersion: 'v18.19.0', engines: { node: '>=20.0.0' } }));
+      const check = findCheck(checks, 'node-version');
+      expect(check.status).toBe('error');
+      expect(check.fix).toContain('nodejs.org');
+    });
+
+    it('warns when NANSEN_BASE_URL override is active', () => {
+      env.NANSEN_BASE_URL = 'https://api.example.dev';
+      const checks = runDoctorChecks(deps());
+      const check = findCheck(checks, 'base-url');
+      expect(check.status).toBe('warn');
+      expect(check.message).toContain('https://api.example.dev');
+    });
+
+    it('warns with a login fix when no API key is configured', () => {
+      const checks = runDoctorChecks(deps());
+      const check = findCheck(checks, 'api-key');
+      expect(check.status).toBe('warn');
+      expect(check.fix).toContain('nansen login');
+    });
+
+    it('reports the API key masked with its source', () => {
+      writeConfig({ apiKey: 'nk_1234567890abcdef' });
+      const checks = runDoctorChecks(deps());
+      const check = findCheck(checks, 'api-key');
+      expect(check.status).toBe('ok');
+      expect(check.message).toContain('nk_1…cdef');
+      expect(check.message).toContain('config file');
+      expect(check.message).not.toContain('nk_1234567890abcdef');
+    });
+
+    it('warns when the env key shadows a different config-file key', () => {
+      writeConfig({ apiKey: 'nk_config_key_0000' });
+      env.NANSEN_API_KEY = 'nk_env_key_1111';
+      const checks = runDoctorChecks(deps());
+      expect(findCheck(checks, 'api-key-shadow').status).toBe('warn');
+    });
+
+    it('errors on a corrupt config file', () => {
+      fs.mkdirSync(nansenDir(), { recursive: true });
+      fs.writeFileSync(path.join(nansenDir(), 'config.json'), 'not json{');
+      const checks = runDoctorChecks(deps());
+      expect(findCheck(checks, 'config-file').status).toBe('error');
+    });
+
+    it('warns on insecure config file permissions', () => {
+      writeConfig({ apiKey: 'nk_1234567890abcdef' });
+      fs.chmodSync(path.join(nansenDir(), 'config.json'), 0o644);
+      const checks = runDoctorChecks(deps());
+      const check = findCheck(checks, 'config-perms');
+      expect(check.status).toBe('warn');
+      expect(check.fix).toContain('chmod 600');
+    });
+
+    it('skips POSIX permission checks on Windows', () => {
+      writeConfig({ apiKey: 'nk_1234567890abcdef' });
+      fs.chmodSync(path.join(nansenDir(), 'config.json'), 0o644);
+      const checks = runDoctorChecks(deps({ platform: 'win32' }));
+      expect(findCheck(checks, 'config-perms')).toBeUndefined();
+    });
+
+    it('reports wallets as optional info when none exist', () => {
+      const checks = runDoctorChecks(deps());
+      expect(findCheck(checks, 'wallets').status).toBe('info');
+    });
+
+    it('counts wallets and shows the default', () => {
+      writeWallet('trading');
+      writeWalletConfig({ defaultWallet: 'trading' });
+      const checks = runDoctorChecks(deps({
+        retrievePasswordFn: () => ({ password: 'pw', source: 'keychain' }),
+      }));
+      const check = findCheck(checks, 'wallets');
+      expect(check.status).toBe('ok');
+      expect(check.message).toContain('1 wallet');
+      expect(check.message).toContain('default: trading');
+    });
+
+    it('errors when the default wallet has no file', () => {
+      writeWallet('trading');
+      writeWalletConfig({ defaultWallet: 'gone' });
+      const checks = runDoctorChecks(deps());
+      expect(findCheck(checks, 'default-wallet').status).toBe('error');
+    });
+
+    it('warns when the password lives in the insecure .credentials file', () => {
+      writeWallet('trading');
+      const checks = runDoctorChecks(deps({
+        retrievePasswordFn: () => ({ password: 'pw', source: 'file' }),
+      }));
+      const check = findCheck(checks, 'wallet-password');
+      expect(check.status).toBe('warn');
+      expect(check.fix).toContain('nansen wallet secure');
+    });
+
+    it('warns when wallets are password-protected but no password is stored', () => {
+      writeWallet('trading');
+      writeWalletConfig({ defaultWallet: 'trading', passwordHash: { salt: 'ab', hash: 'cd' } });
+      const checks = runDoctorChecks(deps());
+      const check = findCheck(checks, 'wallet-password');
+      expect(check.status).toBe('warn');
+      expect(check.message).toContain('no password is stored');
+    });
+
+    it('warns about a stale .credentials file when the active source is elsewhere', () => {
+      writeWallet('trading');
+      fs.writeFileSync(path.join(walletsDir(), '.credentials'), 'NANSEN_WALLET_PASSWORD_B64=cHc=\n', { mode: 0o600 });
+      const checks = runDoctorChecks(deps({
+        retrievePasswordFn: () => ({ password: 'pw', source: 'keychain' }),
+      }));
+      expect(findCheck(checks, 'stale-credentials').status).toBe('warn');
+    });
+
+    it('warns when a Privy wallet exists without Privy env credentials', () => {
+      writeWallet('server', { provider: 'privy' });
+      const checks = runDoctorChecks(deps());
+      expect(findCheck(checks, 'privy-env').status).toBe('warn');
+    });
+
+    it('does not warn about Privy when env credentials are set', () => {
+      writeWallet('server', { provider: 'privy' });
+      env.PRIVY_APP_ID = 'app';
+      env.PRIVY_APP_SECRET = 'secret';
+      const checks = runDoctorChecks(deps());
+      expect(findCheck(checks, 'privy-env')).toBeUndefined();
+    });
+
+    it('counts response cache entries', () => {
+      const cacheDir = path.join(nansenDir(), 'cache');
+      fs.mkdirSync(cacheDir, { recursive: true });
+      fs.writeFileSync(path.join(cacheDir, 'a.json'), '{}');
+      fs.writeFileSync(path.join(cacheDir, 'b.json'), '{}');
+      const checks = runDoctorChecks(deps());
+      expect(findCheck(checks, 'response-cache').message).toContain('2 entries');
+    });
+
+    it('reports cost map freshness', () => {
+      fs.mkdirSync(nansenDir(), { recursive: true });
+      fs.writeFileSync(path.join(nansenDir(), 'cost-map.json'), JSON.stringify({ costs: {}, fetchedAt: Date.now() - 2 * 3600 * 1000 }));
+      const checks = runDoctorChecks(deps());
+      expect(findCheck(checks, 'cost-map').message).toContain('fresh');
+    });
+
+    it('warns when the update-check cache shows a newer version', () => {
+      fs.mkdirSync(nansenDir(), { recursive: true });
+      fs.writeFileSync(path.join(nansenDir(), 'update-check.json'), JSON.stringify({ latest: '9.9.9', checkedAt: Date.now() }));
+      const checks = runDoctorChecks(deps({ cliVersion: '1.0.0' }));
+      const check = findCheck(checks, 'cli-version');
+      expect(check.status).toBe('warn');
+      expect(check.message).toContain('1.0.0 → 9.9.9');
+    });
+
+    it('reports up to date when the cached latest matches', () => {
+      fs.mkdirSync(nansenDir(), { recursive: true });
+      fs.writeFileSync(path.join(nansenDir(), 'update-check.json'), JSON.stringify({ latest: '1.0.0', checkedAt: Date.now() }));
+      const checks = runDoctorChecks(deps({ cliVersion: '1.0.0' }));
+      expect(findCheck(checks, 'cli-version').status).toBe('ok');
+    });
+
+    it('reports telemetry state with the same predicate telemetry.js uses', () => {
+      expect(findCheck(runDoctorChecks(deps()), 'telemetry').message).toContain('enabled');
+      // Only the literal '1' disables telemetry — '0'/'true'/'false' do not
+      env.DO_NOT_TRACK = '0';
+      expect(findCheck(runDoctorChecks(deps()), 'telemetry').message).toContain('enabled');
+      env.DO_NOT_TRACK = '1';
+      expect(findCheck(runDoctorChecks(deps()), 'telemetry').message).toContain('disabled');
+    });
+
+    it('clamps a future cost-map timestamp instead of reporting negative age', () => {
+      fs.mkdirSync(nansenDir(), { recursive: true });
+      fs.writeFileSync(path.join(nansenDir(), 'cost-map.json'), JSON.stringify({ costs: {}, fetchedAt: Date.now() + 5 * 3600 * 1000 }));
+      const check = findCheck(runDoctorChecks(deps()), 'cost-map');
+      expect(check.message).not.toContain('-');
+      expect(check.message).toContain('fetched 0h ago');
+    });
+
+    it('reports keychain availability as a check', () => {
+      expect(findCheck(runDoctorChecks(deps()), 'keychain').status).toBe('info');
+      const binDir = path.join(tempDir, 'bin');
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.writeFileSync(path.join(binDir, 'secret-tool'), '');
+      env.PATH = binDir;
+      expect(findCheck(runDoctorChecks(deps({ platform: 'linux' })), 'keychain').status).toBe('ok');
+    });
+  });
+
+  describe('runConnectivityChecks', () => {
+    it('reports the API as reachable on any HTTP response', async () => {
+      const fetchFn = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      const [check] = await runConnectivityChecks(deps({ fetchFn }));
+      expect(check.id).toBe('api-reachable');
+      expect(check.status).toBe('ok');
+      expect(check.message).toContain('https://api.nansen.ai');
+      expect(check.message).toContain('HTTP 200');
+      // Unauthenticated probe: no headers, no API key
+      expect(fetchFn.mock.calls[0][1].headers).toBeUndefined();
+    });
+
+    it('probes the overridden base URL', async () => {
+      env.NANSEN_BASE_URL = 'https://api.example.dev';
+      const fetchFn = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+      const [check] = await runConnectivityChecks(deps({ fetchFn }));
+      expect(fetchFn.mock.calls[0][0]).toBe('https://api.example.dev/openapi.json');
+      expect(check.status).toBe('ok');
+      expect(check.message).toContain('HTTP 404');
+    });
+
+    it('reports a network failure as an error with a fix', async () => {
+      const err = new Error('fetch failed');
+      err.cause = { code: 'ECONNREFUSED' };
+      const fetchFn = vi.fn().mockRejectedValue(err);
+      const [check] = await runConnectivityChecks(deps({ fetchFn }));
+      expect(check.status).toBe('error');
+      expect(check.message).toContain('ECONNREFUSED');
+      expect(check.fix).toContain('offline checks above remain valid');
+    });
+
+    it('reports a timeout distinctly', async () => {
+      const abortErr = new Error('This operation was aborted');
+      abortErr.name = 'AbortError';
+      const fetchFn = vi.fn().mockRejectedValue(abortErr);
+      const [check] = await runConnectivityChecks(deps({ fetchFn, timeoutMs: 123 }));
+      expect(check.status).toBe('error');
+      expect(check.message).toContain('timed out after 123ms');
+    });
+  });
+
+  describe('formatDoctorReport', () => {
+    it('renders icons, fixes, and a summary count', () => {
+      const report = formatDoctorReport([
+        { id: 'a', status: 'ok', message: 'all good' },
+        { id: 'b', status: 'warn', message: 'be careful', fix: 'Run: nansen wallet secure' },
+        { id: 'c', status: 'error', message: 'broken' },
+      ], { cliVersion: '1.2.3' });
+      expect(report).toContain('v1.2.3');
+      expect(report).toContain('✓ all good');
+      expect(report).toContain('⚠️  be careful');
+      expect(report).toContain('Run: nansen wallet secure');
+      expect(report).toContain('❌ broken');
+      expect(report).toContain('1 error, 1 warning found.');
+    });
+
+    it('says no problems when everything is ok or info', () => {
+      const report = formatDoctorReport([
+        { id: 'a', status: 'ok', message: 'fine' },
+        { id: 'b', status: 'info', message: 'fyi' },
+      ]);
+      expect(report).toContain('No problems found.');
+    });
+  });
+
+  describe('CLI wiring', () => {
+    let originalHome;
+    let originalEnv;
+    let logs;
+    let commands;
+
+    beforeEach(() => {
+      originalHome = process.env.HOME;
+      originalEnv = {
+        NANSEN_API_KEY: process.env.NANSEN_API_KEY,
+        NANSEN_BASE_URL: process.env.NANSEN_BASE_URL,
+        NANSEN_WALLET_PASSWORD: process.env.NANSEN_WALLET_PASSWORD,
+      };
+      process.env.HOME = tempDir;
+      delete process.env.NANSEN_API_KEY;
+      delete process.env.NANSEN_BASE_URL;
+      // Deterministic password source: keeps retrievePassword() off the real keychain
+      process.env.NANSEN_WALLET_PASSWORD = 'test-pw';
+      logs = [];
+      commands = buildCommands({ log: (msg) => logs.push(msg), exit: vi.fn() });
+    });
+
+    afterEach(() => {
+      process.env.HOME = originalHome;
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    });
+
+    it('auth defaults to status and returns a data object', async () => {
+      const result = await commands.auth([], null, {}, {});
+      expect(result.offline).toBe(true);
+      // logged_in may be true on dev machines with a repo-local config.json;
+      // the hermetic getAuthStatus tests above pin the exact value.
+      expect(typeof result.logged_in).toBe('boolean');
+      expect(result.config_file.path).toBe(path.join(tempDir, '.nansen', 'config.json'));
+    });
+
+    it('auth rejects unknown subcommands', async () => {
+      await expect(commands.auth(['whoami'], null, {}, {})).rejects.toThrow(/Unknown auth subcommand/);
+    });
+
+    it('doctor --offline prints a report and returns undefined without touching the network', async () => {
+      const fetchSpy = vi.fn();
+      vi.stubGlobal('fetch', fetchSpy);
+      try {
+        const result = await commands.doctor([], null, { offline: true }, {});
+        expect(result).toBeUndefined();
+        expect(fetchSpy).not.toHaveBeenCalled();
+        const combined = logs.join('\n');
+        expect(combined).toContain('offline diagnostics');
+        expect(combined).toMatch(/error|warning|No problems found/);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
+    it('doctor runs the connectivity probe by default', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+      try {
+        const result = await commands.doctor([], null, { json: true }, {});
+        const connectivity = result.checks.find(c => c.id === 'api-reachable');
+        expect(connectivity.status).toBe('ok');
+        expect(result.offline).toBe(false);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
+    it('doctor --json --offline returns structured checks with no connectivity probe', async () => {
+      const result = await commands.doctor([], null, { json: true, offline: true }, {});
+      expect(Array.isArray(result.checks)).toBe(true);
+      expect(result.checks.length).toBeGreaterThan(0);
+      expect(result.checks.every(c => c.id && c.status && c.message)).toBe(true);
+      expect(result.checks.find(c => c.id === 'api-reachable')).toBeUndefined();
+      expect(result.offline).toBe(true);
+      expect(typeof result.errors).toBe('number');
+      expect(typeof result.warnings).toBe('number');
+    });
+  });
+
+  describe('discoverability', () => {
+    it('HELP lists auth and doctor', () => {
+      expect(HELP).toContain('auth');
+      expect(HELP).toContain('doctor');
+    });
+
+    it('SCHEMA documents auth status and doctor', () => {
+      expect(SCHEMA.commands.auth.subcommands.status).toBeDefined();
+      expect(SCHEMA.commands.doctor).toBeDefined();
+      expect(SCHEMA.commands.doctor.options.json).toBeDefined();
+    });
+  });
+});

--- a/src/__tests__/doctor.test.js
+++ b/src/__tests__/doctor.test.js
@@ -1,7 +1,7 @@
 /**
  * Tests for src/doctor.js — offline auth status and doctor diagnostics.
  * All state lives in a temp HOME; the keychain is stubbed via the
- * retrievePasswordFn seam, so nothing touches the real machine or network.
+ * passwordSourceFn seam, so nothing touches the real machine or network.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -20,7 +20,7 @@ describe('doctor', () => {
   // env leaves unset), no repo-local dev config.json
   const deps = (overrides = {}) => ({
     env,
-    retrievePasswordFn: () => ({ password: null, source: null }),
+    passwordSourceFn: () => null,
     devConfigPath: path.join(tempDir, 'nonexistent-dev-config.json'),
     platform: 'linux',
     ...overrides,
@@ -111,6 +111,17 @@ describe('doctor', () => {
       expect(status.base_url).toEqual({ value: 'https://api.example.dev', source: 'env' });
     });
 
+    it('reports an unreadable wallets directory instead of "no wallets"', () => {
+      writeWallet('trading');
+      fs.chmodSync(walletsDir(), 0o000);
+      try {
+        const status = getAuthStatus(deps());
+        expect(status.x402.wallets_dir_error).toBe('unreadable');
+      } finally {
+        fs.chmodSync(walletsDir(), 0o700);
+      }
+    });
+
     it('reports dev-config as a distinct key source', () => {
       const devConfigPath = path.join(tempDir, 'dev-config.json');
       fs.writeFileSync(devConfigPath, JSON.stringify({ apiKey: 'nk_dev_key_123456' }));
@@ -152,7 +163,7 @@ describe('doctor', () => {
       writeWallet('privy-1', { provider: 'privy' });
       writeWalletConfig({ defaultWallet: 'trading', passwordHash: null });
       const status = getAuthStatus(deps({
-        retrievePasswordFn: () => ({ password: 'pw', source: 'keychain' }),
+        passwordSourceFn: () => 'keychain',
       }));
       expect(status.x402.configured).toBe(true);
       expect(status.x402.wallet_count).toBe(2);
@@ -201,6 +212,38 @@ describe('doctor', () => {
       const check = findCheck(checks, 'base-url');
       expect(check.status).toBe('warn');
       expect(check.message).toContain('https://api.example.dev');
+    });
+
+    it('warns on a non-default base URL from the config file', () => {
+      writeConfig({ apiKey: 'nk_1234567890abcdef', baseUrl: 'https://api.example.dev' });
+      const check = findCheck(runDoctorChecks(deps()), 'base-url');
+      expect(check.status).toBe('warn');
+      expect(check.message).toContain('https://api.example.dev');
+      expect(check.message).toContain('config.json');
+    });
+
+    it('reports ok for the default base URL saved in the config file', () => {
+      writeConfig({ apiKey: 'nk_1234567890abcdef', baseUrl: 'https://api.nansen.ai' });
+      expect(findCheck(runDoctorChecks(deps()), 'base-url').status).toBe('ok');
+    });
+
+    it('errors when the wallets directory cannot be read', () => {
+      writeWallet('trading');
+      fs.chmodSync(walletsDir(), 0o000);
+      try {
+        const check = findCheck(runDoctorChecks(deps()), 'wallets');
+        expect(check.status).toBe('error');
+        expect(check.message).toContain('cannot be read');
+      } finally {
+        fs.chmodSync(walletsDir(), 0o700);
+      }
+    });
+
+    it('quotes paths in suggested fix commands', () => {
+      writeConfig({ apiKey: 'nk_1234567890abcdef' });
+      fs.chmodSync(path.join(nansenDir(), 'config.json'), 0o644);
+      const check = findCheck(runDoctorChecks(deps()), 'config-perms');
+      expect(check.fix).toContain(`chmod 600 "${path.join(nansenDir(), 'config.json')}"`);
     });
 
     it('warns with a login fix when no API key is configured', () => {
@@ -290,7 +333,7 @@ describe('doctor', () => {
       writeWallet('trading');
       writeWalletConfig({ defaultWallet: 'trading' });
       const checks = runDoctorChecks(deps({
-        retrievePasswordFn: () => ({ password: 'pw', source: 'keychain' }),
+        passwordSourceFn: () => 'keychain',
       }));
       const check = findCheck(checks, 'wallets');
       expect(check.status).toBe('ok');
@@ -308,7 +351,7 @@ describe('doctor', () => {
     it('warns when the password lives in the insecure .credentials file', () => {
       writeWallet('trading');
       const checks = runDoctorChecks(deps({
-        retrievePasswordFn: () => ({ password: 'pw', source: 'file' }),
+        passwordSourceFn: () => 'file',
       }));
       const check = findCheck(checks, 'wallet-password');
       expect(check.status).toBe('warn');
@@ -328,7 +371,7 @@ describe('doctor', () => {
       writeWallet('trading');
       fs.writeFileSync(path.join(walletsDir(), '.credentials'), 'NANSEN_WALLET_PASSWORD_B64=cHc=\n', { mode: 0o600 });
       const checks = runDoctorChecks(deps({
-        retrievePasswordFn: () => ({ password: 'pw', source: 'keychain' }),
+        passwordSourceFn: () => 'keychain',
       }));
       expect(findCheck(checks, 'stale-credentials').status).toBe('warn');
     });

--- a/src/__tests__/keychain.test.js
+++ b/src/__tests__/keychain.test.js
@@ -13,7 +13,7 @@ vi.mock('child_process', () => ({
 }));
 
 import { execFileSync } from 'child_process';
-import { storePassword, retrievePassword, deletePassword, deleteCredentialsFile, resolvePassword } from '../keychain.js';
+import { storePassword, retrievePassword, deletePassword, deleteCredentialsFile, resolvePassword, passwordSource } from '../keychain.js';
 
 describe('keychain', () => {
   let originalPlatform;
@@ -213,6 +213,48 @@ describe('keychain', () => {
       setPlatform('freebsd');
       delete process.env.NANSEN_WALLET_PASSWORD;
       expect(resolvePassword()).toBeNull();
+    });
+  });
+
+  describe('passwordSource (metadata-only)', () => {
+    it('reports env without touching the keychain', () => {
+      process.env.NANSEN_WALLET_PASSWORD = 'env-pw';
+      expect(passwordSource()).toBe('env');
+      expect(execFileSync).not.toHaveBeenCalled();
+    });
+
+    it('reports keychain on macOS without requesting the secret', () => {
+      setPlatform('darwin');
+      delete process.env.NANSEN_WALLET_PASSWORD;
+      execFileSync.mockReturnValue(Buffer.from(''));
+      expect(passwordSource()).toBe('keychain');
+      // Attribute lookup only — the -w flag (print password) must be absent
+      const args = execFileSync.mock.calls[0][1];
+      expect(args).toContain('find-generic-password');
+      expect(args).not.toContain('-w');
+    });
+
+    it('uses secret-tool search (attributes) rather than lookup (secret) on Linux', () => {
+      setPlatform('linux');
+      delete process.env.NANSEN_WALLET_PASSWORD;
+      execFileSync.mockReturnValue(Buffer.from('[/org/freedesktop/secrets/collection/login/1]\nlabel = nansen-cli\n'));
+      expect(passwordSource()).toBe('keychain');
+      expect(execFileSync.mock.calls[0][1][0]).toBe('search');
+    });
+
+    it('reports file by pattern-matching the credentials file without decoding it', () => {
+      setPlatform('freebsd');
+      delete process.env.NANSEN_WALLET_PASSWORD;
+      const walletsDir = path.join(tempDir, '.nansen', 'wallets');
+      fs.mkdirSync(walletsDir, { recursive: true });
+      fs.writeFileSync(path.join(walletsDir, '.credentials'), 'NANSEN_WALLET_PASSWORD_B64=cHc=\n');
+      expect(passwordSource()).toBe('file');
+    });
+
+    it('returns null when no source exists', () => {
+      setPlatform('freebsd');
+      delete process.env.NANSEN_WALLET_PASSWORD;
+      expect(passwordSource()).toBeNull();
     });
   });
 });

--- a/src/__tests__/offline-help.test.js
+++ b/src/__tests__/offline-help.test.js
@@ -1,0 +1,62 @@
+/**
+ * `auth` and `doctor --offline` promise zero network activity. The help path
+ * runs before command dispatch, so it has to honour the same contract — the
+ * cost-map refresh fetches the OpenAPI spec and writes ~/.nansen/cost-map.json.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const refreshCostMapIfStale = vi.fn(async () => {});
+
+vi.mock('../cost-cache.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  refreshCostMapIfStale,
+}));
+
+const { runCLI } = await import('../cli.js');
+
+function baseDeps() {
+  return { output: () => {}, errorOutput: () => {}, exit: () => {} };
+}
+
+describe('offline commands: --help does not touch the network', () => {
+  let fetchSpy;
+
+  beforeEach(() => {
+    refreshCostMapIfStale.mockClear();
+    fetchSpy = vi.fn(() => { throw new Error('network access in offline command'); });
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('doctor --offline --help skips the cost-map refresh', async () => {
+    await runCLI(['doctor', '--offline', '--help'], baseDeps());
+    expect(refreshCostMapIfStale).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('auth --help skips the cost-map refresh', async () => {
+    await runCLI(['auth', '--help'], baseDeps());
+    expect(refreshCostMapIfStale).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('auth status --help skips the cost-map refresh', async () => {
+    await runCLI(['auth', 'status', '--help'], baseDeps());
+    expect(refreshCostMapIfStale).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('doctor --help (online) still refreshes the cost map', async () => {
+    await runCLI(['doctor', '--help'], baseDeps());
+    expect(refreshCostMapIfStale).toHaveBeenCalledOnce();
+  });
+
+  it('top-level help still refreshes the cost map', async () => {
+    await runCLI(['help'], baseDeps());
+    expect(refreshCostMapIfStale).toHaveBeenCalledOnce();
+  });
+});

--- a/src/__tests__/telemetry-tracking.test.js
+++ b/src/__tests__/telemetry-tracking.test.js
@@ -12,7 +12,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const trackSucceeded = vi.fn();
 const trackFailed = vi.fn();
 
-vi.mock('../telemetry.js', () => ({
+vi.mock('../telemetry.js', async (importOriginal) => ({
+  ...(await importOriginal()),
   trackCommandSucceeded: trackSucceeded,
   trackCommandFailed: trackFailed,
   getAnonymousId: () => 'test-anon-id',
@@ -172,18 +173,28 @@ describe('telemetry tracking for all first-level commands', () => {
     };
   }
 
-  it('auth status', withWalletPassword(async () => {
+  // `auth` and `doctor --offline` promise ZERO network activity, which
+  // includes telemetry — they are deliberately untracked.
+  it('auth status does not trigger telemetry (offline contract)', withWalletPassword(async () => {
     await runCLI(['auth', 'status'], baseDeps());
-    expect(wasTracked()).toBe(1);
-    expect(trackSucceeded).toHaveBeenCalledOnce();
-    expect(trackSucceeded.mock.calls[0][0].command).toBe('auth status');
+    expect(wasTracked()).toBe(0);
   }));
 
-  it('doctor (--offline keeps the test off the network)', withWalletPassword(async () => {
+  it('doctor --offline does not trigger telemetry (offline contract)', withWalletPassword(async () => {
     await runCLI(['doctor', '--offline'], baseDeps());
-    expect(wasTracked()).toBe(1);
-    expect(trackSucceeded).toHaveBeenCalledOnce();
-    expect(trackSucceeded.mock.calls[0][0].command).toBe('doctor');
+    expect(wasTracked()).toBe(0);
+  }));
+
+  it('doctor without --offline tracks normally', withWalletPassword(async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+    try {
+      await runCLI(['doctor'], baseDeps());
+      expect(wasTracked()).toBe(1);
+      expect(trackSucceeded).toHaveBeenCalledOnce();
+      expect(trackSucceeded.mock.calls[0][0].command).toBe('doctor');
+    } finally {
+      vi.unstubAllGlobals();
+    }
   }));
 
   it('wallet (help subcommand)', async () => {
@@ -272,7 +283,8 @@ describe('telemetry tracking for all first-level commands', () => {
       // research sub-categories (tested via both `research <cat>` and deprecated alias)
       'smart-money', 'profiler', 'token', 'search', 'perp', 'portfolio', 'points', 'prediction-market',
       'research',
-      // operational
+      // operational ('auth' and 'doctor --offline' are tested as deliberately
+      // untracked — the offline contract covers telemetry)
       'account', 'auth', 'doctor', 'login', 'logout', 'schema', 'cache', 'changelog',
       'web',
       // wallet, trading, bridge & perp

--- a/src/__tests__/telemetry-tracking.test.js
+++ b/src/__tests__/telemetry-tracking.test.js
@@ -157,6 +157,35 @@ describe('telemetry tracking for all first-level commands', () => {
     expect(trackSucceeded.mock.calls[0][0].command).toBe('changelog');
   });
 
+  // auth/doctor are offline but still read the wallet password source; pin the
+  // env var so retrievePassword() never touches the real OS keychain.
+  function withWalletPassword(fn) {
+    return async () => {
+      const prev = process.env.NANSEN_WALLET_PASSWORD;
+      process.env.NANSEN_WALLET_PASSWORD = 'test-pw';
+      try {
+        await fn();
+      } finally {
+        if (prev === undefined) delete process.env.NANSEN_WALLET_PASSWORD;
+        else process.env.NANSEN_WALLET_PASSWORD = prev;
+      }
+    };
+  }
+
+  it('auth status', withWalletPassword(async () => {
+    await runCLI(['auth', 'status'], baseDeps());
+    expect(wasTracked()).toBe(1);
+    expect(trackSucceeded).toHaveBeenCalledOnce();
+    expect(trackSucceeded.mock.calls[0][0].command).toBe('auth status');
+  }));
+
+  it('doctor (--offline keeps the test off the network)', withWalletPassword(async () => {
+    await runCLI(['doctor', '--offline'], baseDeps());
+    expect(wasTracked()).toBe(1);
+    expect(trackSucceeded).toHaveBeenCalledOnce();
+    expect(trackSucceeded.mock.calls[0][0].command).toBe('doctor');
+  }));
+
   it('wallet (help subcommand)', async () => {
     await runCLI(['wallet'], baseDeps());
     expect(wasTracked()).toBe(1);
@@ -244,7 +273,7 @@ describe('telemetry tracking for all first-level commands', () => {
       'smart-money', 'profiler', 'token', 'search', 'perp', 'portfolio', 'points', 'prediction-market',
       'research',
       // operational
-      'account', 'login', 'logout', 'schema', 'cache', 'changelog',
+      'account', 'auth', 'doctor', 'login', 'logout', 'schema', 'cache', 'changelog',
       'web',
       // wallet, trading, bridge & perp
       'wallet', 'trade', 'quote', 'execute', 'bridge-status', 'bridge', 'perp',

--- a/src/cli.js
+++ b/src/cli.js
@@ -1839,10 +1839,17 @@ export async function runCLI(rawArgs, deps = {}) {
   const stream = flags.stream || flags.s;
   const csv = options.format === 'csv';
 
+  // `auth` and `doctor --offline` promise zero network activity — that
+  // contract covers the background update-check fetch and telemetry too,
+  // not just the command's own requests.
+  const isOfflineCommand = command === 'auth' || (command === 'doctor' && flags.offline);
+  const trackSucceeded = isOfflineCommand ? async () => {} : trackCommandSucceeded;
+  const trackFailed = isOfflineCommand ? async () => {} : trackCommandFailed;
+
   // Update check (read cached result + schedule background refresh)
   const updateNotification = getUpdateNotification(VERSION);
   const upgradeNotice = getUpgradeNotice(VERSION);
-  scheduleUpdateCheck();
+  if (!isOfflineCommand) scheduleUpdateCheck();
   const notify = () => {
     if (upgradeNotice) errorOutput(upgradeNotice);
     if (updateNotification) errorOutput(updateNotification);
@@ -1996,7 +2003,7 @@ export async function runCLI(rawArgs, deps = {}) {
     };
     const formatted = formatOutput(errorData, { pretty, table });
     output(formatted.text);
-    await trackCommandFailed({ command: fullCommand, duration_ms: Date.now() - startTime, error_code: 'UNKNOWN_COMMAND', flags: usedFlags, chain });
+    await trackFailed({ command: fullCommand, duration_ms: Date.now() - startTime, error_code: 'UNKNOWN_COMMAND', flags: usedFlags, chain });
     exit(1);
     return { type: 'error', data: errorData };
   }
@@ -2049,7 +2056,7 @@ export async function runCLI(rawArgs, deps = {}) {
 
     // Commands that handle their own output return undefined
     if (result === undefined) {
-      await trackCommandSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, flags: usedFlags, chain });
+      await trackSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, flags: usedFlags, chain });
       return { type: 'no-output', command };
     }
 
@@ -2057,7 +2064,7 @@ export async function runCLI(rawArgs, deps = {}) {
     if (command === 'schema') {
       const formatted = formatOutput(result, { pretty, table: false });
       output(formatted.text);
-      await trackCommandSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, flags: usedFlags, chain });
+      await trackSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, flags: usedFlags, chain });
       return { type: 'schema', data: result };
     }
 
@@ -2070,7 +2077,7 @@ export async function runCLI(rawArgs, deps = {}) {
     // Alerts list with --table uses custom table format
     if (command === 'alerts' && subcommand === 'list' && table) {
       output(formatAlertsTable(result));
-      await trackCommandSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, flags: usedFlags, chain });
+      await trackSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, flags: usedFlags, chain });
       return { type: 'success', data: result };
     }
 
@@ -2081,14 +2088,14 @@ export async function runCLI(rawArgs, deps = {}) {
       if (streamOutput) {
         output(streamOutput);
       }
-      await trackCommandSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, from_cache: !!result?.fromCache, flags: usedFlags, chain });
+      await trackSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, from_cache: !!result?.fromCache, flags: usedFlags, chain });
       return { type: 'stream', data: result };
     }
 
     const successData = { success: true, data: result };
     const formatted = formatOutput(successData, { pretty, table, csv });
     output(formatted.text);
-    await trackCommandSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, from_cache: !!result?.fromCache, flags: usedFlags, chain });
+    await trackSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, from_cache: !!result?.fromCache, flags: usedFlags, chain });
     return { type: csv ? 'csv' : 'success', data: result };
   } catch (error) {
     // Unified error envelope across all command families (perp/bridge/trade):
@@ -2103,7 +2110,7 @@ export async function runCLI(rawArgs, deps = {}) {
       const formatted = formatOutput(errorData, { pretty, table, csv });
       output(formatted.text);
     }
-    await trackCommandFailed({
+    await trackFailed({
       command: fullCommand,
       duration_ms: Date.now() - startTime,
       error_code: error.code || 'UNKNOWN',

--- a/src/cli.js
+++ b/src/cli.js
@@ -1870,7 +1870,9 @@ export async function runCLI(rawArgs, deps = {}) {
   }
 
   if (command === 'help' || flags.help || flags.h) {
-    await refreshCostMapIfStale();
+    // Help for an offline command still owes the zero-network contract: the
+    // cost-map refresh fetches the OpenAPI spec and writes ~/.nansen/cost-map.json.
+    if (!isOfflineCommand) await refreshCostMapIfStale();
     // Check for subcommand-specific help: nansen <command> <subcommand> --help
     if (flags.help || flags.h) {
       // Handle 'research <category> <sub> --help' (3-level)

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,6 +15,7 @@ import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from './comman
 import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
+import { getAuthStatus, runDoctorChecks, runConnectivityChecks, formatDoctorReport } from './doctor.js';
 import { refreshCostMapIfStale, getCostForEndpoint, creditsCharged } from './cost-cache.js';
 import { creditWarning, noticeWarnings } from './response-meta.js';
 import { trackCommandSucceeded, trackCommandFailed } from './telemetry.js';
@@ -22,7 +23,7 @@ import { createRequire } from 'module';
 import * as readline from 'readline';
 
 const require = createRequire(import.meta.url);
-const { version: VERSION } = require('../package.json');
+const { version: VERSION, engines: ENGINES } = require('../package.json');
 
 // ============= Schema Definition =============
 
@@ -189,7 +190,7 @@ export function parseArgs(args) {
       const key = arg.slice(2);
       const next = args[i + 1];
       
-      if (key === 'pretty' || key === 'help' || key === 'version' || key === 'table' || key === 'no-retry' || key === 'cache' || key === 'no-cache' || key === 'stream' || key === 'enrich' || key === 'full' || key === 'human' || key === 'enabled' || key === 'disabled' || key === 'expert' || key === 'json') {
+      if (key === 'pretty' || key === 'help' || key === 'version' || key === 'table' || key === 'no-retry' || key === 'cache' || key === 'no-cache' || key === 'stream' || key === 'enrich' || key === 'full' || key === 'human' || key === 'enabled' || key === 'disabled' || key === 'expert' || key === 'json' || key === 'offline') {
         result.flags[key] = true;
       } else if (next && (!next.startsWith('-') || /^-\d/.test(next))) {
         // Try to parse as JSON first (for objects/arrays/booleans),
@@ -729,8 +730,10 @@ COMMANDS:
   alerts      list, create, update, toggle, delete
   web         search, fetch
   account     Show API key status, plan, and remaining credits
+  auth        status — offline auth status: key source, wallets (no network)
   login       Save API key (--api-key <key>, --human, or NANSEN_API_KEY env var)
   logout      Remove saved API key
+  doctor      Diagnostics: auth, wallets, caches, connectivity (--offline --json)
   schema      JSON schema for all commands (use "nansen schema <cmd>" for one)
   cache       clear
   changelog   --since <version> to filter
@@ -883,6 +886,31 @@ export function buildCommands(deps = {}) {
   const cmds = {
     'account': async (_args, apiInstance, _flags, _options) => {
       return apiInstance.getAccount();
+    },
+
+    'auth': async (args, _apiInstance, _flags, _options) => {
+      const subcommand = args[0] || 'status';
+      if (subcommand !== 'status') {
+        throw new NansenError(`Unknown auth subcommand: ${subcommand}. Available: status`, ErrorCode.UNKNOWN);
+      }
+      return getAuthStatus();
+    },
+
+    'doctor': async (_args, _apiInstance, flags, _options) => {
+      const checks = runDoctorChecks({ cliVersion: VERSION, engines: ENGINES });
+      if (!flags.offline) {
+        checks.push(...await runConnectivityChecks());
+      }
+      if (flags.json) {
+        return {
+          version: VERSION,
+          offline: Boolean(flags.offline),
+          checks,
+          errors: checks.filter(c => c.status === 'error').length,
+          warnings: checks.filter(c => c.status === 'warn').length,
+        };
+      }
+      log(formatDoctorReport(checks, { cliVersion: VERSION, offline: Boolean(flags.offline) }));
     },
 
     'web': async (args, apiInstance, flags, options) => {

--- a/src/doctor.js
+++ b/src/doctor.js
@@ -43,12 +43,27 @@ function getCredentialsFilePath(env) {
 
 // ============= Local Readers (never throw) =============
 
-function readJson(filePath) {
+/**
+ * Read + parse a JSON file, distinguishing "cannot read it" (permissions, IO)
+ * from "read it but it is not JSON" — the two need different diagnostics and
+ * different fixes.
+ */
+function readJsonDetailed(filePath) {
+  let raw;
   try {
-    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    raw = fs.readFileSync(filePath, 'utf8');
   } catch {
-    return null;
+    return { data: null, error: 'unreadable' };
   }
+  try {
+    return { data: JSON.parse(raw), error: null };
+  } catch {
+    return { data: null, error: 'parse' };
+  }
+}
+
+function readJson(filePath) {
+  return readJsonDetailed(filePath).data;
 }
 
 /**
@@ -73,12 +88,13 @@ function resolveAuthConfig(env, devConfigPath = DEV_CONFIG_PATH) {
 
   let config = null;
   let configPath = null;
-  let configParseError = false;
+  let configError = null;
 
   if (fs.existsSync(userConfigPath)) {
-    config = readJson(userConfigPath);
+    const result = readJsonDetailed(userConfigPath);
+    config = result.data;
     configPath = userConfigPath;
-    if (config === null) configParseError = true;
+    configError = result.error;
   }
   if (!config && fs.existsSync(devConfigPath)) {
     config = readJson(devConfigPath);
@@ -106,7 +122,7 @@ function resolveAuthConfig(env, devConfigPath = DEV_CONFIG_PATH) {
     baseUrlSource,
     configPath,
     configFileExists: fs.existsSync(userConfigPath),
-    configParseError,
+    configError,
   };
 }
 
@@ -122,25 +138,25 @@ function readWallets(env) {
     wallets: [],
     defaultWallet: null,
     passwordHashSet: false,
-    configParseError: false,
+    configError: null,
   };
   if (!result.dirExists) return result;
 
-  const walletConfig = readJson(path.join(dir, 'config.json'));
-  if (fs.existsSync(path.join(dir, 'config.json')) && walletConfig === null) {
-    result.configParseError = true;
-  }
-  result.defaultWallet = walletConfig?.defaultWallet || null;
-  result.passwordHashSet = Boolean(walletConfig?.passwordHash);
+  const configFilePath = path.join(dir, 'config.json');
+  const walletConfig = fs.existsSync(configFilePath) ? readJsonDetailed(configFilePath) : { data: null, error: null };
+  result.configError = walletConfig.error;
+  result.defaultWallet = walletConfig.data?.defaultWallet || null;
+  result.passwordHashSet = Boolean(walletConfig.data?.passwordHash);
 
   let entries = [];
   try { entries = fs.readdirSync(dir); } catch { /* unreadable dir */ }
   for (const entry of entries) {
     if (!entry.endsWith('.json') || entry === 'config.json') continue;
-    const wallet = readJson(path.join(dir, entry));
+    const wallet = readJsonDetailed(path.join(dir, entry));
     result.wallets.push({
       name: entry.replace(/\.json$/, ''),
-      provider: wallet?.provider || (wallet ? 'local' : 'unreadable'),
+      provider: wallet.data?.provider || (wallet.data ? 'local' : null),
+      error: wallet.error,
     });
   }
   return result;
@@ -203,6 +219,9 @@ export function getAuthStatus(deps = {}) {
     config_file: {
       path: getConfigFilePath(env),
       exists: auth.configFileExists,
+      // 'parse' (corrupt JSON) | 'unreadable' (permissions/IO) | null — without
+      // this, a broken config file is indistinguishable from "not logged in"
+      error: auth.configError,
     },
     base_url: {
       value: auth.baseUrl,
@@ -269,7 +288,9 @@ export function runDoctorChecks(deps = {}) {
 
   // --- auth ---
   const auth = resolveAuthConfig(env, devConfigPath);
-  if (auth.configParseError) {
+  if (auth.configError === 'unreadable') {
+    checks.push(check('config-file', 'error', `${getConfigFilePath(env)} exists but cannot be read — permission problem?`, `Check ownership and mode: ls -l ${getConfigFilePath(env)}`));
+  } else if (auth.configError === 'parse') {
     checks.push(check('config-file', 'error', `${getConfigFilePath(env)} exists but is not valid JSON`, 'Run: nansen login (re-saves the file)'));
   }
   if (auth.apiKey) {
@@ -277,7 +298,7 @@ export function runDoctorChecks(deps = {}) {
       ? 'NANSEN_API_KEY env var'
       : `config file ${auth.configPath}`;
     checks.push(check('api-key', 'ok', `API key found (${maskKey(auth.apiKey)}, source: ${sourceLabel})`));
-    if (auth.apiKeySource === 'env' && auth.configFileExists && !auth.configParseError) {
+    if (auth.apiKeySource === 'env' && auth.configFileExists && !auth.configError) {
       const fileKey = readJson(getConfigFilePath(env))?.apiKey;
       if (fileKey && fileKey !== auth.apiKey) {
         checks.push(check('api-key-shadow', 'warn', 'NANSEN_API_KEY env var overrides a different key saved in the config file'));
@@ -303,8 +324,9 @@ export function runDoctorChecks(deps = {}) {
     : check('keychain', 'info', 'No OS keychain on this platform — wallet passwords fall back to the .credentials file'));
 
   const walletInfo = readWallets(env);
-  if (walletInfo.configParseError) {
-    checks.push(check('wallet-config', 'error', `${path.join(walletInfo.dir, 'config.json')} exists but is not valid JSON`));
+  if (walletInfo.configError) {
+    const problem = walletInfo.configError === 'unreadable' ? 'cannot be read — permission problem?' : 'is not valid JSON';
+    checks.push(check('wallet-config', 'error', `${path.join(walletInfo.dir, 'config.json')} exists but ${problem}`));
   }
   if (!walletInfo.dirExists || walletInfo.wallets.length === 0) {
     checks.push(check('wallets', 'info', 'No local wallets (only needed for trading and x402 micropayments)', 'Run: nansen wallet create <name>'));
@@ -314,9 +336,9 @@ export function runDoctorChecks(deps = {}) {
     if (walletInfo.defaultWallet && !walletInfo.wallets.some(w => w.name === walletInfo.defaultWallet)) {
       checks.push(check('default-wallet', 'error', `Default wallet "${walletInfo.defaultWallet}" has no wallet file`, 'Run: nansen wallet default <name>'));
     }
-    const unreadable = walletInfo.wallets.filter(w => w.provider === 'unreadable');
-    for (const w of unreadable) {
-      checks.push(check('wallet-file', 'error', `Wallet file ${path.join(walletInfo.dir, `${w.name}.json`)} is not valid JSON`));
+    for (const w of walletInfo.wallets.filter(w => w.error)) {
+      const problem = w.error === 'unreadable' ? 'cannot be read — permission problem?' : 'is not valid JSON';
+      checks.push(check('wallet-file', 'error', `Wallet file ${path.join(walletInfo.dir, `${w.name}.json`)} ${problem}`));
     }
     if (posixModes) {
       const walletsDirMode = fileMode(walletInfo.dir);

--- a/src/doctor.js
+++ b/src/doctor.js
@@ -1,0 +1,456 @@
+/**
+ * Nansen CLI - Offline diagnostics
+ *
+ * `nansen auth status` — where credentials come from, without any network call.
+ * `nansen doctor`      — health checks over ~/.nansen, environment, and wallets.
+ *
+ * Everything in this module is offline by design: it reads local files, env
+ * vars, and (for the wallet password) the OS keychain — never the network.
+ * Paths are resolved lazily at call time so tests can point HOME at a temp dir.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { retrievePassword } from './keychain.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const DEFAULT_BASE_URL = 'https://api.nansen.ai';
+const COST_MAP_STALE_MS = 24 * 60 * 60 * 1000;
+
+// ============= Lazy Paths =============
+
+function getHome(env) {
+  return env.HOME || env.USERPROFILE || '';
+}
+
+function getConfigDir(env) {
+  return path.join(getHome(env), '.nansen');
+}
+
+function getConfigFilePath(env) {
+  return path.join(getConfigDir(env), 'config.json');
+}
+
+function getWalletsDir(env) {
+  return path.join(getConfigDir(env), 'wallets');
+}
+
+function getCredentialsFilePath(env) {
+  return path.join(getWalletsDir(env), '.credentials');
+}
+
+// ============= Local Readers (never throw) =============
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Mask an API key for display: enough to recognise it, never enough to use it.
+ */
+export function maskKey(key) {
+  if (typeof key !== 'string' || key.length === 0) return null;
+  // Below 12 chars, first4+last4 would disclose most of the key
+  if (key.length < 12) return '****';
+  return `${key.slice(0, 4)}…${key.slice(-4)}`;
+}
+
+const DEV_CONFIG_PATH = path.join(__dirname, '..', 'config.json');
+
+/**
+ * Resolve the API key and base URL the way src/api.js loadConfig() does —
+ * ~/.nansen/config.json, then the repo-local dev config.json, then env
+ * overrides — but lazily and without secrets leaving this function unmasked.
+ */
+function resolveAuthConfig(env, devConfigPath = DEV_CONFIG_PATH) {
+  const userConfigPath = getConfigFilePath(env);
+
+  let config = null;
+  let configPath = null;
+  let configParseError = false;
+
+  if (fs.existsSync(userConfigPath)) {
+    config = readJson(userConfigPath);
+    configPath = userConfigPath;
+    if (config === null) configParseError = true;
+  }
+  if (!config && fs.existsSync(devConfigPath)) {
+    config = readJson(devConfigPath);
+    if (config) configPath = devConfigPath;
+  }
+
+  let apiKey = config?.apiKey || null;
+  let apiKeySource = apiKey ? (configPath === devConfigPath ? 'dev-config' : 'config') : null;
+  if (env.NANSEN_API_KEY) {
+    apiKey = env.NANSEN_API_KEY;
+    apiKeySource = 'env';
+  }
+
+  let baseUrl = config?.baseUrl || DEFAULT_BASE_URL;
+  let baseUrlSource = config?.baseUrl ? 'config' : 'default';
+  if (env.NANSEN_BASE_URL) {
+    baseUrl = env.NANSEN_BASE_URL;
+    baseUrlSource = 'env';
+  }
+
+  return {
+    apiKey,
+    apiKeySource,
+    baseUrl,
+    baseUrlSource,
+    configPath,
+    configFileExists: fs.existsSync(userConfigPath),
+    configParseError,
+  };
+}
+
+/**
+ * Enumerate local wallets without side effects — unlike listWallets(), this
+ * never creates the wallets directory.
+ */
+function readWallets(env) {
+  const dir = getWalletsDir(env);
+  const result = {
+    dir,
+    dirExists: fs.existsSync(dir),
+    wallets: [],
+    defaultWallet: null,
+    passwordHashSet: false,
+    configParseError: false,
+  };
+  if (!result.dirExists) return result;
+
+  const walletConfig = readJson(path.join(dir, 'config.json'));
+  if (fs.existsSync(path.join(dir, 'config.json')) && walletConfig === null) {
+    result.configParseError = true;
+  }
+  result.defaultWallet = walletConfig?.defaultWallet || null;
+  result.passwordHashSet = Boolean(walletConfig?.passwordHash);
+
+  let entries = [];
+  try { entries = fs.readdirSync(dir); } catch { /* unreadable dir */ }
+  for (const entry of entries) {
+    if (!entry.endsWith('.json') || entry === 'config.json') continue;
+    const wallet = readJson(path.join(dir, entry));
+    result.wallets.push({
+      name: entry.replace(/\.json$/, ''),
+      provider: wallet?.provider || (wallet ? 'local' : 'unreadable'),
+    });
+  }
+  return result;
+}
+
+function fileMode(filePath) {
+  try {
+    return fs.statSync(filePath).mode & 0o777;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether an OS keychain is available for wallet password storage, mirroring
+ * the platform support in src/keychain.js. Checks tool presence only — never
+ * reads or writes an entry.
+ */
+function isKeychainAvailable(platform, env) {
+  if (platform === 'darwin') return fs.existsSync('/usr/bin/security');
+  if (platform === 'linux') {
+    return (env.PATH || '').split(path.delimiter).some(dir => {
+      try { return dir && fs.existsSync(path.join(dir, 'secret-tool')); } catch { return false; }
+    });
+  }
+  return false; // Windows: keychain.js always falls back to the .credentials file
+}
+
+function isInsecureMode(mode) {
+  return mode !== null && (mode & 0o077) !== 0;
+}
+
+// ============= auth status =============
+
+/**
+ * Offline authentication status. Reads config files, env vars, and the wallet
+ * store; makes no network calls. Returns a data object (rendered as JSON by
+ * the CLI layer, like `account`).
+ */
+export function getAuthStatus(deps = {}) {
+  const {
+    env = process.env,
+    retrievePasswordFn = retrievePassword,
+    devConfigPath = DEV_CONFIG_PATH,
+    platform = process.platform,
+  } = deps;
+
+  const auth = resolveAuthConfig(env, devConfigPath);
+  const walletInfo = readWallets(env);
+  const password = retrievePasswordFn();
+  const defaultEntry = walletInfo.wallets.find(w => w.name === walletInfo.defaultWallet) || null;
+
+  return {
+    logged_in: Boolean(auth.apiKey),
+    api_key: {
+      present: Boolean(auth.apiKey),
+      source: auth.apiKeySource,
+      masked: maskKey(auth.apiKey),
+    },
+    config_file: {
+      path: getConfigFilePath(env),
+      exists: auth.configFileExists,
+    },
+    base_url: {
+      value: auth.baseUrl,
+      source: auth.baseUrlSource,
+    },
+    x402: {
+      configured: walletInfo.wallets.length > 0,
+      wallets_dir: walletInfo.dir,
+      wallet_count: walletInfo.wallets.length,
+      default_wallet: walletInfo.defaultWallet,
+      default_wallet_provider: defaultEntry?.provider || null,
+      password: {
+        available: Boolean(password.password),
+        source: password.source,
+        keychain_available: isKeychainAvailable(platform, env),
+      },
+    },
+    offline: true,
+  };
+}
+
+// ============= doctor =============
+
+function check(id, status, message, fix = null) {
+  const result = { id, status, message };
+  if (fix) result.fix = fix;
+  return result;
+}
+
+function parseEngineMajor(requirement) {
+  const match = /(\d+)/.exec(requirement || '');
+  return match ? parseInt(match[1], 10) : null;
+}
+
+/**
+ * Run all offline diagnostics. Returns an array of
+ * { id, status: 'ok'|'warn'|'error'|'info', message, fix? } checks.
+ */
+export function runDoctorChecks(deps = {}) {
+  const {
+    env = process.env,
+    retrievePasswordFn = retrievePassword,
+    nodeVersion = process.version,
+    cliVersion = null,
+    engines = null,
+    devConfigPath = DEV_CONFIG_PATH,
+    platform = process.platform,
+  } = deps;
+
+  const checks = [];
+
+  // --- environment ---
+  const requiredMajor = parseEngineMajor(engines?.node) ?? 20;
+  const currentMajor = parseInt(nodeVersion.replace(/^v/, ''), 10);
+  checks.push(currentMajor >= requiredMajor
+    ? check('node-version', 'ok', `Node ${nodeVersion} (>= ${requiredMajor} required)`)
+    : check('node-version', 'error', `Node ${nodeVersion} is below the required major version ${requiredMajor}`, `Install Node >= ${requiredMajor}: https://nodejs.org`));
+
+  if (env.NANSEN_BASE_URL) {
+    checks.push(check('base-url', 'warn', `NANSEN_BASE_URL override active: ${env.NANSEN_BASE_URL}`, 'Unset NANSEN_BASE_URL to use https://api.nansen.ai'));
+  } else {
+    checks.push(check('base-url', 'ok', `API base URL: ${DEFAULT_BASE_URL}`));
+  }
+
+  // --- auth ---
+  const auth = resolveAuthConfig(env, devConfigPath);
+  if (auth.configParseError) {
+    checks.push(check('config-file', 'error', `${getConfigFilePath(env)} exists but is not valid JSON`, 'Run: nansen login (re-saves the file)'));
+  }
+  if (auth.apiKey) {
+    const sourceLabel = auth.apiKeySource === 'env'
+      ? 'NANSEN_API_KEY env var'
+      : `config file ${auth.configPath}`;
+    checks.push(check('api-key', 'ok', `API key found (${maskKey(auth.apiKey)}, source: ${sourceLabel})`));
+    if (auth.apiKeySource === 'env' && auth.configFileExists && !auth.configParseError) {
+      const fileKey = readJson(getConfigFilePath(env))?.apiKey;
+      if (fileKey && fileKey !== auth.apiKey) {
+        checks.push(check('api-key-shadow', 'warn', 'NANSEN_API_KEY env var overrides a different key saved in the config file'));
+      }
+    }
+  } else {
+    checks.push(check('api-key', auth.configFileExists ? 'error' : 'warn', 'No API key configured', 'Run: nansen login --api-key <key>  (or fund an x402 wallet for pay-per-call access)'));
+  }
+  // POSIX modes are meaningless on Windows — fs.stat reports 0o666 for every
+  // file there, which would warn on all of them
+  const posixModes = platform !== 'win32';
+  if (posixModes) {
+    const configMode = fileMode(getConfigFilePath(env));
+    if (isInsecureMode(configMode)) {
+      checks.push(check('config-perms', 'warn', `${getConfigFilePath(env)} has insecure permissions (${configMode.toString(8)})`, `Run: chmod 600 ${getConfigFilePath(env)}`));
+    }
+  }
+
+  // --- wallets / x402 ---
+  const keychainAvailable = isKeychainAvailable(platform, env);
+  checks.push(keychainAvailable
+    ? check('keychain', 'ok', 'OS keychain available for wallet password storage')
+    : check('keychain', 'info', 'No OS keychain on this platform — wallet passwords fall back to the .credentials file'));
+
+  const walletInfo = readWallets(env);
+  if (walletInfo.configParseError) {
+    checks.push(check('wallet-config', 'error', `${path.join(walletInfo.dir, 'config.json')} exists but is not valid JSON`));
+  }
+  if (!walletInfo.dirExists || walletInfo.wallets.length === 0) {
+    checks.push(check('wallets', 'info', 'No local wallets (only needed for trading and x402 micropayments)', 'Run: nansen wallet create <name>'));
+  } else {
+    const defaultNote = walletInfo.defaultWallet ? `default: ${walletInfo.defaultWallet}` : 'no default set';
+    checks.push(check('wallets', 'ok', `${walletInfo.wallets.length} wallet${walletInfo.wallets.length === 1 ? '' : 's'} in ${walletInfo.dir} (${defaultNote})`));
+    if (walletInfo.defaultWallet && !walletInfo.wallets.some(w => w.name === walletInfo.defaultWallet)) {
+      checks.push(check('default-wallet', 'error', `Default wallet "${walletInfo.defaultWallet}" has no wallet file`, 'Run: nansen wallet default <name>'));
+    }
+    const unreadable = walletInfo.wallets.filter(w => w.provider === 'unreadable');
+    for (const w of unreadable) {
+      checks.push(check('wallet-file', 'error', `Wallet file ${path.join(walletInfo.dir, `${w.name}.json`)} is not valid JSON`));
+    }
+    if (posixModes) {
+      const walletsDirMode = fileMode(walletInfo.dir);
+      if (isInsecureMode(walletsDirMode)) {
+        checks.push(check('wallets-perms', 'warn', `${walletInfo.dir} has insecure permissions (${walletsDirMode.toString(8)})`, `Run: chmod 700 ${walletInfo.dir}`));
+      }
+    }
+
+    // Password storage — only relevant once wallets exist
+    const password = retrievePasswordFn();
+    if (password.source === 'file') {
+      checks.push(check('wallet-password', 'warn', 'Wallet password stored in the insecure .credentials file', 'Run: nansen wallet secure  (migrates it to the OS keychain)'));
+    } else if (password.source) {
+      checks.push(check('wallet-password', 'ok', `Wallet password available (source: ${password.source})`));
+    } else if (walletInfo.passwordHashSet) {
+      checks.push(check('wallet-password', 'warn', 'Wallets are password-protected but no password is stored — x402 payments and trading will fail non-interactively', 'Set NANSEN_WALLET_PASSWORD, or store it: nansen wallet secure'));
+    }
+    if (password.source !== 'file' && fs.existsSync(getCredentialsFilePath(env))) {
+      checks.push(check('stale-credentials', 'warn', `${getCredentialsFilePath(env)} still exists but is not the active password source`, `Delete it: rm ${getCredentialsFilePath(env)}`));
+    }
+
+    // Privy wallets need API credentials from the environment
+    const hasPrivyWallet = walletInfo.wallets.some(w => w.provider === 'privy');
+    if (hasPrivyWallet && (!env.PRIVY_APP_ID || !env.PRIVY_APP_SECRET)) {
+      checks.push(check('privy-env', 'warn', 'Privy wallet present but PRIVY_APP_ID / PRIVY_APP_SECRET are not set', 'Export both env vars to use Privy wallets'));
+    }
+  }
+
+  // --- caches ---
+  const cacheDir = path.join(getConfigDir(env), 'cache');
+  let cacheCount = 0;
+  try { cacheCount = fs.readdirSync(cacheDir).filter(f => f.endsWith('.json')).length; } catch { /* missing dir */ }
+  checks.push(check('response-cache', 'info', `Response cache: ${cacheCount} entr${cacheCount === 1 ? 'y' : 'ies'} (${cacheDir})`, cacheCount > 0 ? 'Clear with: nansen cache clear' : null));
+
+  const costMap = readJson(path.join(getConfigDir(env), 'cost-map.json'));
+  if (costMap?.fetchedAt) {
+    // Clamp: a future fetchedAt (clock skew, corrupt cache) is not "fetched -5h ago"
+    const ageMs = Math.max(0, Date.now() - costMap.fetchedAt);
+    const fresh = ageMs < COST_MAP_STALE_MS;
+    checks.push(check('cost-map', 'info', `Credit cost map: ${fresh ? 'fresh' : 'stale'} (fetched ${Math.round(ageMs / 3600000)}h ago)`));
+  } else {
+    checks.push(check('cost-map', 'info', 'Credit cost map not cached yet (refreshes on next nansen help)'));
+  }
+
+  if (cliVersion) {
+    const updateCache = readJson(path.join(getConfigDir(env), 'update-check.json'));
+    if (updateCache?.latest && updateCache.latest !== cliVersion) {
+      const [lM, lm, lp] = updateCache.latest.split('.').map(Number);
+      const [cM, cm, cp] = cliVersion.split('.').map(Number);
+      const newer = lM > cM || (lM === cM && (lm > cm || (lm === cm && lp > cp)));
+      if (newer) {
+        checks.push(check('cli-version', 'warn', `Update available: ${cliVersion} → ${updateCache.latest}`, 'Run: npm i -g nansen-cli'));
+      } else {
+        checks.push(check('cli-version', 'ok', `nansen-cli ${cliVersion} is up to date`));
+      }
+    } else if (updateCache?.latest) {
+      checks.push(check('cli-version', 'ok', `nansen-cli ${cliVersion} is up to date`));
+    } else {
+      checks.push(check('cli-version', 'info', `nansen-cli ${cliVersion} (no update-check cache yet)`));
+    }
+  }
+
+  const loAuth = readJson(path.join(getConfigDir(env), 'limit-order-auth.json'));
+  if (loAuth?.expiresAt) {
+    const valid = loAuth.expiresAt > Date.now() + 300_000;
+    checks.push(check('limit-order-jwt', 'info', `Limit-order session: ${valid ? 'valid' : 'expired'} (re-authenticates automatically)`));
+  }
+
+  // --- telemetry ---
+  // Same predicate as src/telemetry.js — only the literal '1' disables it
+  const telemetryOff = env.NANSEN_NO_TELEMETRY === '1' || env.DO_NOT_TRACK === '1';
+  checks.push(check('telemetry', 'info', telemetryOff ? 'Telemetry disabled' : 'Anonymous telemetry enabled (disable: DO_NOT_TRACK=1)'));
+
+  return checks;
+}
+
+/**
+ * Safe connectivity check: an unauthenticated GET against the configured API
+ * base URL. No API key is sent and no credits are consumed. Any HTTP response
+ * proves reachability; only a network failure or timeout is a problem — so
+ * `doctor` stays useful for diagnosing exactly the "API is unavailable" case.
+ */
+export async function runConnectivityChecks(deps = {}) {
+  const {
+    env = process.env,
+    fetchFn = fetch,
+    timeoutMs = 5000,
+    devConfigPath = DEV_CONFIG_PATH,
+  } = deps;
+
+  const { baseUrl } = resolveAuthConfig(env, devConfigPath);
+  const started = Date.now();
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    let response;
+    try {
+      response = await fetchFn(`${baseUrl}/openapi.json`, { method: 'GET', signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+    const ms = Date.now() - started;
+    return [check('api-reachable', 'ok', `API reachable: ${baseUrl} (HTTP ${response.status}, ${ms}ms)`)];
+  } catch (error) {
+    const reason = error.name === 'AbortError'
+      ? `timed out after ${timeoutMs}ms`
+      : (error.cause?.code || error.message);
+    return [check('api-reachable', 'error', `API unreachable: ${baseUrl} (${reason})`, 'Check your network/proxy. The offline checks above remain valid.')];
+  }
+}
+
+const STATUS_ICONS = { ok: '✓', warn: '⚠️ ', error: '❌', info: 'ℹ' };
+
+/**
+ * Render doctor checks as human-readable lines with a summary tail.
+ */
+export function formatDoctorReport(checks, { cliVersion = null, offline = false } = {}) {
+  const lines = [];
+  const mode = offline
+    ? 'offline diagnostics (no network calls)'
+    : 'diagnostics (local checks + a credit-free connectivity probe; --offline to skip network)';
+  lines.push(`Nansen CLI doctor${cliVersion ? ` v${cliVersion}` : ''} — ${mode}`);
+  lines.push('');
+  for (const c of checks) {
+    lines.push(`${STATUS_ICONS[c.status] || ' '} ${c.message}`);
+    if (c.fix) lines.push(`    ${c.fix}`);
+  }
+  const warnings = checks.filter(c => c.status === 'warn').length;
+  const errors = checks.filter(c => c.status === 'error').length;
+  lines.push('');
+  if (warnings === 0 && errors === 0) {
+    lines.push('No problems found.');
+  } else {
+    lines.push(`${errors} error${errors === 1 ? '' : 's'}, ${warnings} warning${warnings === 1 ? '' : 's'} found.`);
+  }
+  return lines.join('\n');
+}

--- a/src/doctor.js
+++ b/src/doctor.js
@@ -12,7 +12,9 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { retrievePassword } from './keychain.js';
+import { passwordSource } from './keychain.js';
+import { isNewer } from './update-check.js';
+import { isTelemetryDisabled } from './telemetry.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -135,6 +137,7 @@ function readWallets(env) {
   const result = {
     dir,
     dirExists: fs.existsSync(dir),
+    dirError: null,
     wallets: [],
     defaultWallet: null,
     passwordHashSet: false,
@@ -149,7 +152,7 @@ function readWallets(env) {
   result.passwordHashSet = Boolean(walletConfig.data?.passwordHash);
 
   let entries = [];
-  try { entries = fs.readdirSync(dir); } catch { /* unreadable dir */ }
+  try { entries = fs.readdirSync(dir); } catch { result.dirError = 'unreadable'; }
   for (const entry of entries) {
     if (!entry.endsWith('.json') || entry === 'config.json') continue;
     const wallet = readJsonDetailed(path.join(dir, entry));
@@ -199,14 +202,14 @@ function isInsecureMode(mode) {
 export function getAuthStatus(deps = {}) {
   const {
     env = process.env,
-    retrievePasswordFn = retrievePassword,
+    passwordSourceFn = passwordSource,
     devConfigPath = DEV_CONFIG_PATH,
     platform = process.platform,
   } = deps;
 
   const auth = resolveAuthConfig(env, devConfigPath);
   const walletInfo = readWallets(env);
-  const password = retrievePasswordFn();
+  const pwSource = passwordSourceFn();
   const defaultEntry = walletInfo.wallets.find(w => w.name === walletInfo.defaultWallet) || null;
 
   return {
@@ -230,12 +233,13 @@ export function getAuthStatus(deps = {}) {
     x402: {
       configured: walletInfo.wallets.length > 0,
       wallets_dir: walletInfo.dir,
+      wallets_dir_error: walletInfo.dirError,
       wallet_count: walletInfo.wallets.length,
       default_wallet: walletInfo.defaultWallet,
       default_wallet_provider: defaultEntry?.provider || null,
       password: {
-        available: Boolean(password.password),
-        source: password.source,
+        available: pwSource !== null,
+        source: pwSource,
         keychain_available: isKeychainAvailable(platform, env),
       },
     },
@@ -263,7 +267,7 @@ function parseEngineMajor(requirement) {
 export function runDoctorChecks(deps = {}) {
   const {
     env = process.env,
-    retrievePasswordFn = retrievePassword,
+    passwordSourceFn = passwordSource,
     nodeVersion = process.version,
     cliVersion = null,
     engines = null,
@@ -272,6 +276,7 @@ export function runDoctorChecks(deps = {}) {
   } = deps;
 
   const checks = [];
+  const auth = resolveAuthConfig(env, devConfigPath);
 
   // --- environment ---
   const requiredMajor = parseEngineMajor(engines?.node) ?? 20;
@@ -280,16 +285,19 @@ export function runDoctorChecks(deps = {}) {
     ? check('node-version', 'ok', `Node ${nodeVersion} (>= ${requiredMajor} required)`)
     : check('node-version', 'error', `Node ${nodeVersion} is below the required major version ${requiredMajor}`, `Install Node >= ${requiredMajor}: https://nodejs.org`));
 
-  if (env.NANSEN_BASE_URL) {
-    checks.push(check('base-url', 'warn', `NANSEN_BASE_URL override active: ${env.NANSEN_BASE_URL}`, 'Unset NANSEN_BASE_URL to use https://api.nansen.ai'));
+  // Report the URL the CLI will actually use — a config file can set a
+  // non-default base URL too, not just the env var
+  if (auth.baseUrlSource === 'env') {
+    checks.push(check('base-url', 'warn', `NANSEN_BASE_URL override active: ${auth.baseUrl}`, `Unset NANSEN_BASE_URL to use ${DEFAULT_BASE_URL}`));
+  } else if (auth.baseUrl !== DEFAULT_BASE_URL) {
+    checks.push(check('base-url', 'warn', `Non-default API base URL in ${auth.configPath}: ${auth.baseUrl}`, 'Run: nansen login (re-saves the default)'));
   } else {
-    checks.push(check('base-url', 'ok', `API base URL: ${DEFAULT_BASE_URL}`));
+    checks.push(check('base-url', 'ok', `API base URL: ${auth.baseUrl}`));
   }
 
   // --- auth ---
-  const auth = resolveAuthConfig(env, devConfigPath);
   if (auth.configError === 'unreadable') {
-    checks.push(check('config-file', 'error', `${getConfigFilePath(env)} exists but cannot be read — permission problem?`, `Check ownership and mode: ls -l ${getConfigFilePath(env)}`));
+    checks.push(check('config-file', 'error', `${getConfigFilePath(env)} exists but cannot be read — permission problem?`, `Check ownership and mode: ls -l "${getConfigFilePath(env)}"`));
   } else if (auth.configError === 'parse') {
     checks.push(check('config-file', 'error', `${getConfigFilePath(env)} exists but is not valid JSON`, 'Run: nansen login (re-saves the file)'));
   }
@@ -313,7 +321,7 @@ export function runDoctorChecks(deps = {}) {
   if (posixModes) {
     const configMode = fileMode(getConfigFilePath(env));
     if (isInsecureMode(configMode)) {
-      checks.push(check('config-perms', 'warn', `${getConfigFilePath(env)} has insecure permissions (${configMode.toString(8)})`, `Run: chmod 600 ${getConfigFilePath(env)}`));
+      checks.push(check('config-perms', 'warn', `${getConfigFilePath(env)} has insecure permissions (${configMode.toString(8)})`, `Run: chmod 600 "${getConfigFilePath(env)}"`));
     }
   }
 
@@ -328,7 +336,9 @@ export function runDoctorChecks(deps = {}) {
     const problem = walletInfo.configError === 'unreadable' ? 'cannot be read — permission problem?' : 'is not valid JSON';
     checks.push(check('wallet-config', 'error', `${path.join(walletInfo.dir, 'config.json')} exists but ${problem}`));
   }
-  if (!walletInfo.dirExists || walletInfo.wallets.length === 0) {
+  if (walletInfo.dirError) {
+    checks.push(check('wallets', 'error', `${walletInfo.dir} exists but cannot be read — permission problem?`, `Check ownership and mode: ls -ld "${walletInfo.dir}"`));
+  } else if (!walletInfo.dirExists || walletInfo.wallets.length === 0) {
     checks.push(check('wallets', 'info', 'No local wallets (only needed for trading and x402 micropayments)', 'Run: nansen wallet create <name>'));
   } else {
     const defaultNote = walletInfo.defaultWallet ? `default: ${walletInfo.defaultWallet}` : 'no default set';
@@ -343,21 +353,22 @@ export function runDoctorChecks(deps = {}) {
     if (posixModes) {
       const walletsDirMode = fileMode(walletInfo.dir);
       if (isInsecureMode(walletsDirMode)) {
-        checks.push(check('wallets-perms', 'warn', `${walletInfo.dir} has insecure permissions (${walletsDirMode.toString(8)})`, `Run: chmod 700 ${walletInfo.dir}`));
+        checks.push(check('wallets-perms', 'warn', `${walletInfo.dir} has insecure permissions (${walletsDirMode.toString(8)})`, `Run: chmod 700 "${walletInfo.dir}"`));
       }
     }
 
-    // Password storage — only relevant once wallets exist
-    const password = retrievePasswordFn();
-    if (password.source === 'file') {
+    // Password storage — only relevant once wallets exist. Metadata-only:
+    // the secret itself is never retrieved.
+    const pwSource = passwordSourceFn();
+    if (pwSource === 'file') {
       checks.push(check('wallet-password', 'warn', 'Wallet password stored in the insecure .credentials file', 'Run: nansen wallet secure  (migrates it to the OS keychain)'));
-    } else if (password.source) {
-      checks.push(check('wallet-password', 'ok', `Wallet password available (source: ${password.source})`));
+    } else if (pwSource) {
+      checks.push(check('wallet-password', 'ok', `Wallet password available (source: ${pwSource})`));
     } else if (walletInfo.passwordHashSet) {
       checks.push(check('wallet-password', 'warn', 'Wallets are password-protected but no password is stored — x402 payments and trading will fail non-interactively', 'Set NANSEN_WALLET_PASSWORD, or store it: nansen wallet secure'));
     }
-    if (password.source !== 'file' && fs.existsSync(getCredentialsFilePath(env))) {
-      checks.push(check('stale-credentials', 'warn', `${getCredentialsFilePath(env)} still exists but is not the active password source`, `Delete it: rm ${getCredentialsFilePath(env)}`));
+    if (pwSource !== 'file' && fs.existsSync(getCredentialsFilePath(env))) {
+      checks.push(check('stale-credentials', 'warn', `${getCredentialsFilePath(env)} still exists but is not the active password source`, `Delete it: rm "${getCredentialsFilePath(env)}"`));
     }
 
     // Privy wallets need API credentials from the environment
@@ -385,17 +396,10 @@ export function runDoctorChecks(deps = {}) {
 
   if (cliVersion) {
     const updateCache = readJson(path.join(getConfigDir(env), 'update-check.json'));
-    if (updateCache?.latest && updateCache.latest !== cliVersion) {
-      const [lM, lm, lp] = updateCache.latest.split('.').map(Number);
-      const [cM, cm, cp] = cliVersion.split('.').map(Number);
-      const newer = lM > cM || (lM === cM && (lm > cm || (lm === cm && lp > cp)));
-      if (newer) {
-        checks.push(check('cli-version', 'warn', `Update available: ${cliVersion} → ${updateCache.latest}`, 'Run: npm i -g nansen-cli'));
-      } else {
-        checks.push(check('cli-version', 'ok', `nansen-cli ${cliVersion} is up to date`));
-      }
-    } else if (updateCache?.latest) {
-      checks.push(check('cli-version', 'ok', `nansen-cli ${cliVersion} is up to date`));
+    if (updateCache?.latest) {
+      checks.push(isNewer(updateCache.latest, cliVersion)
+        ? check('cli-version', 'warn', `Update available: ${cliVersion} → ${updateCache.latest}`, 'Run: npm i -g nansen-cli')
+        : check('cli-version', 'ok', `nansen-cli ${cliVersion} is up to date`));
     } else {
       checks.push(check('cli-version', 'info', `nansen-cli ${cliVersion} (no update-check cache yet)`));
     }
@@ -408,9 +412,7 @@ export function runDoctorChecks(deps = {}) {
   }
 
   // --- telemetry ---
-  // Same predicate as src/telemetry.js — only the literal '1' disables it
-  const telemetryOff = env.NANSEN_NO_TELEMETRY === '1' || env.DO_NOT_TRACK === '1';
-  checks.push(check('telemetry', 'info', telemetryOff ? 'Telemetry disabled' : 'Anonymous telemetry enabled (disable: DO_NOT_TRACK=1)'));
+  checks.push(check('telemetry', 'info', isTelemetryDisabled(env) ? 'Telemetry disabled' : 'Anonymous telemetry enabled (disable: DO_NOT_TRACK=1)'));
 
   return checks;
 }

--- a/src/keychain.js
+++ b/src/keychain.js
@@ -169,6 +169,52 @@ function credentialsFileDelete() {
   }
 }
 
+// ============= Metadata-Only Checks =============
+
+function keychainHasEntry() {
+  try {
+    if (process.platform === 'darwin') {
+      // Without -w this prints attributes only — the secret never leaves the keychain
+      execFileSync('/usr/bin/security', [
+        'find-generic-password',
+        '-s', SERVICE,
+        '-a', ACCOUNT,
+      ], { timeout: TIMEOUT_MS, stdio: 'pipe' });
+      return true;
+    }
+
+    if (process.platform === 'linux') {
+      // `search` prints attributes, unlike `lookup` which prints the secret
+      const result = execFileSync('secret-tool', [
+        'search',
+        'service', SERVICE,
+        'account', ACCOUNT,
+      ], { timeout: TIMEOUT_MS, stdio: ['pipe', 'pipe', 'pipe'] });
+      return result.toString().trim().length > 0;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Where a wallet password is stored, without ever materializing the secret:
+ * env presence, keychain attribute search, and a regex test on the
+ * credentials file (the base64 value is never decoded).
+ * @returns {'env'|'keychain'|'file'|null}
+ */
+export function passwordSource() {
+  if (process.env.NANSEN_WALLET_PASSWORD) return 'env';
+  if (keychainHasEntry()) return 'keychain';
+  try {
+    const content = fs.readFileSync(getCredentialsPath(), 'utf8');
+    if (/^NANSEN_WALLET_PASSWORD(_B64)?=.+$/m.test(content)) return 'file';
+  } catch { /* missing or unreadable */ }
+  return null;
+}
+
 // ============= Public API =============
 
 /**

--- a/src/schema.json
+++ b/src/schema.json
@@ -1843,6 +1843,7 @@
             "api_key.masked",
             "config_file.path",
             "config_file.exists",
+            "config_file.error",
             "base_url.value",
             "base_url.source",
             "x402.configured",

--- a/src/schema.json
+++ b/src/schema.json
@@ -1847,6 +1847,8 @@
             "base_url.value",
             "base_url.source",
             "x402.configured",
+            "x402.wallets_dir",
+            "x402.wallets_dir_error",
             "x402.wallet_count",
             "x402.default_wallet",
             "x402.default_wallet_provider",

--- a/src/schema.json
+++ b/src/schema.json
@@ -1831,6 +1831,53 @@
     "account": {
       "description": "Show API key status, plan, and remaining credits. Does not consume credits."
     },
+    "auth": {
+      "description": "Offline authentication status. Reports API key presence and source (env var vs config file), base URL, and x402 wallet readiness without any network call. Consumes no credits.",
+      "subcommands": {
+        "status": {
+          "description": "Show where credentials come from, entirely offline",
+          "returns": [
+            "logged_in",
+            "api_key.present",
+            "api_key.source",
+            "api_key.masked",
+            "config_file.path",
+            "config_file.exists",
+            "base_url.value",
+            "base_url.source",
+            "x402.configured",
+            "x402.wallet_count",
+            "x402.default_wallet",
+            "x402.default_wallet_provider",
+            "x402.password.available",
+            "x402.password.source",
+            "x402.password.keychain_available",
+            "offline"
+          ],
+          "examples": [
+            "nansen auth status --pretty"
+          ]
+        }
+      }
+    },
+    "doctor": {
+      "description": "Diagnostics for the CLI setup: Node version, auth config, wallet storage and password hygiene, keychain availability, caches, telemetry, plus a safe API connectivity probe (unauthenticated, consumes no credits). Local checks work with the API unavailable; --offline skips network entirely.",
+      "options": {
+        "json": {
+          "type": "boolean",
+          "description": "Return machine-readable checks ({id, status, message, fix?}) instead of formatted text"
+        },
+        "offline": {
+          "type": "boolean",
+          "description": "Skip the connectivity probe — no network access at all"
+        }
+      },
+      "examples": [
+        "nansen doctor",
+        "nansen doctor --offline",
+        "nansen doctor --json --pretty"
+      ]
+    },
     "web": {
       "description": "Web search and fetch commands",
       "subcommands": {

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -26,8 +26,15 @@ const TIMEOUT_MS = 1000;
 
 // ─── opt-out ──────────────────────────────────────────────
 
-export const TELEMETRY_DISABLED =
-  process.env.DO_NOT_TRACK === '1' || process.env.NANSEN_NO_TELEMETRY === '1';
+/**
+ * The single source of truth for the opt-out predicate — only the literal '1'
+ * disables telemetry. Also used by `nansen doctor` to report telemetry state.
+ */
+export function isTelemetryDisabled(env = process.env) {
+  return env.DO_NOT_TRACK === '1' || env.NANSEN_NO_TELEMETRY === '1';
+}
+
+export const TELEMETRY_DISABLED = isTelemetryDisabled();
 
 // ─── environment ──────────────────────────────────────────
 

--- a/src/update-check.js
+++ b/src/update-check.js
@@ -18,8 +18,9 @@ const PACKAGE_NAME = 'nansen-cli';
 
 /**
  * Compare two semver strings. Returns true if latest > current.
+ * Exported so `nansen doctor` reports upgrade state with identical semantics.
  */
-function isNewer(latest, current) {
+export function isNewer(latest, current) {
   const parse = v => v.replace(/^v/, '').split('.').map(Number);
   const [lM, lm, lp] = parse(latest);
   const [cM, cm, cp] = parse(current);


### PR DESCRIPTION
Adds local-only auth/setup diagnostics, in the spirit of `gh auth status` and `aws configure list`. Resolves API-278.

## Why

`nansen account` requires a live API call and doesn't explain *where* credentials came from. There was no way to answer "am I authenticated, and from which source?" when offline, and no health check for the common broken states (insecure password file, dangling default wallet, env var silently shadowing a saved key).

## Commands

### `nansen auth status` — fully offline, zero credits

Returns a JSON data object (same output convention as `account`): API key presence + source (`env` vs `config`, value masked like `nk_x…0000` — the full key never appears in output), config file path/existence, active base URL + source (flags `NANSEN_BASE_URL` overrides), and x402 wallet readiness — wallet count, default wallet + provider, wallet-password source (`env`/`keychain`/`file`), and OS keychain availability.

### `nansen doctor` — local checks + a safe connectivity probe

✓/⚠️/❌ checklist with an actionable fix per finding; `--json` returns structured `{id, status, message, fix?}` checks:

- Node version vs the `engines` requirement
- Config file validity (corrupt JSON → finding, not crash) and permissions (`chmod` hints; skipped on Windows where POSIX modes are meaningless)
- Env key shadowing a different saved key
- Wallet storage: dangling default wallet, unreadable wallet files, dir permissions
- Password hygiene: insecure `.credentials` file → `nansen wallet secure`; password-protected wallets with no stored password (the silent x402 failure mode); stale `.credentials` beside an active keychain entry
- Privy wallets without `PRIVY_APP_ID`/`PRIVY_APP_SECRET`
- Caches (response cache, cost-map freshness, update-check → upgrade notice), telemetry state (same predicate as `telemetry.js`)
- Connectivity: unauthenticated GET to `<baseUrl>/openapi.json` — no API key sent, zero credits, 5s timeout; network failure is reported as a finding so `doctor` stays useful exactly when the API is unreachable. `--offline` skips network entirely.

## Implementation notes

- New `src/doctor.js`: lazy path resolution, injectable `env`/`platform`/`fetchFn`/`retrievePasswordFn` seams, every reader wrapped so broken state is a finding rather than a crash. Wallet enumeration deliberately avoids `listWallets()` (mkdir side effect).
- Credential resolution mirrors `loadConfig()` in `src/api.js` exactly (user config → repo-local dev config → env overrides), with the dev config reported as a distinct `dev-config` source.
- Wired into `HELP`, `schema.json` (help routing + agent discovery), the parseArgs boolean allowlist (`--offline`), and the telemetry-coverage guard.
- README troubleshooting and the keychain-migration skill now point at these commands instead of `cat ~/.nansen/config.json` / probing with `wallet export` (which prints private keys).
- 52 hermetic tests (temp HOME, stubbed keychain/fetch, platform seams); `npm test` (1917) and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
