### PR TITLE
fix(auth): warn when env key survives logout (API-253)

### DIFF
--- a/.changeset/warn-active-logout-env.md
+++ b/.changeset/warn-active-logout-env.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Warn on logout when `NANSEN_API_KEY` remains active in the environment.

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -1777,7 +1777,8 @@ describe('buildCommands', () => {
       deleteConfigFn: vi.fn(),
       getConfigFileFn: vi.fn(() => '/home/user/.nansen/config.json'),
       NansenAPIClass: vi.fn(),
-      isTTY: true
+      isTTY: true,
+      env: {}
     };
     commands = buildCommands(mockDeps);
   });
@@ -1793,13 +1794,26 @@ describe('buildCommands', () => {
     it('should report success when config deleted', async () => {
       mockDeps.deleteConfigFn.mockReturnValue(true);
       await commands.logout([], null, {}, {});
-      expect(logs[0]).toContain('Removed');
+      expect(logs).toEqual(['✓ Removed /home/user/.nansen/config.json']);
     });
 
     it('should report when no config found', async () => {
       mockDeps.deleteConfigFn.mockReturnValue(false);
       await commands.logout([], null, {}, {});
-      expect(logs[0]).toContain('No saved credentials');
+      expect(logs).toEqual(['No saved credentials found']);
+    });
+
+    it('should warn when NANSEN_API_KEY remains active', async () => {
+      mockDeps.env.NANSEN_API_KEY = 'test-key';
+      mockDeps.deleteConfigFn.mockReturnValue(true);
+
+      await commands.logout([], null, {}, {});
+
+      expect(logs).toEqual([
+        '✓ Removed /home/user/.nansen/config.json',
+        'Warning: NANSEN_API_KEY remains active. Run: unset NANSEN_API_KEY'
+      ]);
+      expect(mockDeps.NansenAPIClass).not.toHaveBeenCalled();
     });
   });
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -877,7 +877,8 @@ export function buildCommands(deps = {}) {
     saveConfigFn = saveConfig,
     deleteConfigFn = deleteConfig,
     getConfigFileFn = getConfigFile,
-    isTTY = process.stdin.isTTY
+    isTTY = process.stdin.isTTY,
+    env = process.env
   } = deps;
 
   const cmds = {
@@ -1048,6 +1049,9 @@ export function buildCommands(deps = {}) {
         log(`✓ Removed ${getConfigFileFn()}`);
       } else {
         log('No saved credentials found');
+      }
+      if (env.NANSEN_API_KEY) {
+        log('Warning: NANSEN_API_KEY remains active. Run: unset NANSEN_API_KEY');
       }
     },
 


### PR DESCRIPTION
## Summary

- warn when `NANSEN_API_KEY` remains active after `nansen logout`
- tell the user to run `unset NANSEN_API_KEY`
- preserve existing logout output when the environment variable is absent

Linear: [API-253](https://linear.app/nansen/issue/API-253)

## Security rationale

`NANSEN_API_KEY` has higher auth priority than the saved config. Deleting `~/.nansen/config.json` alone can therefore leave the CLI authenticated and give a false all-clear. The fix checks only whether the variable is active, never prints or mutates its value, and performs no network request.

## Tests

- `npm test`: 51 test files passed; 1,887 tests passed, 2 skipped
- `npm run lint`: passed
- focused logout tests verify unchanged output without the variable and the actionable warning with it

## Checklist

- [x] Tests pass (`npm test`)
- [x] `src/schema.json` unchanged; no commands or flags changed
- [x] `README.md` unchanged; no top-level commands or categories changed
- [x] Changeset added