### PR TITLE
API-240: Fix profiler labels — migrate addressLabels to the v1 endpoint

### DIFF
--- a/.changeset/fix-profiler-labels-v1-endpoint.md
+++ b/.changeset/fix-profiler-labels-v1-endpoint.md
@@ -2,4 +2,4 @@
 "nansen-cli": patch
 ---
 
-Fix `profiler labels`: call `/api/v1/profiler/address/labels` with its v1 request body — the beta endpoint previously used was removed from the Nansen API.
+Fix `profiler labels`: call `/api/v1/profiler/address/labels` with its v1 request body — the beta endpoint previously used was removed from the Nansen API. `profiler batch --include labels` now returns the label array itself instead of the raw `{pagination, data}` envelope.

--- a/.changeset/fix-profiler-labels-v1-endpoint.md
+++ b/.changeset/fix-profiler-labels-v1-endpoint.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix `profiler labels`: call `/api/v1/profiler/address/labels` with its v1 request body — the beta endpoint previously used was removed from the Nansen API.

--- a/skills/nansen-wallet-batch/SKILL.md
+++ b/skills/nansen-wallet-batch/SKILL.md
@@ -19,7 +19,7 @@ allowed-tools: Bash(nansen:*)
 ADDRESSES="0xaddr1,0xaddr2,0xaddr3,..." CHAIN=ethereum
 nansen research profiler batch --addresses "$ADDRESSES" --chain $CHAIN --include labels,balance
 # → .data.{total, completed, results[]: {address, chain, labels[], balance, error}}
