### PR TITLE
fix: validate --slippage-bps on limit-order create

### DIFF
--- a/.changeset/validate-slippage-bps-on-create.md
+++ b/.changeset/validate-slippage-bps-on-create.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Validate `--slippage-bps` on `limit-order create`: values outside 0-10000 now fail with a clear error before any auth/API call.

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -499,6 +499,19 @@ describe('buildLimitOrderCommands', () => {
       expect(logs.some(l => l.includes('"above" or "below"'))).toBe(true);
     });
 
+    it('validates slippage-bps range', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      await cmds.create([], null, {}, {
+        from: 'SOL', to: 'USDC', amount: '1', 'trigger-mint': 'SOL',
+        'trigger-price': '80', 'trigger-condition': 'below', 'slippage-bps': '15000',
+      });
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logs.some(l => l.includes('0 and 10000'))).toBe(true);
+    });
+
     it('rejects EVM token address for --from', async () => {
       const logs = [];
       const exit = vi.fn();

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -512,6 +512,21 @@ describe('buildLimitOrderCommands', () => {
       expect(logs.some(l => l.includes('0 and 10000'))).toBe(true);
     });
 
+    it('rejects non-integer slippage-bps values (1.5, 1e2, 0x10, true)', async () => {
+      for (const bad of ['1.5', '1e2', '0x10', true]) {
+        const logs = [];
+        const exit = vi.fn();
+        const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+        await cmds.create([], null, {}, {
+          from: 'SOL', to: 'USDC', amount: '1', 'trigger-mint': 'SOL',
+          'trigger-price': '80', 'trigger-condition': 'below', 'slippage-bps': bad,
+        });
+        expect(exit).toHaveBeenCalledWith(1);
+        expect(logs.some(l => l.includes('whole integer') && l.includes('0 and 10000'))).toBe(true);
+      }
+    });
+
     it('accepts valid slippage-bps and forwards it to createOrder', async () => {
       createTestWallet('lo-create-slip');
       const logs = [];
@@ -1010,6 +1025,16 @@ describe('buildLimitOrderCommands', () => {
       await cmds.update([], null, {}, { order: 'order-1', 'slippage-bps': '15000' });
       expect(exit).toHaveBeenCalledWith(1);
       expect(logs.some(l => l.includes('0 and 10000'))).toBe(true);
+    });
+
+    it('rejects non-integer slippage-bps on update', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      await cmds.update([], null, {}, { order: 'order-1', 'slippage-bps': '1.5' });
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logs.some(l => l.includes('whole integer') && l.includes('0 and 10000'))).toBe(true);
     });
   });
 });

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -512,6 +512,32 @@ describe('buildLimitOrderCommands', () => {
       expect(logs.some(l => l.includes('0 and 10000'))).toBe(true);
     });
 
