### PR TITLE
fix: reject --oid values above 2^53-1 on perp cancel

### DIFF
--- a/.changeset/perp-cancel-oid-safe-integer.md
+++ b/.changeset/perp-cancel-oid-safe-integer.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Reject `--oid` values above 2^53-1 on `perp cancel`: large Hyperliquid uint64 order IDs would be silently rounded by JS Number, potentially cancelling the wrong order.

--- a/.changeset/validate-slippage-bps-on-create.md
+++ b/.changeset/validate-slippage-bps-on-create.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Validate `--slippage-bps` on `limit-order create`: values outside 0-10000 now fail with a clear error before any auth/API call.

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -499,6 +499,19 @@ describe('buildLimitOrderCommands', () => {
       expect(logs.some(l => l.includes('"above" or "below"'))).toBe(true);
     });
 
+    it('validates slippage-bps range', async () => {
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      await cmds.create([], null, {}, {
+        from: 'SOL', to: 'USDC', amount: '1', 'trigger-mint': 'SOL',
+        'trigger-price': '80', 'trigger-condition': 'below', 'slippage-bps': '15000',
+      });
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logs.some(l => l.includes('0 and 10000'))).toBe(true);
+    });
+
     it('rejects EVM token address for --from', async () => {
       const logs = [];
       const exit = vi.fn();

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -512,6 +512,32 @@ describe('buildLimitOrderCommands', () => {
       expect(logs.some(l => l.includes('0 and 10000'))).toBe(true);
     });
 
+    it('accepts valid slippage-bps and forwards it to createOrder', async () => {
+      createTestWallet('lo-create-slip');
+      const logs = [];
+      const exit = vi.fn();
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+      mockFetchSequence([
+        { body: { challenge: 'sign this' } },
+        { body: { token: 'jwt-123' } },
+        { body: { vaultPubkey: 'vault123', userPubkey: 'pub1' } },
+        { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-req-1' } },
+        { body: { id: 'order-slip', txSignature: 'sig-slip' }, status: 201 },
+      ]);
+
+      await cmds.create([], null, {}, {
+        from: 'SOL', to: 'USDC', amount: '1', 'trigger-mint': 'SOL',
+        'trigger-condition': 'below', 'trigger-price': '80',
+        'slippage-bps': '100', wallet: 'lo-create-slip',
+      });
+
+      expect(exit).not.toHaveBeenCalled();
+      expect(logs.some(l => l.includes('Limit order created'))).toBe(true);
+      const createBody = JSON.parse(global.fetch.mock.calls[4][1].body);
+      expect(createBody.slippageBps).toBe(100);
+    });
+
     it('rejects EVM token address for --from', async () => {
       const logs = [];
       const exit = vi.fn();

--- a/src/__tests__/perp.test.js
+++ b/src/__tests__/perp.test.js
@@ -260,6 +260,21 @@ describe('perp cancel validation', () => {
       cmds.cancel([], null, {}, { coin: 'ETH', oid: '0', wallet: 'x' }),
     ).rejects.toThrow(/Invalid --oid "0"/);
   });
+
+  it('rejects --oid above 2^53-1 to prevent silent rounding of large uint64 ids', async () => {
+    const unsafeOid = String(Number.MAX_SAFE_INTEGER + 1); // 9007199254740992
+    await expect(
+      cmds.cancel([], null, {}, { coin: 'ETH', oid: unsafeOid, wallet: 'x' }),
+    ).rejects.toThrow(/exceeds safe integer precision/);
+  });
+
+  it('accepts --oid exactly at 2^53-1 (MAX_SAFE_INTEGER)', async () => {
+    const safeOid = String(Number.MAX_SAFE_INTEGER); // 9007199254740991
+    // Should not throw on validation; will fail later on missing wallet — that's fine.
+    await expect(
+      cmds.cancel([], null, {}, { coin: 'ETH', oid: safeOid, wallet: 'x' }),
+    ).rejects.not.toThrow(/exceeds safe integer precision/);
+  });
 });
 
 describe('perp meta listing (L1)', () => {

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -501,7 +501,7 @@ export function buildLimitOrderCommands(deps = {}) {
       const triggerPrice = options['trigger-price'];
       const triggerCondition = options['trigger-condition'];
       const triggerMintRaw = options['trigger-mint'];
-      const slippageBps = options['slippage-bps'] != null ? Number(options['slippage-bps']) : undefined;
+      const slippageBpsRaw = options['slippage-bps'];
       const expiresStr = options.expires || '30d';
       const walletName = options.wallet;
 
@@ -516,7 +516,7 @@ OPTIONS:
   --trigger-mint <symbol|addr>   Token whose price triggers the order (e.g. SOL)
   --trigger-condition <cond>     "above" or "below"
   --trigger-price <usd>          Trigger price in USD (must be a positive number)
-  --slippage-bps <bps>               Slippage in basis points (100 = 1%), omit for auto
+  --slippage-bps <bps>           Slippage in basis points, 0-10000 (100 = 1%), omit for auto
   --expires <duration>           Expiry duration: "24h", "7d", "30d" (default: 30d)
   --wallet <name>                Wallet name (or "walletconnect"/"wc")
 
@@ -579,6 +579,18 @@ EXAMPLES:
         log('Error: --trigger-condition must be "above" or "below".');
         exit(1);
         return;
+      }
+
+      // Same bounds as update / bridge: whole-order slippage is 0–10000 bps.
+      let slippageBps;
+      if (slippageBpsRaw != null) {
+        const bps = Number(slippageBpsRaw);
+        if (isNaN(bps) || bps < 0 || bps > 10000) {
+          log('Error: --slippage-bps must be between 0 and 10000 basis points.');
+          exit(1);
+          return;
+        }
+        slippageBps = bps;
       }
 
       let expiresAt;

--- a/src/perp.js
+++ b/src/perp.js
@@ -466,6 +466,12 @@ function parsePositiveInt(raw, name) {
   if (!Number.isInteger(n) || n <= 0) {
     throw invalid(`Invalid --${name} "${raw}". Must be a positive integer.`);
   }
+  // Hyperliquid order IDs are uint64. JS Number loses precision above 2^53-1,
+  // so parseInt would silently round a large oid and cancel the wrong order.
+  // Refuse here for the same reason the response path withholds unsafe oids.
+  if (!Number.isSafeInteger(n)) {
+    throw invalid(`Invalid --${name} "${raw}". Value exceeds safe integer precision (2^53-1); copy the exact order ID from "nansen perp positions".`);
+  }
   return n;
 }
 

--- a/src/schema.json
+++ b/src/schema.json
@@ -1682,7 +1682,7 @@
                 },
                 "slippage-bps": {
                   "type": "number",
-                  "description": "Slippage tolerance in basis points (e.g. 50 = 0.5%)"
+                  "description": "Slippage in whole basis points, 0-10000 (50 = 0.5%), omit for auto"
                 },
                 "expires": {
                   "type": "string",


### PR DESCRIPTION
## Summary
- `perp cancel --oid` parsed via `parseInt` which silently rounds uint64 IDs above 2^53-1, potentially cancelling the wrong order
- Add `Number.isSafeInteger` guard — same logic the response path already uses to withhold unsafe oids from output
- Add regression tests: unsafe oid rejected, MAX_SAFE_INTEGER accepted

## Test plan
- [x] `npx vitest run src/__tests__/perp.test.js -t cancel`
- [x] `--oid 9007199254740992` (2^53) → error: "exceeds safe integer precision"
- [x] `--oid 9007199254740991` (2^53-1) → passes validation