### PR TITLE
API-319: Reconcile MCP setup docs — canonical endpoint, API-key URL, and per-client paths

### DIFF
--- a/.changeset/mcp-docs-reconcile.md
+++ b/.changeset/mcp-docs-reconcile.md
@@ -2,4 +2,4 @@
 "nansen-cli": patch
 ---
 
-Add a canonical MCP setup section to the README — endpoint `https://mcp.nansen.ai/ra/mcp`, `NANSEN-API-KEY` auth, and one-click / one-command / manual paths for Claude Desktop, Claude Code, Cursor, Claude Tag, and generic or stdio-only clients — and point the credit top-up warnings at the canonical API-key URL (app.nansen.ai/auth/agent-setup).
+Add a canonical MCP setup section to the README — endpoint `https://mcp.nansen.ai/ra/mcp`, `NANSEN-API-KEY` auth, and one-click / one-command / manual paths for Claude Desktop, Claude Code, Cursor, Claude Tag, and generic or stdio-only clients — and drop the API-key URL from the out-of-credits and low-credit warnings in favour of generic top-up wording.

--- a/.changeset/mcp-docs-reconcile.md
+++ b/.changeset/mcp-docs-reconcile.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Add a canonical MCP setup section to the README — endpoint `https://mcp.nansen.ai/ra/mcp`, `NANSEN-API-KEY` auth, and one-click / one-command / manual paths for Claude Desktop, Claude Code, Cursor, Claude Tag, and generic or stdio-only clients — and point the credit top-up warnings at the canonical API-key URL (app.nansen.ai/auth/agent-setup).

--- a/.changeset/mcp-docs-reconcile.md
+++ b/.changeset/mcp-docs-reconcile.md
@@ -2,4 +2,4 @@
 "nansen-cli": patch
 ---
 
-Add a canonical MCP setup section to the README — endpoint `https://mcp.nansen.ai/ra/mcp`, `NANSEN-API-KEY` auth, and one-click / one-command / manual paths for Claude Desktop, Claude Code, Cursor, Claude Tag, and generic or stdio-only clients — and point the out-of-credits and low-credit warnings at the credit top-up page (app.nansen.ai/api?tab=api) instead of the API-key URL.
+Add a canonical MCP setup section to the README — endpoint `https://mcp.nansen.ai/ra/mcp`, `NANSEN-API-KEY` auth, per-client setup paths for Claude Code, Claude Tag, and generic or stdio-only clients, plus a pointer to the connection docs for Claude Desktop and Cursor — and point the out-of-credits and low-credit warnings at the credit top-up page (app.nansen.ai/api?tab=api) instead of the API-key URL.

--- a/.changeset/mcp-docs-reconcile.md
+++ b/.changeset/mcp-docs-reconcile.md
@@ -2,4 +2,4 @@
 "nansen-cli": patch
 ---
 
-Add a canonical MCP setup section to the README — endpoint `https://mcp.nansen.ai/ra/mcp`, `NANSEN-API-KEY` auth, per-client setup paths for Claude Code, Claude Tag, and generic or stdio-only clients, plus a pointer to the connection docs for Claude Desktop and Cursor — and point the out-of-credits and low-credit warnings at the credit top-up page (app.nansen.ai/api?tab=api) instead of the API-key URL.
+Add a canonical MCP setup section to the README — endpoint `https://mcp.nansen.ai/ra/mcp`, `NANSEN-API-KEY` auth, per-client setup paths for Claude Code, Claude Tag, and generic or stdio-only clients, plus a pointer to the connection docs for Claude Desktop and Cursor — and point the out-of-credits and low-credit warnings at the credits tab of the billing page, `app.nansen.ai/api?tab=api`, instead of the bare `app.nansen.ai/api`.

--- a/.changeset/mcp-docs-reconcile.md
+++ b/.changeset/mcp-docs-reconcile.md
@@ -2,4 +2,4 @@
 "nansen-cli": patch
 ---
 
-Add a canonical MCP setup section to the README — endpoint `https://mcp.nansen.ai/ra/mcp`, `NANSEN-API-KEY` auth, and one-click / one-command / manual paths for Claude Desktop, Claude Code, Cursor, Claude Tag, and generic or stdio-only clients — and drop the API-key URL from the out-of-credits and low-credit warnings in favour of generic top-up wording.
+Add a canonical MCP setup section to the README — endpoint `https://mcp.nansen.ai/ra/mcp`, `NANSEN-API-KEY` auth, and one-click / one-command / manual paths for Claude Desktop, Claude Code, Cursor, Claude Tag, and generic or stdio-only clients — and point the out-of-credits and low-credit warnings at the credit top-up page (app.nansen.ai/api?tab=api) instead of the API-key URL.

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ nansen research smart-money netflow --chain solana --fields token_symbol,net_flo
 
 | Code | Action |
 |------|--------|