+    it('accepts valid slippage-bps and forwards it to createOrder', async () => {
+      createTestWallet('lo-create-slip');
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      mockFetchSequence([
+        { body: { challenge: 'sign this' } },
+        { body: { token: 'jwt-123' } },
+        { body: { vaultPubkey: 'vault123', userPubkey: 'pub1' } },
+        { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-req-1' } },
+        { body: { id: 'order-slip', txSignature: 'sig-slip' }, status: 201 },
+      ]);
+
+      await cmds.create([], null, {}, {
+        from: 'SOL', to: 'USDC', amount: '1', 'trigger-mint': 'SOL',
+        'trigger-condition': 'below', 'trigger-price': '80',
+        'slippage-bps': '100', wallet: 'lo-create-slip',
+      });
+
+      expect(exit).not.toHaveBeenCalled();
+      expect(logs.some(l => l.includes('Limit order created'))).toBe(true);
+      const createBody = JSON.parse(global.fetch.mock.calls[4][1].body);
+      expect(createBody.slippageBps).toBe(100);
+    });
+
     it('rejects EVM token address for --from', async () => {
       const logs = [];
       const exit = vi.fn();

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -401,6 +401,17 @@ export function parseExpiry(expiryStr) {
   throw new Error(`Invalid expiry format: "${expiryStr}". Use "24h", "7d", "30d", or epoch ms.`);
 }
 
+// Whole integer bps in [0, 10000], matching bridge parseSlippageBps.
+// Number() would accept "1.5", "1e2", "0x10", and boolean true.
+function parseSlippageBps(raw) {
+  const s = String(raw).trim();
+  const bad = 'Error: --slippage-bps must be a whole integer between 0 and 10000 basis points.';
+  if (!/^\d+$/.test(s)) throw new Error(bad);
+  const n = parseInt(s, 10);
+  if (!Number.isInteger(n) || n < 0 || n > 10000) throw new Error(bad);
+  return n;
+}
+
 // ============= Order Formatting =============
 
 function formatOrderStatus(status) {
@@ -516,7 +527,7 @@ OPTIONS:
   --trigger-mint <symbol|addr>   Token whose price triggers the order (e.g. SOL)
   --trigger-condition <cond>     "above" or "below"
   --trigger-price <usd>          Trigger price in USD (must be a positive number)
-  --slippage-bps <bps>           Slippage in basis points, 0-10000 (100 = 1%), omit for auto
+  --slippage-bps <bps>           Whole integer bps, 0-10000 (100 = 1%), omit for auto
   --expires <duration>           Expiry duration: "24h", "7d", "30d" (default: 30d)
   --wallet <name>                Wallet name (or "walletconnect"/"wc")
 
@@ -581,16 +592,16 @@ EXAMPLES:
         return;
       }
 
-      // Same bounds as update / bridge: whole-order slippage is 0–10000 bps.
+      // Same bounds as update / bridge: whole-integer bps in 0–10000.
       let slippageBps;
       if (slippageBpsRaw != null) {
-        const bps = Number(slippageBpsRaw);
-        if (isNaN(bps) || bps < 0 || bps > 10000) {
-          log('Error: --slippage-bps must be between 0 and 10000 basis points.');
+        try {
+          slippageBps = parseSlippageBps(slippageBpsRaw);
+        } catch (err) {
+          log(err.message);
           exit(1);
           return;
         }
-        slippageBps = bps;
       }
 
       let expiresAt;
@@ -832,7 +843,7 @@ Usage: nansen trade limit-order update --order <orderId> [--trigger-price <usd>]
 OPTIONS:
   --order <id>            Order ID to update
   --trigger-price <usd>   New trigger price in USD
-  --slippage-bps <bps>    Slippage in basis points (100 = 1%)
+  --slippage-bps <bps>    Whole integer bps, 0-10000 (100 = 1%)
   --wallet <name>         Wallet name (or "walletconnect"/"wc")
 
 NOTE: Only provided fields are updated. Auto slippage can only be set at creation time
@@ -862,13 +873,13 @@ EXAMPLES:
         updateBody.triggerPriceUsd = price;
       }
       if (slippageBps != null) {
-        const bps = Number(slippageBps);
-        if (isNaN(bps) || bps < 0 || bps > 10000) {
-          log('Error: --slippage-bps must be between 0 and 10000 basis points.');
+        try {
+          updateBody.slippageBps = parseSlippageBps(slippageBps);
+        } catch (err) {
+          log(err.message);
           exit(1);
           return;
         }
-        updateBody.slippageBps = bps;
       }
 
       try {

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -501,7 +501,7 @@ export function buildLimitOrderCommands(deps = {}) {
       const triggerPrice = options['trigger-price'];
       const triggerCondition = options['trigger-condition'];
       const triggerMintRaw = options['trigger-mint'];
-      const slippageBps = options['slippage-bps'] != null ? Number(options['slippage-bps']) : undefined;
+      const slippageBpsRaw = options['slippage-bps'];
       const expiresStr = options.expires || '30d';
       const walletName = options.wallet;
 
@@ -516,7 +516,7 @@ OPTIONS:
   --trigger-mint <symbol|addr>   Token whose price triggers the order (e.g. SOL)
   --trigger-condition <cond>     "above" or "below"
   --trigger-price <usd>          Trigger price in USD (must be a positive number)
-  --slippage-bps <bps>               Slippage in basis points (100 = 1%), omit for auto
+  --slippage-bps <bps>           Slippage in basis points, 0-10000 (100 = 1%), omit for auto
   --expires <duration>           Expiry duration: "24h", "7d", "30d" (default: 30d)
   --wallet <name>                Wallet name (or "walletconnect"/"wc")
 
@@ -579,6 +579,18 @@ EXAMPLES:
         log('Error: --trigger-condition must be "above" or "below".');
         exit(1);
         return;
+      }
+
+      // Same bounds as update / bridge: whole-order slippage is 0–10000 bps.
+      let slippageBps;
+      if (slippageBpsRaw != null) {
+        const bps = Number(slippageBpsRaw);
+        if (isNaN(bps) || bps < 0 || bps > 10000) {
+          log('Error: --slippage-bps must be between 0 and 10000 basis points.');
+          exit(1);
+          return;
+        }
+        slippageBps = bps;
       }
 
       let expiresAt;

--- a/src/schema.json
+++ b/src/schema.json
@@ -1682,7 +1682,7 @@
                 },
                 "slippage-bps": {
                   "type": "number",
-                  "description": "Slippage in whole basis points, 0-10000 (50 = 0.5%), omit for auto"
+                  "description": "Slippage as a whole integer in basis points, 0-10000 (50 = 0.5%), omit for auto"
                 },
                 "expires": {
                   "type": "string",
@@ -1771,7 +1771,7 @@
                 },
                 "slippage-bps": {
                   "type": "number",
-                  "description": "New slippage in basis points (0-10000)"
+                  "description": "New slippage as a whole integer in basis points (0-10000)"
                 },
                 "wallet": {
                   "type": "string",

--- a/src/schema.json
+++ b/src/schema.json
@@ -1682,7 +1682,7 @@
                 },
                 "slippage-bps": {
                   "type": "number",
-                  "description": "Slippage tolerance in basis points (e.g. 50 = 0.5%)"
+                  "description": "Slippage in whole basis points, 0-10000 (50 = 0.5%), omit for auto"
                 },
                 "expires": {
                   "type": "string",


### PR DESCRIPTION
## Summary
- Validate `--slippage-bps` on `limit-order create` with the same 0–10000 bounds already used by `update` (and bridge)
- Reject invalid values client-side before auth/deposit/API calls
- Align schema/help text with the enforced range
- Add regression tests for out-of-range and valid create input

## Test plan
- [x] `npx vitest run src/__tests__/limit-order.test.js -t slippage`
- [x] `nansen trade limit-order create ... --slippage-bps 15000` → error, exits 1
- [x] `nansen trade limit-order create ... --slippage-bps 100` → accepted (with other required flags)
- [x] Omit `--slippage-bps` → still allowed (auto)