### PR TITLE
API-235: document global --limit/--page pagination flags in nansen schema

### DIFF
--- a/.changeset/schema-global-pagination-options.md
+++ b/.changeset/schema-global-pagination-options.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Document global pagination options in `nansen schema`.

--- a/src/schema.json
+++ b/src/schema.json
@@ -1968,6 +1968,15 @@
       "type": "string",
       "description": "Comma-separated list of fields to include in output"
     },
+    "limit": {
+      "type": "number",
+      "description": "Maximum results per page for list-returning research commands; maps to pagination.per_page. General endpoints default to 10 (max 1000), while profiler address endpoints default to 20 (max 100). Supported by smart-money, profiler, token, perp, points, prediction-market, and supported research historical-* commands. Commands that declare their own limit option (search, token top-tokens, trade limit-order list) use those command-specific semantics instead; token ohlcv, profiler perp-positions, and historical-token-flow-summary do not support pagination. profiler labels defaults to 100 when omitted."
+    },
+    "page": {
+      "type": "number",
+      "default": 1,
+      "description": "1-based page number for list-returning research commands; maps to pagination.page. Supported by smart-money, profiler, token, perp, points, prediction-market, and supported research historical-* commands. Trade, wallet, and operational commands ignore it; token ohlcv, profiler perp-positions, and historical-token-flow-summary do not support pagination. profiler labels defaults to page 1 when omitted."
+    },
     "no-retry": {
       "type": "boolean",
       "description": "Disable automatic retry on rate limits/errors"


### PR DESCRIPTION
## Problem

`buildPagination(options)` in `src/cli.js` reads `--limit`/`--page` at six shared call sites (`smart-money`, `profiler`, `token`, `perp`, `points`, `prediction-market`), plus a local copy in `src/commands/research.js` for the `historical-*` commands — but `schema.json` `globalOptions` never listed either flag. Agents consuming `nansen schema` (the machine-readable CLI contract) could not discover pagination at all, nor the API-side fact that profiler endpoints and general endpoints have different `per_page` rules.

## Change

Docs-only: adds `limit` and `page` to `globalOptions` in `src/schema.json`.

- `limit` → `pagination.per_page`. Description states the split verified against the live OpenAPI spec at docs.nansen.ai: general endpoints (`PaginationRequest`) default 10, max 1000; profiler address endpoints (`ProfilerPaginationRequest`) default 20, max 100. It also names the commands that declare their own `limit` with different semantics (`search`, `token top-tokens`, `trade limit-order list`), the endpoints that reject/ignore pagination (`token ohlcv`, `profiler perp-positions`, `historical-token-flow-summary`), and the CLI-side `per_page: 100` default on `profiler labels`.
- `page` → `pagination.page`, 1-based, default 1.

No runtime code touched — `nansen schema --full` and `nansen schema <cmd>` already render `globalOptions`, so the entries surface automatically. Changeset included (patch).

Not a duplicate of #491, which adds command-specific options (alerts/batch/screener) and does not touch `globalOptions`. Related: ECINT-6899 tracks the API side; this PR is the CLI side.

## Validation

- `npm test`: 2031 passed, 2 skipped
- `npm run lint`: clean
- `node src/index.js schema --full` exposes both new entries with descriptions
- Independent Codex code review: APPROVED after fixing one finding (the description originally claimed trade commands ignore `--limit`, contradicting `trade limit-order list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)