-| `CREDITS_EXHAUSTED` | Stop all API calls immediately. `details.credits.remaining` is your actual balance. Top up your credits in the Nansen app. |
+| `CREDITS_EXHAUSTED` | Stop all API calls immediately. `details.credits.remaining` is your actual balance. Top up at [app.nansen.ai/api?tab=api](https://app.nansen.ai/api?tab=api). |
 | `UNAUTHORIZED` | Wrong or missing key. Re-auth. |
 | `RATE_LIMITED` | Auto-retried by CLI. `details.rateLimit.resetSeconds` is how long the window needs to drain. |
 | `UNSUPPORTED_FILTER` | Remove the filter and retry. |

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ nansen research smart-money netflow --chain solana --fields token_symbol,net_flo
 
 | Code | Action |
 |------|--------|
-| `CREDITS_EXHAUSTED` | Stop all API calls immediately. `details.credits.remaining` is your actual balance. Top up at [app.nansen.ai/auth/agent-setup](https://app.nansen.ai/auth/agent-setup). |
+| `CREDITS_EXHAUSTED` | Stop all API calls immediately. `details.credits.remaining` is your actual balance. Top up your credits in the Nansen app. |
 | `UNAUTHORIZED` | Wrong or missing key. Re-auth. |
 | `RATE_LIMITED` | Auto-retried by CLI. `details.rateLimit.resetSeconds` is how long the window needs to drain. |
 | `UNSUPPORTED_FILTER` | Remove the filter and retry. |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,17 @@ Connect any MCP client to Nansen's streamable HTTP server:
 - **Authentication:** `NANSEN-API-KEY` header
 - **API key:** [app.nansen.ai/auth/agent-setup](https://app.nansen.ai/auth/agent-setup)
 
-**One-click:** [Claude Desktop (`.dxt` bundle)](https://docs.nansen.ai/mcp/connecting) and [Cursor (install deep link)](https://docs.nansen.ai/mcp/connecting) are available from the connection docs.
+**One-click (Claude Desktop):** download [`nansen.dxt`](https://github.com/nansen-ai/nansen-mcp-dxt/raw/refs/heads/main/nansen.dxt), open it, and paste your API key when prompted.
+
+**One-click (Cursor):** open this deep link — GitHub strips the `cursor://` scheme from rendered links, so copy the line:
+
+```
+cursor://anysphere.cursor-deeplink/mcp/install?name=nansen-mcp&config=eyJlbnYiOnsiTkFOU0VOX0FQSV9LRVkiOiJSRVBMQUNFX1RISVMifSwiY29tbWFuZCI6Im5weCIsImFyZ3MiOlsiLXkiLCJtY3AtcmVtb3RlIiwiaHR0cHM6Ly9tY3AubmFuc2VuLmFpL3JhL21jcC8iLCItLWhlYWRlciIsIk5BTlNFTi1BUEktS0VZOiR7TkFOU0VOX0FQSV9LRVl9IiwiLS1hbGxvdy1odHRwIl19Cg==
+```
+
+It installs the `mcp-remote` bridge with `NANSEN_API_KEY` set to `REPLACE_THIS` — swap in your key afterwards. For a native (bridge-free) Cursor setup, use the manual JSON below instead.
+
+Screenshots and per-client walkthroughs: [docs.nansen.ai/mcp/connecting](https://docs.nansen.ai/mcp/connecting).
 
 **One-command (Claude Code):**
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,61 @@ nansen schema [command] [--pretty]    # full command reference (no API key neede
 
 Run `nansen schema --pretty` for the full subcommand and field reference.
 
+## MCP
+
+Connect any MCP client to Nansen's streamable HTTP server:
+
+- **Endpoint:** `https://mcp.nansen.ai/ra/mcp`
+- **Authentication:** `NANSEN-API-KEY` header
+- **API key:** [app.nansen.ai/auth/agent-setup](https://app.nansen.ai/auth/agent-setup)
+
+**One-click:** [Claude Desktop (`.dxt` bundle)](https://docs.nansen.ai/mcp/connecting) and [Cursor (install deep link)](https://docs.nansen.ai/mcp/connecting) are available from the connection docs.
+
+**One-command (Claude Code):**
+
+```bash
+claude mcp add --transport http nansen https://mcp.nansen.ai/ra/mcp --header "NANSEN-API-KEY: <your-key>"
+```
+
+**Manual (any streamable-HTTP client):** for example, add this to Cursor's `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "nansen": {
+      "url": "https://mcp.nansen.ai/ra/mcp",
+      "headers": {
+        "NANSEN-API-KEY": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+**Manual (stdio-only clients):** use `mcp-remote` as a bridge. Keep the header as one argument with no space after the colon:
+
+```json
+{
+  "mcpServers": {
+    "nansen": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote@latest",
+        "https://mcp.nansen.ai/ra/mcp",
+        "--header",
+        "NANSEN-API-KEY:${NANSEN_API_KEY}"
+      ],
+      "env": {
+        "NANSEN_API_KEY": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+**Claude Tag (Claude in Slack):** an admin must attach a plugin whose `.mcp.json` points at `https://mcp.nansen.ai/ra/mcp` and add a custom credential allowing the host `mcp.nansen.ai`. See the [Claude Tag custom-connections documentation](https://claude.com/docs/claude-tag/admins/connections/custom). Per-user fallback: use Claude Code or Claude Desktop.
+
 ## Trading
 
 DEX swaps on `solana` and `base`. Two-step: quote then execute.
@@ -216,7 +271,7 @@ nansen research smart-money netflow --chain solana --fields token_symbol,net_flo
 
 | Code | Action |
 |------|--------|
-| `CREDITS_EXHAUSTED` | Stop all API calls immediately. `details.credits.remaining` is your actual balance. Top up at [app.nansen.ai/api](https://app.nansen.ai/api). |
+| `CREDITS_EXHAUSTED` | Stop all API calls immediately. `details.credits.remaining` is your actual balance. Top up at [app.nansen.ai/auth/agent-setup](https://app.nansen.ai/auth/agent-setup). |
 | `UNAUTHORIZED` | Wrong or missing key. Re-auth. |
 | `RATE_LIMITED` | Auto-retried by CLI. `details.rateLimit.resetSeconds` is how long the window needs to drain. |
 | `UNSUPPORTED_FILTER` | Remove the filter and retry. |

--- a/README.md
+++ b/README.md
@@ -59,17 +59,7 @@ Connect any MCP client to Nansen's streamable HTTP server:
 - **Authentication:** `NANSEN-API-KEY` header
 - **API key:** [app.nansen.ai/auth/agent-setup](https://app.nansen.ai/auth/agent-setup)
 
-**One-click (Claude Desktop):** download [`nansen.dxt`](https://github.com/nansen-ai/nansen-mcp-dxt/raw/refs/heads/main/nansen.dxt), open it, and paste your API key when prompted.
-
-**One-click (Cursor):** open this deep link — GitHub strips the `cursor://` scheme from rendered links, so copy the line:
-
-```
-cursor://anysphere.cursor-deeplink/mcp/install?name=nansen-mcp&config=eyJlbnYiOnsiTkFOU0VOX0FQSV9LRVkiOiJSRVBMQUNFX1RISVMifSwiY29tbWFuZCI6Im5weCIsImFyZ3MiOlsiLXkiLCJtY3AtcmVtb3RlIiwiaHR0cHM6Ly9tY3AubmFuc2VuLmFpL3JhL21jcC8iLCItLWhlYWRlciIsIk5BTlNFTi1BUEktS0VZOiR7TkFOU0VOX0FQSV9LRVl9IiwiLS1hbGxvdy1odHRwIl19Cg==
-```
-
-It installs the `mcp-remote` bridge with `NANSEN_API_KEY` set to `REPLACE_THIS` — swap in your key afterwards. For a native (bridge-free) Cursor setup, use the manual JSON below instead.
-
-Screenshots and per-client walkthroughs: [docs.nansen.ai/mcp/connecting](https://docs.nansen.ai/mcp/connecting).
+**Claude Desktop and Cursor:** setup instructions for both — the Claude Desktop `.dxt` bundle and the Cursor install deep link — are in the connection docs: [docs.nansen.ai/mcp/connecting](https://docs.nansen.ai/mcp/connecting).
 
 **One-command (Claude Code):**
 

--- a/src/__tests__/response-meta.test.js
+++ b/src/__tests__/response-meta.test.js
@@ -169,17 +169,17 @@ describe('creditWarning', () => {
   it('warns when the balance is exhausted', () => {
     const warning = creditWarning({ credits: { used: 5, remaining: 0 } });
     expect(warning).toContain('Out of API credits');
-    expect(warning).toContain('Top up your credits in the Nansen app');
-    // Credit warnings stay URL-free — the auth/agent-setup link belongs to MCP setup, not top-ups.
-    expect(warning).not.toContain('app.nansen.ai');
+    expect(warning).toContain('https://app.nansen.ai/api?tab=api');
+    // Top-ups live on the billing page; auth/agent-setup is for MCP setup and API keys.
+    expect(warning).not.toContain('auth/agent-setup');
   });
 
   it('warns when the balance will not cover another call of the same size', () => {
     const warning = creditWarning({ credits: { used: 10, remaining: 3 } });
     expect(warning).toContain('3 API credits left');
     expect(warning).toContain('less than this call cost (10)');
-    expect(warning).toContain('Top up your credits in the Nansen app');
-    expect(warning).not.toContain('app.nansen.ai');
+    expect(warning).toContain('https://app.nansen.ai/api?tab=api');
+    expect(warning).not.toContain('auth/agent-setup');
   });
 
   it('singularises one remaining credit', () => {

--- a/src/__tests__/response-meta.test.js
+++ b/src/__tests__/response-meta.test.js
@@ -169,12 +169,14 @@ describe('creditWarning', () => {
   it('warns when the balance is exhausted', () => {
     const warning = creditWarning({ credits: { used: 5, remaining: 0 } });
     expect(warning).toContain('Out of API credits');
+    expect(warning).toContain('https://app.nansen.ai/auth/agent-setup');
   });
 
   it('warns when the balance will not cover another call of the same size', () => {
     const warning = creditWarning({ credits: { used: 10, remaining: 3 } });
     expect(warning).toContain('3 API credits left');
     expect(warning).toContain('less than this call cost (10)');
+    expect(warning).toContain('https://app.nansen.ai/auth/agent-setup');
   });
 
   it('singularises one remaining credit', () => {

--- a/src/__tests__/response-meta.test.js
+++ b/src/__tests__/response-meta.test.js
@@ -169,14 +169,17 @@ describe('creditWarning', () => {
   it('warns when the balance is exhausted', () => {
     const warning = creditWarning({ credits: { used: 5, remaining: 0 } });
     expect(warning).toContain('Out of API credits');
-    expect(warning).toContain('https://app.nansen.ai/auth/agent-setup');
+    expect(warning).toContain('Top up your credits in the Nansen app');
+    // Credit warnings stay URL-free — the auth/agent-setup link belongs to MCP setup, not top-ups.
+    expect(warning).not.toContain('app.nansen.ai');
   });
 
   it('warns when the balance will not cover another call of the same size', () => {
     const warning = creditWarning({ credits: { used: 10, remaining: 3 } });
     expect(warning).toContain('3 API credits left');
     expect(warning).toContain('less than this call cost (10)');
-    expect(warning).toContain('https://app.nansen.ai/auth/agent-setup');
+    expect(warning).toContain('Top up your credits in the Nansen app');
+    expect(warning).not.toContain('app.nansen.ai');
   });
 
   it('singularises one remaining credit', () => {

--- a/src/response-meta.js
+++ b/src/response-meta.js
@@ -118,12 +118,12 @@ export function creditWarning(meta) {
   const { used, remaining, cost } = credits;
   if (remaining === null) return null;
   if (remaining === 0) {
-    return '⚠️  Out of API credits. Top up at https://app.nansen.ai/api';
+    return '⚠️  Out of API credits. Top up at https://app.nansen.ai/auth/agent-setup';
   }
   // The cost header is the authoritative charge; used is the fallback.
   const charged = cost ?? used;
   if (charged !== null && charged > 0 && remaining < charged) {
-    return `⚠️  ${remaining} API credit${remaining === 1 ? '' : 's'} left — less than this call cost (${charged}). Top up at https://app.nansen.ai/api`;
+    return `⚠️  ${remaining} API credit${remaining === 1 ? '' : 's'} left — less than this call cost (${charged}). Top up at https://app.nansen.ai/auth/agent-setup`;
   }
   return null;
 }

--- a/src/response-meta.js
+++ b/src/response-meta.js
@@ -118,12 +118,12 @@ export function creditWarning(meta) {
   const { used, remaining, cost } = credits;
   if (remaining === null) return null;
   if (remaining === 0) {
-    return '⚠️  Out of API credits. Top up your credits in the Nansen app.';
+    return '⚠️  Out of API credits. Top up at https://app.nansen.ai/api?tab=api';
   }
   // The cost header is the authoritative charge; used is the fallback.
   const charged = cost ?? used;
   if (charged !== null && charged > 0 && remaining < charged) {
-    return `⚠️  ${remaining} API credit${remaining === 1 ? '' : 's'} left — less than this call cost (${charged}). Top up your credits in the Nansen app.`;
+    return `⚠️  ${remaining} API credit${remaining === 1 ? '' : 's'} left — less than this call cost (${charged}). Top up at https://app.nansen.ai/api?tab=api`;
   }
   return null;
 }

--- a/src/response-meta.js
+++ b/src/response-meta.js
@@ -118,12 +118,12 @@ export function creditWarning(meta) {
   const { used, remaining, cost } = credits;
   if (remaining === null) return null;
   if (remaining === 0) {
-    return '⚠️  Out of API credits. Top up at https://app.nansen.ai/auth/agent-setup';
+    return '⚠️  Out of API credits. Top up your credits in the Nansen app.';
   }
   // The cost header is the authoritative charge; used is the fallback.
   const charged = cost ?? used;
   if (charged !== null && charged > 0 && remaining < charged) {
-    return `⚠️  ${remaining} API credit${remaining === 1 ? '' : 's'} left — less than this call cost (${charged}). Top up at https://app.nansen.ai/auth/agent-setup`;
+    return `⚠️  ${remaining} API credit${remaining === 1 ? '' : 's'} left — less than this call cost (${charged}). Top up your credits in the Nansen app.`;
   }
   return null;
 }


### PR DESCRIPTION
## Why

MCP setup guidance is inconsistent across surfaces: the README had no MCP section at all, and the public MCP docs use a generic-client snippet that is awkward against the hosted endpoint (`--allow-http` on an HTTPS URL, and a `--header "NANSEN-API-KEY: "` form that mcp-remote mis-splits on the space).

This PR establishes the canonical values in the repo and gives every client one unambiguous path.

## Canonical values

- **MCP endpoint:** `https://mcp.nansen.ai/ra/mcp` (streamable HTTP, `NANSEN-API-KEY` header)
- **API-key URL (auth / MCP setup only):** `https://app.nansen.ai/auth/agent-setup`
- **Credit top-up URL (credit warnings only):** `https://app.nansen.ai/api?tab=api` — the credits tab of the billing page

## What changed

- **README — new `## MCP` section** with the canonical endpoint/auth/key URL and per-client paths:
  - *Claude Desktop and Cursor:* pointed at [docs.nansen.ai/mcp/connecting](https://docs.nansen.ai/mcp/connecting), where the `.dxt` bundle and the Cursor install deep link are maintained. The README does not duplicate those install artifacts and does not claim either is one-click from here.
  - *One-command:* Claude Code via `claude mcp add --transport http nansen … --header "NANSEN-API-KEY: <your-key>"`
  - *Manual:* native `url` + `headers` JSON for any streamable-HTTP client, and a corrected `mcp-remote` bridge for stdio-only clients (no `--allow-http`, header passed as a single `NANSEN-API-KEY:${NANSEN_API_KEY}` arg with the key in `env`)
  - *Claude Tag (Claude in Slack):* admin-configured path (plugin `.mcp.json` + host credential for `mcp.nansen.ai`), with an explicit per-user fallback to Claude Code / Claude Desktop
- **Credit warnings — README error table + `src/response-meta.js`:** the out-of-credits and low-credit warnings move from the bare `app.nansen.ai/api` to the credits tab of that same billing page, `app.nansen.ai/api?tab=api`. `auth/agent-setup` is not used here — it stays confined to auth and MCP setup.
- **Tests:** `creditWarning` assertions pin the top-up URL and assert `auth/agent-setup` does not leak into either warning
- **Changeset:** patch

## Follow-up for the docs site (not in this repo)

The Cursor deep link on [docs.nansen.ai/mcp/connecting](https://docs.nansen.ai/mcp/connecting) embeds `--allow-http` in its base64 config against an HTTPS endpoint. Harmless today (the header form inside it is correct — no space), but worth dropping so the deep link matches the corrected snippet in this README.

## Verification

- `npm test` — 2033 passed, 2 skipped; `npm run lint` clean
- Live check against `https://mcp.nansen.ai/ra/mcp`: `tools/list` responds, and a `tools/call` with the `NANSEN-API-KEY` header reaches the tool handler
- `claude mcp add --transport http` syntax verified against the current Claude Code CLI
- Deliberately does **not** reference `nansen mcp install` (#487) so this stands alone on main; the client list and header forms here match that PR so the two compose either way

🤖 Generated with [Claude Code](https://claude.com/claude-code)