-# labels[]: {label, category ("smart_money","fund","social","behavioral","others"), fullname}
+# labels[]: {label, category ("smart_money","fund","social","behavioral","others"), kind[]}
 # balance: {data[]: {token_symbol, token_amount, price_usd, value_usd}}
 ```
 Check .error per result — invalid addresses return an error message, not a crash. Skip those.

--- a/skills/nansen-wallet-profiler/SKILL.md
+++ b/skills/nansen-wallet-profiler/SKILL.md
@@ -92,7 +92,7 @@ nansen research profiler compare --addresses "0xabc,0xdef" --chain ethereum
 
 - `pnl-summary` has no pagination support (returns aggregate stats, not a list).
 - `perp-positions` has no pagination support.
-- `labels` has no pagination support — the API ignores `per_page` and always returns all labels for the address. `--limit` is not available for this sub-command.
+- `labels` supports pagination — `--limit`/`--page` are honoured and the response is `{pagination: {page, per_page, is_last_page}, data[]: {label, category, kind[]}}`.
 - `transactions` caps at per_page=100 (API limit).
 - `trace` makes many API calls — use `--width` conservatively.
 - `batch` accepts `--file <path>` with one address per line as alternative to `--addresses`.

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -63,7 +63,11 @@ const MOCK_RESPONSES = {
     ]
   },
   addressLabels: {
-    labels: ['Smart Trader', 'Fund']
+    pagination: { page: 1, per_page: 100, total: 2 },
+    data: [
+      { label: 'Smart Trader', category: 'behavioral' },
+      { label: 'Fund', category: 'others' }
+    ]
   },
   addressTransactions: {
     transactions: [
@@ -807,12 +811,13 @@ describe('NansenAPI', () => {
           chain: 'ethereum'
         });
         
-        const body = expectFetchCalledWith('/api/beta/profiler/address/labels');
-        expect(body.parameters.address).toBe(TEST_DATA.ethereum.address);
-        expect(body.parameters.chain).toBe('ethereum');
-        
-        expect(result.labels).toContain('Smart Trader');
-        expect(result.labels).toContain('Fund');
+        const body = expectFetchCalledWith('/api/v1/profiler/address/labels');
+        expect(body.address).toBe(TEST_DATA.ethereum.address);
+        expect(body.chain).toBe('ethereum');
+
+        const labels = result.data.map(item => item.label);
+        expect(labels).toContain('Smart Trader');
+        expect(labels).toContain('Fund');
       });
     });
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -3829,6 +3829,25 @@ describe('--enrich flag on token transfers', () => {
     expect(result.transfers[0].to_labels).toEqual(['Smart Trader']);
   });
 
+  it('should enrich transfers from the v1 labels response shape', async () => {
+    const mockApi = {
+      tokenTransfers: vi.fn().mockResolvedValue({
+        transfers: [
+          { from: '0xaaa', to: '0xbbb', amount_usd: 1000 }
+        ]
+      }),
+      addressLabels: vi.fn().mockResolvedValue({
+        pagination: { page: 1, per_page: 100, total: 1 },
+        data: [{ label: 'Smart Trader', category: 'behavioral' }]
+      })
+    };
+    const commands = buildCommands({});
+    const result = await commands['token'](['transfers'], mockApi, { enrich: true }, { token: '0xabc' });
+
+    expect(result.transfers[0].from_labels).toEqual(['Smart Trader']);
+    expect(result.transfers[0].to_labels).toEqual(['Smart Trader']);
+  });
+
   it('should not enrich when --enrich flag is not set', async () => {
     const mockApi = {
       tokenTransfers: vi.fn().mockResolvedValue({

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -3975,6 +3975,26 @@ describe('batchProfile', () => {
     expect(result.results[0].balance).toBeDefined();
   });
 
+  it('should unwrap the v1 labels response into a labels array', async () => {
+    const mockApi = {
+      addressLabels: vi.fn().mockResolvedValue({
+        pagination: { page: 1, per_page: 100, is_last_page: true },
+        data: [{ label: 'Fund', category: 'fund', kind: ['entity/fund'] }]
+      }),
+    };
+
+    const result = await batchProfile(mockApi, {
+      addresses: ['0x0000000000000000000000000000000000000001'],
+      chain: 'ethereum',
+      include: ['labels'],
+      delayMs: 0,
+    });
+
+    expect(result.results[0].labels).toEqual([
+      { label: 'Fund', category: 'fund', kind: ['entity/fund'] }
+    ]);
+  });
+
   it('should capture individual errors without failing batch', async () => {
     const mockApi = {
       addressLabels: vi.fn().mockRejectedValue(new Error('Not found')),

--- a/src/__tests__/coverage.test.js
+++ b/src/__tests__/coverage.test.js
@@ -20,7 +20,7 @@ const DOCUMENTED_ENDPOINTS = {
   ],
   profiler: [
     { name: 'balance', method: 'addressBalance', endpoint: '/api/v1/profiler/address/current-balance' },
-    { name: 'labels', method: 'addressLabels', endpoint: '/api/beta/profiler/address/labels' },
+    { name: 'labels', method: 'addressLabels', endpoint: '/api/v1/profiler/address/labels' },
     { name: 'transactions', method: 'addressTransactions', endpoint: '/api/v1/profiler/address/transactions' },
     { name: 'pnl', method: 'addressPnl', endpoint: '/api/v1/profiler/address/pnl-and-trade-performance' },
     { name: 'search', method: 'entitySearch', endpoint: '/api/beta/profiler/entity-name-search' },

--- a/src/api.js
+++ b/src/api.js
@@ -908,8 +908,9 @@ export class NansenAPI {
   async addressLabels(params = {}) {
     const { address, chain = 'ethereum', pagination = { page: 1, per_page: 100 } } = params;
     if (address) requireValidAddress(address, chain);
-    return this.request('/api/beta/profiler/address/labels', {
-      parameters: { address, chain },
+    return this.request('/api/v1/profiler/address/labels', {
+      address,
+      chain,
       pagination
     });
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -570,7 +570,10 @@ export async function batchProfile(api, params = {}) {
     }
     try {
       if (include.includes('labels')) {
-        entry.labels = await api.addressLabels({ address, chain });
+        const labelsResult = await api.addressLabels({ address, chain });
+        entry.labels = Array.isArray(labelsResult?.data)
+          ? labelsResult.data
+          : labelsResult?.labels || [];
       }
       if (include.includes('balance')) {
         entry.balance = await api.addressBalance({ address, chain });

--- a/src/cli.js
+++ b/src/cli.js
@@ -489,7 +489,9 @@ async function enrichTransfers(result, apiInstance, chain) {
   for (const addr of addrs) {
     try {
       const labelsResult = await apiInstance.addressLabels({ address: addr, chain });
-      labelMap[addr] = labelsResult?.labels || labelsResult?.data?.results || [];
+      labelMap[addr] = Array.isArray(labelsResult?.data)
+        ? labelsResult.data.map(item => item.label)
+        : labelsResult?.labels || [];
     } catch {
       labelMap[addr] = [];
     }


### PR DESCRIPTION
## Summary

`NansenAPI.addressLabels()` still called a removed beta endpoint. Every `nansen profiler labels` call (and `--enrich` label lookups) hit a dead endpoint. `src/schema.json` already documented the v1 path, so code and docs disagreed.

Verified against the published OpenAPI spec (<https://docs.nansen.ai/api/profiler/address-labels>), the v1 contract differs beyond the URL:

- **Request**: top-level `{address, chain, pagination}` with `additionalProperties: false` — the old `{parameters: {address, chain}}` wrapper would be rejected, so a URL-only fix was not enough.
- **Response**: `{pagination, data: [{label, category, kind}]}` instead of the beta `labels` string array.

## Changes

- `src/api.js` — `addressLabels()` now posts to `/api/v1/profiler/address/labels` with the v1 top-level body.
- `src/cli.js` — `enrichTransfers()` maps `data[].label`, keeping the legacy `labels` fallback so existing mocks and cached responses still work.
- Tests and documentation fixtures now cover the v1 contract.
- Added a patch changeset.

## Validation

- `npm test`: 2,032 passed, 2 pre-existing skips
- `npm run lint`: clean
- Independent code review: approved, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
