### PR TITLE
fix: use pending nonce for EVM sends in transfer

### DIFF
--- a/.changeset/transfer-evm-nonce-pending.md
+++ b/.changeset/transfer-evm-nonce-pending.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Use `pending` nonce block tag for EVM sends: back-to-back transfers no longer risk reusing the same nonce when mempool transactions are queued.

--- a/src/__tests__/transfer.test.js
+++ b/src/__tests__/transfer.test.js
@@ -335,6 +335,31 @@ describe('sendTokens integration', () => {
       expect(result.token).toBeNull();
     });
 
+    test('fetches nonce with both "pending" and "latest" for gap check', async () => {
+      mockEvmRpcSmart();
+      await sendTokens({ to: '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4', amount: '0.01', chain: 'evm', password: 'test' });
+      const nonceCalls = fetch.mock.calls
+        .map(([, opts]) => JSON.parse(opts.body))
+        .filter(b => b.method === 'eth_getTransactionCount');
+      const tags = nonceCalls.map(b => b.params[1]);
+      expect(tags).toContain('pending');
+      expect(tags).toContain('latest');
+    });
+
+    test('rejects when too many transactions are already queued (stuck nonce guard)', async () => {
+      fetch.mockImplementation(async (url, opts) => {
+        const body = JSON.parse(opts.body);
+        if (body.method === 'eth_getTransactionCount') {
+          // pending = 5, latest = 2 → gap of 3 > MAX_PENDING_NONCE_GAP (2)
+          return { json: () => Promise.resolve({ result: body.params[1] === 'pending' ? '0x5' : '0x2' }) };
+        }
+        return { json: () => Promise.resolve({ result: '0x0' }) };
+      });
+      await expect(
+        sendTokens({ to: '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4', amount: '0.01', chain: 'evm', password: 'test' }),
+      ).rejects.toThrow(/unmined transactions queued/);
+    });
+
     test('sends on Base chain', async () => {
       mockEvmRpcSmart();
       const result = await sendTokens({ to: '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4', amount: '0.01', chain: 'base', password: 'test' });

--- a/src/__tests__/transfer.test.js
+++ b/src/__tests__/transfer.test.js
@@ -357,7 +357,12 @@ describe('sendTokens integration', () => {
       });
       await expect(
         sendTokens({ to: '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4', amount: '0.01', chain: 'evm', password: 'test' }),
-      ).rejects.toThrow(/unmined transactions queued/);
+      ).rejects.toThrow(
+        /unmined transactions queued[\s\S]*Wait for them to clear[\s\S]*load-balanced public RPC/,
+      );
+      await expect(
+        sendTokens({ to: '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4', amount: '0.01', chain: 'evm', password: 'test' }),
+      ).rejects.not.toThrow(/Replace the stuck transaction|--nonce|--priority-fee/);
     });
 
     test('sends on Base chain', async () => {

--- a/src/transfer.js
+++ b/src/transfer.js
@@ -120,9 +120,27 @@ async function buildEvmTransaction({ to, amount, token, privateKey, chain, max =
   const privBuf = Buffer.from(privateKey, 'hex');
   const from = deriveEvmAddress(privateKey);
 
-  // Nonce
-  const nonceHex = await rpcCall(rpcUrl, 'eth_getTransactionCount', [from, 'latest']);
-  const nonce = BigInt(nonceHex);
+  // Fetch both pending and latest nonce counts. 'pending' is used so mempool-
+  // queued transactions are counted — 'latest' alone would assign the same
+  // nonce to back-to-back sends, causing one to fail or silently replace the
+  // other. The gap check mirrors trading.js's getEvmNonce: if more than 2
+  // transactions are already queued, signing another would silently stack
+  // behind them and sit unexecutable until they clear or get replaced.
+  const MAX_PENDING_NONCE_GAP = 2;
+  const [pendingHex, latestHex] = await Promise.all([
+    rpcCall(rpcUrl, 'eth_getTransactionCount', [from, 'pending']),
+    rpcCall(rpcUrl, 'eth_getTransactionCount', [from, 'latest']),
+  ]);
+  const nonce = BigInt(pendingHex);
+  const latestNonce = BigInt(latestHex);
+  const gap = Number(nonce - latestNonce);
+  if (gap > MAX_PENDING_NONCE_GAP) {
+    throw new Error(
+      `${from} has ${gap} unmined transactions queued on ${chain} (next mined nonce ${latestNonce}, next pending ${nonce}). ` +
+      `Signing another would queue behind them and stay unexecutable until they clear. ` +
+      `Replace the stuck transaction at nonce ${latestNonce} with a higher fee first.`,
+    );
+  }
 
   // Fees — dynamic priority fee
   const feeHistory = await rpcCall(rpcUrl, 'eth_feeHistory', [4, 'latest', [50]]);

--- a/src/transfer.js
+++ b/src/transfer.js
@@ -135,10 +135,14 @@ async function buildEvmTransaction({ to, amount, token, privateKey, chain, max =
   const latestNonce = BigInt(latestHex);
   const gap = Number(nonce - latestNonce);
   if (gap > MAX_PENDING_NONCE_GAP) {
+    // wallet send has no --nonce/--priority-fee, so don't tell the user to
+    // replace via this CLI. Also note the two-RPC race on load-balanced
+    // endpoints (same caveat as trading.js getEvmNonce).
     throw new Error(
       `${from} has ${gap} unmined transactions queued on ${chain} (next mined nonce ${latestNonce}, next pending ${nonce}). ` +
       `Signing another would queue behind them and stay unexecutable until they clear. ` +
-      `Replace the stuck transaction at nonce ${latestNonce} with a higher fee first.`,
+      `Wait for them to clear (or replace them with a higher fee from where they were sent) before retrying. ` +
+      `Note that a load-balanced public RPC may report a transaction it isn't actually holding, so don't diagnose from a single endpoint.`,
     );
   }
 


### PR DESCRIPTION
## Summary
- `buildEvmTransaction` used `eth_getTransactionCount(..., 'latest')`, so mempool txs were ignored
- Back-to-back `nansen send` could reuse the same nonce (fail or silent replace)
- Fetch both `pending` and `latest`; sign at `pending`
- Stuck-nonce guard: refuse if pending−latest > 2 (same idea as `getEvmNonce` in `trading.js`)
- Error text does **not** suggest `--nonce` / `--priority-fee` (send has neither); tells the user to wait or replace from where the stuck tx was sent
- Documents the load-balanced RPC race (two calls can hit different nodes)

## Test plan
- [x] `npx vitest run src/__tests__/transfer.test.js -t EVM`
- [x] nonce calls use both `"pending"` and `"latest"`
- [x] gap > 2 throws; message includes wait + RPC caveat, not `--nonce`/`--priority-fee`