### PR TITLE
API-317: Fix the Cursor install flow — explicit key flows instead of the placeholder deep link

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,38 @@ Uses the API key from `nansen login` / `NANSEN_API_KEY`; re-run `install` after 
 
 `install` writes the config; `verify` proves it works. The MCP server answers `tools/list` — and even some free tools — without a key, so a broken credential only surfaces on the first real data call. `nansen mcp verify` makes that call (a `token_info` lookup, consuming a small number of API credits) and maps each failure to a fix. With a client argument (`nansen mcp verify cursor`) it checks the key actually stored in that client's config — catching stale keys after rotation; hand-written entries are fine as long as they still target the official server URL/transport (other differences are warned about, not refused), and the key is only ever sent to the official server URL. Without one it checks the `nansen login` / `NANSEN_API_KEY` credential directly.
 
+### Cursor
+
+Recommended setup:
+
+```bash
+nansen login --api-key <key>       # or set NANSEN_API_KEY
+nansen mcp install cursor
+# Restart Cursor, then verify:
+nansen mcp verify cursor
+```
+
+To configure Cursor manually, create `~/.cursor/mcp.json` with this block and replace `YOUR_API_KEY` with your key from [app.nansen.ai/auth/agent-setup](https://app.nansen.ai/auth/agent-setup) before saving:
+
+```json
+{
+  "mcpServers": {
+    "nansen": {
+      "url": "https://mcp.nansen.ai/ra/mcp",
+      "headers": {
+        "NANSEN-API-KEY": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Paste the whole block only into a new file. If `mcp.json` already exists, add only the `nansen` entry under its existing `mcpServers`. On macOS/Linux, run `chmod 600 ~/.cursor/mcp.json` because the file contains a secret; on Windows, or to have permissions and merging handled automatically, use `nansen mcp install cursor`.
+
+For the manual path, ask Cursor's agent to run a paid Nansen tool, such as token info for a known token, and confirm that real data is returned. `tools/list` and some free tools work without a key, so visible tools do not verify authentication. If you have the CLI, `nansen mcp verify cursor` is the authoritative end-to-end check.
+
+Cursor deep links are retired: their opaque base64 payload embeds an uneditable placeholder key, so use the CLI installer or the explicit configuration above instead.
+
 ## Trading
 
 DEX swaps on `solana` and `base`. Two-step: quote then execute.


### PR DESCRIPTION
## Summary

The public Cursor instructions point at a deep link whose base64-encoded config embeds `"NANSEN_API_KEY": "REPLACE_THIS"` — the "one-click" install lands broken, and fixing it means decoding an opaque payload or hand-editing `~/.cursor/mcp.json`. It also bridges through `npx mcp-remote ... --allow-http` even though the server is HTTPS and Cursor speaks streamable HTTP natively.

**Decision:** explicit key flows, no personalized deep link. A personalized link would put a live API key inside a URL (clipboard history, chat logs, link previews) and still be an opaque payload; and a static link can't collect a key at all — Cursor's deeplink install saves the decoded config as-is, so a placeholder is inherent to that design.

This PR adds a `### Cursor` README subsection (stacked on #502, which provides `nansen mcp install|verify`):

- **Recommended:** `nansen login --api-key <key>` → `nansen mcp install cursor` → restart → `nansen mcp verify cursor` (one real authenticated data call).
- **Manual:** plain-JSON `~/.cursor/mcp.json` block with a visible `YOUR_API_KEY` slot (exact shape `install` writes, so `verify` accepts it with no drift warnings), merge guidance for existing configs, a macOS/Linux `chmod 600` note, and an authenticated in-Cursor check (paid tool call — `tools/list` answers keyless, so visible tools prove nothing).
- One sentence retiring the deep link.

**Follow-up (docs site):** https://docs.nansen.ai/mcp/connecting still hosts the deep link; this subsection is written to be adopted there verbatim.

## Verification

From a clean `HOME` (no `~/.cursor/`), with a real key:
1. `nansen mcp install cursor` → file created `0600`, real key written, zero placeholders.
2. `nansen mcp verify cursor` → ✓ authenticated MCP data call succeeded.
3. The README JSON block verbatim + key substitution → `verify cursor` ✓, no drift warnings.
4. Raw `tools/call` (`token_info`, the request Cursor's agent sends) with the manually-configured key → real data returned.

Cursor's own docs confirm native `url` + `headers` support in `mcp.json`.

## Checklist

- [x] Tests pass (`npm test` — 2010 passed, 2 skipped; `npm run lint` clean)
- [x] `src/schema.json` updated if new commands or flags were added — n/a, docs-only
- [x] `README.md` updated
- [x] Changeset added — n/a, docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)