### PR TITLE
Revoke excessive ERC-20 allowances before swaps

### DIFF
--- a/.changeset/revoke-excessive-allowance.md
+++ b/.changeset/revoke-excessive-allowance.md
@@ -6,3 +6,7 @@
 re-approving when it is more than 10x the current trade's scoped amount, such
 as a legacy unlimited approval or an allowance granted by another app. Most
 trades are unaffected. Opt out with `--no-revoke-excessive-allowance`.
+
+After each revoke or reapproval, the CLI reads the resulting allowance back
+on-chain and fails closed (instead of proceeding to the swap) if it doesn't
+match what was expected or can't be read.

--- a/.changeset/revoke-excessive-allowance.md
+++ b/.changeset/revoke-excessive-allowance.md
@@ -1,0 +1,8 @@
+---
+"nansen-cli": minor
+---
+
+`trade execute` now revokes an existing on-chain ERC-20 allowance before
+re-approving when it is more than 10x the current trade's scoped amount, such
+as a legacy unlimited approval or an allowance granted by another app. Most
+trades are unaffected. Opt out with `--no-revoke-excessive-allowance`.

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -86,6 +86,15 @@ describe('parseArgs', () => {
     expect(result.flags.verbose).toBe(true);
     expect(result.flags.debug).toBe(true);
   });
+
+  it('should not swallow a following positional arg as the value of a trade execute boolean flag', () => {
+    for (const flag of ['no-simulate', 'no-verify-outcome', 'no-revoke-excessive-allowance']) {
+      const result = parseArgs(['trade', 'execute', `--${flag}`, '1708900000000-abc123']);
+      expect(result.flags[flag]).toBe(true);
+      expect(result.options[flag]).toBeUndefined();
+      expect(result._).toEqual(['trade', 'execute', '1708900000000-abc123']);
+    }
+  });
 });
 
 describe('formatValue', () => {

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { validateQuoteInput, fetchNativeBalance, fetchTokenBalance, validateBalance, resolvePercentAmount, validateGasBalance, GASLESS_MIN_TRADE_USD, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertInputWithinMax, assertSwapCalldataNotBareTransfer, MAX_UINT256 } from '../trade-validation.js';
+import { validateQuoteInput, fetchNativeBalance, fetchTokenBalance, validateBalance, resolvePercentAmount, validateGasBalance, GASLESS_MIN_TRADE_USD, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertInputWithinMax, assertSwapCalldataNotBareTransfer, MAX_UINT256, needsAllowanceRevoke } from '../trade-validation.js';
 
 describe('validateQuoteInput', () => {
   const validSolana = {
@@ -1150,11 +1150,33 @@ describe('encodeApproveCalldata', () => {
     expect(() => encodeApproveCalldata(VALID_SPENDER, '1.5e6')).toThrow(/not an integer/i);
   });
 
+  it('allows zero only for explicit revoke approvals', () => {
+    const data = encodeApproveCalldata(VALID_SPENDER, 0n, { allowZero: true });
+    expect(decodeApprove(data).amount).toBe(0n);
+  });
+
   it('enforces the request-intent cap (maxAllowance)', () => {
     // exactly at the cap is fine
     expect(() => encodeApproveCalldata(VALID_SPENDER, 1000n, { maxAllowance: 1000n })).not.toThrow();
     // one unit over the cap is refused
     expect(() => encodeApproveCalldata(VALID_SPENDER, 1001n, { maxAllowance: 1000n })).toThrow(/exceeds the request/i);
+  });
+});
+
+describe('needsAllowanceRevoke', () => {
+  it('does not revoke zero or sufficient scoped allowances', () => {
+    expect(needsAllowanceRevoke(0n, 1000n)).toBe(false);
+    expect(needsAllowanceRevoke(1000n, 1000n)).toBe(false);
+  });
+
+  it('uses a strict more-than-10x boundary', () => {
+    expect(needsAllowanceRevoke(10000n, 1000n)).toBe(false);
+    expect(needsAllowanceRevoke(10001n, 1000n)).toBe(true);
+  });
+
+  it('ignores invalid approval amounts defensively', () => {
+    expect(needsAllowanceRevoke(1000000n, 0n)).toBe(false);
+    expect(needsAllowanceRevoke(1000000n, -1n)).toBe(false);
   });
 });
 

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -3644,7 +3644,7 @@ describe('ERC-20 excessive allowance handling', () => {
 
     // Only the revoke was broadcast; the reapproval and swap never ran.
     expect(executeBodies).toHaveLength(1);
-    expect(logs.some(l => l.includes('Allowance revoke may not have confirmed for #1: allowance is still 2000000, not 0'))).toBe(true);
+    expect(logs.some(l => l.includes('Allowance revoke may not have confirmed for #1: could not verify the allowance was cleared (allowance did not reach expected state after 5 attempts (last read: 2000000))'))).toBe(true);
   });
 
   it('fails closed when a reapproval receipt succeeds but the allowance does not actually increase', async () => {
@@ -3693,7 +3693,7 @@ describe('ERC-20 excessive allowance handling', () => {
 
     // Both the revoke and the reapproval were broadcast; the swap never ran.
     expect(executeBodies).toHaveLength(2);
-    expect(logs.some(l => l.includes('Approval may not have confirmed after revoking the prior allowance (now 0): allowance is 0, below the 100000 this trade requires'))).toBe(true);
+    expect(logs.some(l => l.includes('Approval may not have confirmed after revoking the prior allowance (now 0): could not verify the approval took effect (allowance did not reach expected state after 5 attempts (last read: 0))'))).toBe(true);
   });
 
   it('fails closed when post-revoke allowance verification returns empty data', async () => {

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -619,6 +619,23 @@ describe('buildApprovalTransaction', () => {
     expect(signedHex).not.toContain('f'.repeat(64));
   });
 
+  it('should build a zero-amount revoke approval when explicitly allowed', () => {
+    const wallet = generateEvmWallet();
+    const signedHex = buildApprovalTransaction(
+      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      '0x57df6092665eb6058de53939612413ff4b09114e',
+      wallet.privateKey,
+      'base',
+      0,
+      '1000000',
+      0n,
+      undefined,
+      { allowZero: true },
+    );
+    expect(signedHex).toMatch(/^0x[0-9a-f]+$/);
+    expect(signedHex).toContain('0'.repeat(64));
+  });
+
   it('should reject unsupported chains', () => {
     const wallet = generateEvmWallet();
     expect(() => buildApprovalTransaction('0xabc', '0xdef', wallet.privateKey, 'polygon', 0))
@@ -1514,6 +1531,85 @@ describe('Privy execute support', () => {
     // Verify approval receipt was waited for (eth_getTransactionReceipt called for approval)
     expect(logs.some(l => l.includes('Waiting for approval confirmation'))).toBe(true);
     expect(logs.some(l => l.includes('Approval confirmed in block'))).toBe(true);
+  });
+
+  it('refuses to broadcast when Privy returns no signed revoke transaction', async () => {
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'lifi',
+        inputMint: BASE_USDC,
+        outputMint: OUT_TOKEN,
+        inAmount: '100000',
+        inputAmount: '100000',
+        outAmount: '44000000000000',
+        approvalAddress: LIFI_ROUTER,
+        gas: '300000',
+        transaction: {
+          to: LIFI_ROUTER,
+          data: '0xdeadbeef',
+          value: '0',
+          gas: '300000',
+          maxFeePerGas: '1000000',
+          maxPriorityFeePerGas: '1000000',
+        },
+      }],
+    }, 'base', 'privy', { evm: 'wl_evm_1', solana: 'wl_sol_1' }, null, {
+      swapMode: 'exactIn',
+      request: evmIntent({
+        walletAddress: '0xPrivyAddr',
+        fromToken: BASE_USDC,
+        toToken: OUT_TOKEN,
+        amount: '100000',
+        maxInputAmount: '100000',
+      }),
+    });
+
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(JSON.parse(opts.body));
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Success', txHash: '0xshouldnothappen', chainType: 'evm', broadcaster: 'test' })),
+        });
+      }
+      if (urlStr.includes('privy.io') && opts?.method === 'GET') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ id: 'wl_evm_1', address: '0xPrivyAddr', chain_type: 'ethereum' }),
+        });
+      }
+      if (urlStr.includes('privy.io') && opts?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ data: {} }),
+        });
+      }
+      if (urlStr.includes('base') || urlStr.includes('mainnet')) {
+        const body = opts?.body ? JSON.parse(opts.body) : {};
+        if (body.method === 'eth_getCode') {
+          return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+        }
+        if (body.method === 'eth_call') {
+          return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x' + (2000000n).toString(16).padStart(64, '0') })) });
+        }
+        if (body.method === 'eth_getTransactionCount') {
+          return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+        }
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: null })) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    }));
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (msg) => logs.push(msg), exit: () => {} });
+    await expect(cmds.execute([], null, { 'no-simulate': true }, { quote: quoteId })).rejects.toThrow(/All quotes failed/i);
+
+    expect(executeBodies).toHaveLength(0);
+    expect(logs.some(l => l.includes('Privy returned no signed revoke transaction'))).toBe(true);
+    expect(logs.some(l => l.includes('allowance revoke failed'))).toBe(false);
   });
 });
 
@@ -3168,6 +3264,258 @@ describe('Swap target validation blocks a poisoned quote (security hardening)', 
 
     delete process.env.NANSEN_WALLET_PASSWORD;
     vi.unstubAllGlobals();
+  });
+});
+
+describe('ERC-20 excessive allowance handling', () => {
+  const approveSelector = '095ea7b3';
+  const amountWord = (amount) => BigInt(amount).toString(16).padStart(64, '0');
+  const hexResult = (amount) => '0x' + amountWord(amount);
+
+  function saveLocalErc20Quote(walletAddress, { inputAmount = '100000', approvalAddress = LIFI_ROUTER } = {}) {
+    return saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'lifi',
+        inputMint: BASE_USDC,
+        outputMint: BASE_ETH,
+        inAmount: inputAmount,
+        inputAmount,
+        outAmount: '44000000000000',
+        approvalAddress,
+        gas: '300000',
+        transaction: {
+          to: approvalAddress,
+          data: '0xdeadbeef',
+          value: '0',
+          gas: '300000',
+          gasPrice: '5000000',
+        },
+        metadata: {},
+      }],
+    }, 'base', 'local', null, null, {
+      swapMode: 'exactIn',
+      request: evmIntent({
+        walletAddress,
+        fromToken: BASE_USDC,
+        toToken: BASE_ETH,
+        amount: inputAmount,
+        maxInputAmount: inputAmount,
+      }),
+    });
+  }
+
+  function saveWalletConnectErc20Quote(walletAddress, { inputAmount = '100000', approvalAddress = LIFI_ROUTER } = {}) {
+    return saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'lifi',
+        inputMint: BASE_USDC,
+        outputMint: BASE_ETH,
+        inAmount: inputAmount,
+        inputAmount,
+        outAmount: '44000000000000',
+        approvalAddress,
+        gas: '300000',
+        transaction: {
+          to: approvalAddress,
+          data: '0xdeadbeef',
+          value: '0',
+          gas: '300000',
+          gasPrice: '5000000',
+        },
+        metadata: {},
+      }],
+    }, 'base', 'walletconnect', null, null, {
+      swapMode: 'exactIn',
+      request: evmIntent({
+        walletAddress,
+        fromToken: BASE_USDC,
+        toToken: BASE_ETH,
+        amount: inputAmount,
+        maxInputAmount: inputAmount,
+      }),
+    });
+  }
+
+  function mockLocalEvmExecute({ allowance, executeResponses }) {
+    const executeBodies = [];
+    const sequence = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? JSON.parse(opts.body) : {};
+
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        const response = executeResponses[executeBodies.length] ?? executeResponses.at(-1);
+        executeBodies.push(body);
+        sequence.push({ type: 'execute', txHash: response.txHash, signedTransaction: body.signedTransaction });
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify(response)),
+        });
+      }
+
+      if (body.method === 'eth_getCode') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+      }
+      if (body.method === 'eth_getTransactionCount') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+      }
+      if (body.method === 'eth_getTransactionReceipt') {
+        const txHash = body.params?.[0];
+        sequence.push({ type: 'receipt', txHash });
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { status: '0x1', blockNumber: '0x100' } })) });
+      }
+      if (body.method === 'eth_call') {
+        const data = body.params?.[0]?.data || '';
+        const result = data.startsWith('0xdd62ed3e') ? hexResult(allowance) : '0x';
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result })) });
+      }
+
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+    return { executeBodies, sequence };
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.NANSEN_WALLET_PASSWORD;
+  });
+
+  it('revokes an oversized allowance, waits for receipt, reapproves scoped amount, then broadcasts swap', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+    const quoteId = saveLocalErc20Quote(walletAddress);
+    const { executeBodies, sequence } = mockLocalEvmExecute({
+      allowance: 2000000n,
+      executeResponses: [
+        { status: 'Success', txHash: '0xRevokeHash', chainType: 'evm', broadcaster: 'test' },
+        { status: 'Success', txHash: '0xApprovalHash', chainType: 'evm', broadcaster: 'test' },
+        { status: 'Success', txHash: '0xSwapHash', chainType: 'evm', broadcaster: 'test' },
+      ],
+    });
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    await cmds.execute([], null, { 'no-simulate': true }, { quote: quoteId });
+
+    expect(executeBodies).toHaveLength(3);
+    expect(executeBodies[0].signedTransaction).toContain(approveSelector);
+    expect(executeBodies[0].signedTransaction).toContain(amountWord(0n));
+    expect(executeBodies[1].signedTransaction).toContain(approveSelector);
+    expect(executeBodies[1].signedTransaction).toContain(amountWord(100000n));
+    expect(executeBodies[2].signedTransaction).not.toContain(approveSelector);
+    expect(sequence.map(e => `${e.type}:${e.txHash}`)).toEqual([
+      'execute:0xRevokeHash',
+      'receipt:0xRevokeHash',
+      'execute:0xApprovalHash',
+      'receipt:0xApprovalHash',
+      'execute:0xSwapHash',
+      'receipt:0xSwapHash',
+    ]);
+    expect(logs.some(l => l.includes('Existing allowance (2000000)'))).toBe(true);
+    expect(logs.some(l => l.includes('Allowance revoked in block'))).toBe(true);
+  });
+
+  it('fails closed when reapproval fails after a successful revoke', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+    const quoteId = saveLocalErc20Quote(walletAddress);
+    const { executeBodies } = mockLocalEvmExecute({
+      allowance: 2000000n,
+      executeResponses: [
+        { status: 'Success', txHash: '0xRevokeHash', chainType: 'evm', broadcaster: 'test' },
+        { status: 'Failed', error: 'approval simulation failed', txHash: '0xApprovalHash', chainType: 'evm', broadcaster: 'test' },
+      ],
+    });
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    await expect(cmds.execute([], null, { 'no-simulate': true }, { quote: quoteId })).rejects.toThrow(/All quotes failed/i);
+
+    expect(executeBodies).toHaveLength(2);
+    expect(executeBodies[0].signedTransaction).toContain(amountWord(0n));
+    expect(executeBodies[1].signedTransaction).toContain(amountWord(100000n));
+    expect(logs.some(l => l.includes('Approval failed for #1 after revoking the prior allowance (now 0)'))).toBe(true);
+  });
+
+  it('reuses a sufficient allowance below the excessive threshold without approval transactions', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+    const quoteId = saveLocalErc20Quote(walletAddress);
+    const { executeBodies } = mockLocalEvmExecute({
+      allowance: 300000n,
+      executeResponses: [
+        { status: 'Success', txHash: '0xSwapHash', chainType: 'evm', broadcaster: 'test' },
+      ],
+    });
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    await cmds.execute([], null, { 'no-simulate': true }, { quote: quoteId });
+
+    expect(executeBodies).toHaveLength(1);
+    expect(executeBodies[0].signedTransaction).not.toContain(approveSelector);
+    expect(logs.some(l => l.includes('Sufficient allowance exists for #1, skipping approval'))).toBe(true);
+  });
+
+  it('reuses an oversized sufficient allowance when revocation is explicitly disabled', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+    const quoteId = saveLocalErc20Quote(walletAddress);
+    const { executeBodies } = mockLocalEvmExecute({
+      allowance: 2000000n,
+      executeResponses: [
+        { status: 'Success', txHash: '0xSwapHash', chainType: 'evm', broadcaster: 'test' },
+      ],
+    });
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    await cmds.execute([], null, { 'no-simulate': true, 'no-revoke-excessive-allowance': true }, { quote: quoteId });
+
+    expect(executeBodies).toHaveLength(1);
+    expect(executeBodies[0].signedTransaction).not.toContain(approveSelector);
+    expect(logs.some(l => l.includes('--no-revoke-excessive-allowance was set'))).toBe(true);
+    expect(logs.some(l => l.includes('Sufficient allowance exists for #1, skipping approval'))).toBe(true);
+    expect(logs.some(l => l.includes('Approval required'))).toBe(false);
+  });
+
+  it('fails closed when WalletConnect revoke returns no confirmable transaction', async () => {
+    const wcAddress = '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4';
+    vi.spyOn(wcTrading, 'getWalletConnectAddress').mockResolvedValue(wcAddress);
+    const approvalSpy = vi.spyOn(wcTrading, 'sendApprovalViaWalletConnect').mockResolvedValue({});
+    const sendSpy = vi.spyOn(wcTrading, 'sendTransactionViaWalletConnect').mockResolvedValue({ txHash: '0xshouldnothappen' });
+    const quoteId = saveWalletConnectErc20Quote(wcAddress);
+    const { executeBodies } = mockLocalEvmExecute({
+      allowance: 2000000n,
+      executeResponses: [
+        { status: 'Success', txHash: '0xshouldnothappen', chainType: 'evm', broadcaster: 'test' },
+      ],
+    });
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    await expect(cmds.execute([], null, { 'no-simulate': true }, { quote: quoteId })).rejects.toThrow(/All quotes failed/i);
+
+    expect(approvalSpy).toHaveBeenCalledTimes(1);
+    expect(approvalSpy).toHaveBeenCalledWith(
+      BASE_USDC,
+      LIFI_ROUTER,
+      8453,
+      0n,
+      undefined,
+      { allowZero: true },
+    );
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(executeBodies).toHaveLength(0);
+    expect(logs.some(l => l.includes('cannot confirm allowance was cleared'))).toBe(true);
+    expect(logs.some(l => l.includes('Approval required'))).toBe(false);
   });
 });
 

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -1475,6 +1475,9 @@ describe('Privy execute support', () => {
     });
 
     const rpcCalls = [];
+    // Post-approval allowance verification re-reads eth_call, so track the
+    // simulated on-chain value: 0 until the approval broadcasts successfully.
+    let currentAllowance = 0n;
     vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
       const urlStr = typeof url === 'string' ? url : url.toString();
       // Privy getWallet
@@ -1501,9 +1504,9 @@ describe('Privy execute support', () => {
         if (body.method === 'eth_getCode') {
           return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
         }
-        // eth_call for allowance check — return 0 (needs approval)
+        // eth_call for allowance check
         if (body.method === 'eth_call') {
-          return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x0000000000000000000000000000000000000000000000000000000000000000' })) });
+          return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x' + currentAllowance.toString(16).padStart(64, '0') })) });
         }
         // eth_getTransactionReceipt (for waitForReceipt)
         if (body.method === 'eth_getTransactionReceipt') {
@@ -1513,6 +1516,7 @@ describe('Privy execute support', () => {
       }
       // Trading API executeTransaction
       if (urlStr.includes('trading-api')) {
+        currentAllowance = 1000000n; // the approval that was just broadcast lands on-chain
         return Promise.resolve({
           ok: true,
           text: () => Promise.resolve(JSON.stringify({ status: 'Success', txHash: '0xApprovalHash', chainType: 'evm', broadcaster: 'test' })),
@@ -1649,11 +1653,15 @@ describe('Privy execute support', () => {
     // Privy signs the revoke (1st POST) but returns an empty response for the
     // approval (2nd POST) — the allowance has already been zeroed on-chain.
     let privyPostCount = 0;
+    let currentAllowance = 2000000n; // Oversized existing allowance (2 USDC) → triggers revoke-then-reapprove
     const executeBodies = [];
     vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
       const urlStr = typeof url === 'string' ? url : url.toString();
       if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
         executeBodies.push(JSON.parse(opts.body));
+        // The broadcast revoke lands on-chain, so the post-revoke allowance
+        // verification reads back 0.
+        currentAllowance = 0n;
         return Promise.resolve({
           ok: true,
           text: () => Promise.resolve(JSON.stringify({ status: 'Success', txHash: '0xRevokeHash', chainType: 'evm', broadcaster: 'test' })),
@@ -1676,8 +1684,7 @@ describe('Privy execute support', () => {
           return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
         }
         if (body.method === 'eth_call') {
-          // Oversized existing allowance (2 USDC) → triggers revoke-then-reapprove
-          return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x' + (2000000n).toString(16).padStart(64, '0') })) });
+          return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x' + currentAllowance.toString(16).padStart(64, '0') })) });
         }
         if (body.method === 'eth_getTransactionCount') {
           return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
@@ -3482,6 +3489,10 @@ describe('ERC-20 excessive allowance handling', () => {
   function mockLocalEvmExecute({ allowance, executeResponses }) {
     const executeBodies = [];
     const sequence = [];
+    // Post-action allowance verification re-reads eth_call, so track the
+    // simulated on-chain value and update it when a broadcast approve()
+    // (revoke-to-zero or scoped reapproval) actually lands.
+    let currentAllowance = BigInt(allowance);
     vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
       const urlStr = typeof url === 'string' ? url : url.toString();
       const body = opts?.body ? JSON.parse(opts.body) : {};
@@ -3490,6 +3501,11 @@ describe('ERC-20 excessive allowance handling', () => {
         const response = executeResponses[executeBodies.length] ?? executeResponses.at(-1);
         executeBodies.push(body);
         sequence.push({ type: 'execute', txHash: response.txHash, signedTransaction: body.signedTransaction });
+        const selectorIdx = body.signedTransaction?.indexOf(approveSelector);
+        if (response.status === 'Success' && selectorIdx >= 0) {
+          const amountStart = selectorIdx + approveSelector.length + 64;
+          currentAllowance = BigInt('0x' + body.signedTransaction.slice(amountStart, amountStart + 64));
+        }
         return Promise.resolve({
           ok: true,
           text: () => Promise.resolve(JSON.stringify(response)),
@@ -3509,13 +3525,13 @@ describe('ERC-20 excessive allowance handling', () => {
       }
       if (body.method === 'eth_call') {
         const data = body.params?.[0]?.data || '';
-        const result = data.startsWith('0xdd62ed3e') ? hexResult(allowance) : '0x';
+        const result = data.startsWith('0xdd62ed3e') ? hexResult(currentAllowance) : '0x';
         return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result })) });
       }
 
       return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
     }));
-    return { executeBodies, sequence };
+    return { executeBodies, sequence, setAllowance: (v) => { currentAllowance = BigInt(v); } };
   }
 
   afterEach(() => {
@@ -3581,6 +3597,97 @@ describe('ERC-20 excessive allowance handling', () => {
     expect(executeBodies[0].signedTransaction).toContain(amountWord(0n));
     expect(executeBodies[1].signedTransaction).toContain(amountWord(100000n));
     expect(logs.some(l => l.includes('Approval failed for #1 after revoking the prior allowance (now 0)'))).toBe(true);
+  });
+
+  it('fails closed when a revoke receipt succeeds but the allowance does not actually clear', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+    const quoteId = saveLocalErc20Quote(walletAddress);
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? JSON.parse(opts.body) : {};
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(body);
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Success', txHash: '0xRevokeHash', chainType: 'evm', broadcaster: 'test' })),
+        });
+      }
+      if (body.method === 'eth_getCode') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+      }
+      if (body.method === 'eth_getTransactionCount') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+      }
+      if (body.method === 'eth_getTransactionReceipt') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { status: '0x1', blockNumber: '0x100' } })) });
+      }
+      if (body.method === 'eth_call') {
+        // The revoke's receipt reports success, but the allowance never actually
+        // clears on-chain (e.g. a broadcaster that confirmed the wrong tx).
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: hexResult(2000000n) })) });
+      }
+      return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    await expect(cmds.execute([], null, { 'no-simulate': true }, { quote: quoteId })).rejects.toThrow(/All quotes failed/i);
+
+    // Only the revoke was broadcast; the reapproval and swap never ran.
+    expect(executeBodies).toHaveLength(1);
+    expect(logs.some(l => l.includes('Allowance revoke may not have confirmed for #1: allowance is still 2000000, not 0'))).toBe(true);
+  });
+
+  it('fails closed when a reapproval receipt succeeds but the allowance does not actually increase', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+    const quoteId = saveLocalErc20Quote(walletAddress);
+    const executeBodies = [];
+    let executeCount = 0;
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? JSON.parse(opts.body) : {};
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(body);
+        executeCount++;
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({
+            status: 'Success',
+            txHash: executeCount === 1 ? '0xRevokeHash' : '0xApprovalHash',
+            chainType: 'evm',
+            broadcaster: 'test',
+          })),
+        });
+      }
+      if (body.method === 'eth_getCode') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+      }
+      if (body.method === 'eth_getTransactionCount') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+      }
+      if (body.method === 'eth_getTransactionReceipt') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { status: '0x1', blockNumber: '0x100' } })) });
+      }
+      if (body.method === 'eth_call') {
+        // Revoke actually clears the allowance, but the reapproval's receipt
+        // reports success without the allowance ever increasing.
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: hexResult(executeCount === 0 ? 2000000n : 0n) })) });
+      }
+      return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    await expect(cmds.execute([], null, { 'no-simulate': true }, { quote: quoteId })).rejects.toThrow(/All quotes failed/i);
+
+    // Both the revoke and the reapproval were broadcast; the swap never ran.
+    expect(executeBodies).toHaveLength(2);
+    expect(logs.some(l => l.includes('Approval may not have confirmed after revoking the prior allowance (now 0): allowance is 0, below the 100000 this trade requires'))).toBe(true);
   });
 
   it('reuses a sufficient allowance below the excessive threshold without approval transactions', async () => {
@@ -3662,18 +3769,19 @@ describe('ERC-20 excessive allowance handling', () => {
   it('fails closed when WalletConnect approval returns no confirmable transaction after a revoke', async () => {
     const wcAddress = '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4';
     vi.spyOn(wcTrading, 'getWalletConnectAddress').mockResolvedValue(wcAddress);
-    // Revoke confirms (returns a tx hash); the reapproval returns nothing.
-    const approvalSpy = vi.spyOn(wcTrading, 'sendApprovalViaWalletConnect')
-      .mockResolvedValueOnce({ txHash: '0xRevokeHash' })
-      .mockResolvedValueOnce({});
-    const sendSpy = vi.spyOn(wcTrading, 'sendTransactionViaWalletConnect').mockResolvedValue({ txHash: '0xshouldnothappen' });
     const quoteId = saveWalletConnectErc20Quote(wcAddress);
-    const { executeBodies } = mockLocalEvmExecute({
+    const { executeBodies, setAllowance } = mockLocalEvmExecute({
       allowance: 2000000n,
       executeResponses: [
         { status: 'Success', txHash: '0xshouldnothappen', chainType: 'evm', broadcaster: 'test' },
       ],
     });
+    // Revoke confirms (returns a tx hash, simulating the allowance clearing
+    // on-chain); the reapproval returns nothing.
+    const approvalSpy = vi.spyOn(wcTrading, 'sendApprovalViaWalletConnect')
+      .mockImplementationOnce(async () => { setAllowance(0n); return { txHash: '0xRevokeHash' }; })
+      .mockResolvedValueOnce({});
+    const sendSpy = vi.spyOn(wcTrading, 'sendTransactionViaWalletConnect').mockResolvedValue({ txHash: '0xshouldnothappen' });
 
     const logs = [];
     const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -42,6 +42,7 @@ import {
   pollBridgeStatus,
   saveTxRecord,
   loadTxRecord,
+  __setAllowanceTimingForTests,
 } from '../trading.js';
 import { SIMULATION_RPCS } from '../rpc-urls.js';
 import { keccak256, rlpEncode } from '../crypto.js';
@@ -3534,7 +3535,12 @@ describe('ERC-20 excessive allowance handling', () => {
     return { executeBodies, sequence, setAllowance: (v) => { currentAllowance = BigInt(v); } };
   }
 
+  beforeEach(() => {
+    __setAllowanceTimingForTests({ verifyDelayMs: 0, propagationDelayMs: 0 });
+  });
+
   afterEach(() => {
+    __setAllowanceTimingForTests();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     delete process.env.NANSEN_WALLET_PASSWORD;
@@ -3688,6 +3694,49 @@ describe('ERC-20 excessive allowance handling', () => {
     // Both the revoke and the reapproval were broadcast; the swap never ran.
     expect(executeBodies).toHaveLength(2);
     expect(logs.some(l => l.includes('Approval may not have confirmed after revoking the prior allowance (now 0): allowance is 0, below the 100000 this trade requires'))).toBe(true);
+  });
+
+  it('fails closed when post-revoke allowance verification returns empty data', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+    const quoteId = saveLocalErc20Quote(walletAddress);
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? JSON.parse(opts.body) : {};
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(body);
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Success', txHash: '0xRevokeHash', chainType: 'evm', broadcaster: 'test' })),
+        });
+      }
+      if (body.method === 'eth_getCode') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+      }
+      if (body.method === 'eth_getTransactionCount') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+      }
+      if (body.method === 'eth_getTransactionReceipt') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { status: '0x1', blockNumber: '0x100' } })) });
+      }
+      if (body.method === 'eth_call') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: executeBodies.length === 0 ? hexResult(2000000n) : '0x',
+        })) });
+      }
+      return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    await expect(cmds.execute([], null, { 'no-simulate': true }, { quote: quoteId })).rejects.toThrow(/All quotes failed/i);
+
+    expect(executeBodies).toHaveLength(1);
+    expect(logs.some(l => l.includes('invalid allowance() return data: 0x'))).toBe(true);
   });
 
   it('reuses a sufficient allowance below the excessive threshold without approval transactions', async () => {

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -1613,6 +1613,92 @@ describe('Privy execute support', () => {
     expect(logs.some(l => l.includes('Privy returned no signed transaction'))).toBe(true);
     expect(logs.some(l => l.includes('Allowance revoke failed'))).toBe(true);
   });
+
+  it('fails closed when Privy returns no signed approval transaction after a successful revoke', async () => {
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'lifi',
+        inputMint: BASE_USDC,
+        outputMint: OUT_TOKEN,
+        inAmount: '100000',
+        inputAmount: '100000',
+        outAmount: '44000000000000',
+        approvalAddress: LIFI_ROUTER,
+        gas: '300000',
+        transaction: {
+          to: LIFI_ROUTER,
+          data: '0xdeadbeef',
+          value: '0',
+          gas: '300000',
+          maxFeePerGas: '1000000',
+          maxPriorityFeePerGas: '1000000',
+        },
+      }],
+    }, 'base', 'privy', { evm: 'wl_evm_1', solana: 'wl_sol_1' }, null, {
+      swapMode: 'exactIn',
+      request: evmIntent({
+        walletAddress: '0xPrivyAddr',
+        fromToken: BASE_USDC,
+        toToken: OUT_TOKEN,
+        amount: '100000',
+        maxInputAmount: '100000',
+      }),
+    });
+
+    // Privy signs the revoke (1st POST) but returns an empty response for the
+    // approval (2nd POST) — the allowance has already been zeroed on-chain.
+    let privyPostCount = 0;
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(JSON.parse(opts.body));
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Success', txHash: '0xRevokeHash', chainType: 'evm', broadcaster: 'test' })),
+        });
+      }
+      if (urlStr.includes('privy.io') && opts?.method === 'GET') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ id: 'wl_evm_1', address: '0xPrivyAddr', chain_type: 'ethereum' }),
+        });
+      }
+      if (urlStr.includes('privy.io') && opts?.method === 'POST') {
+        privyPostCount++;
+        const data = privyPostCount === 1 ? { signed_transaction: '0xSignedRevoke' } : {};
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ data }) });
+      }
+      if (urlStr.includes('base') || urlStr.includes('mainnet')) {
+        const body = opts?.body ? JSON.parse(opts.body) : {};
+        if (body.method === 'eth_getCode') {
+          return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+        }
+        if (body.method === 'eth_call') {
+          // Oversized existing allowance (2 USDC) → triggers revoke-then-reapprove
+          return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x' + (2000000n).toString(16).padStart(64, '0') })) });
+        }
+        if (body.method === 'eth_getTransactionCount') {
+          return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+        }
+        if (body.method === 'eth_getTransactionReceipt') {
+          return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { status: '0x1', blockNumber: '0x100' } })) });
+        }
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: null })) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    }));
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (msg) => logs.push(msg), exit: () => {} });
+    await expect(cmds.execute([], null, { 'no-simulate': true }, { quote: quoteId })).rejects.toThrow(/All quotes failed/i);
+
+    // Only the revoke was broadcast; the swap was never signed or sent.
+    expect(executeBodies).toHaveLength(1);
+    expect(logs.some(l => l.includes('Allowance revoked in block'))).toBe(true);
+    expect(logs.some(l => l.includes('Approval failed for #1 after revoking the prior allowance (now 0): Privy returned no signed transaction'))).toBe(true);
+  });
 });
 
 // ============= stripLeadingZeros =============

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -3644,7 +3644,7 @@ describe('ERC-20 excessive allowance handling', () => {
 
     // Only the revoke was broadcast; the reapproval and swap never ran.
     expect(executeBodies).toHaveLength(1);
-    expect(logs.some(l => l.includes('Allowance revoke may not have confirmed for #1: could not verify the allowance was cleared (allowance did not reach expected state after 5 attempts (last read: 2000000))'))).toBe(true);
+    expect(logs.some(l => l.includes('Revoke tx confirmed but allowance was not cleared for #1: could not verify the allowance was cleared (allowance did not reach expected state after 5 attempts (last read: 2000000))'))).toBe(true);
   });
 
   it('fails closed when a reapproval receipt succeeds but the allowance does not actually increase', async () => {
@@ -3693,7 +3693,7 @@ describe('ERC-20 excessive allowance handling', () => {
 
     // Both the revoke and the reapproval were broadcast; the swap never ran.
     expect(executeBodies).toHaveLength(2);
-    expect(logs.some(l => l.includes('Approval may not have confirmed after revoking the prior allowance (now 0): could not verify the approval took effect (allowance did not reach expected state after 5 attempts (last read: 0))'))).toBe(true);
+    expect(logs.some(l => l.includes('Approval tx confirmed but allowance did not reach the required amount for #1 after revoking the prior allowance (now 0): could not verify the approval took effect (allowance did not reach expected state after 5 attempts (last read: 0))'))).toBe(true);
   });
 
   it('fails closed when post-revoke allowance verification returns empty data', async () => {
@@ -3737,6 +3737,24 @@ describe('ERC-20 excessive allowance handling', () => {
 
     expect(executeBodies).toHaveLength(1);
     expect(logs.some(l => l.includes('invalid allowance() return data: 0x'))).toBe(true);
+  });
+
+  it('guards the allowance timing override outside test environments', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    const originalVitest = process.env.VITEST;
+    process.env.NODE_ENV = 'production';
+    delete process.env.VITEST;
+
+    try {
+      expect(() => __setAllowanceTimingForTests({ verifyDelayMs: 0 })).toThrow(/tests only/i);
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+      if (originalVitest == null) {
+        delete process.env.VITEST;
+      } else {
+        process.env.VITEST = originalVitest;
+      }
+    }
   });
 
   it('reuses a sufficient allowance below the excessive threshold without approval transactions', async () => {

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -3658,6 +3658,34 @@ describe('ERC-20 excessive allowance handling', () => {
     expect(logs.some(l => l.includes('cannot confirm allowance was cleared'))).toBe(true);
     expect(logs.some(l => l.includes('Approval required'))).toBe(false);
   });
+
+  it('fails closed when WalletConnect approval returns no confirmable transaction after a revoke', async () => {
+    const wcAddress = '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4';
+    vi.spyOn(wcTrading, 'getWalletConnectAddress').mockResolvedValue(wcAddress);
+    // Revoke confirms (returns a tx hash); the reapproval returns nothing.
+    const approvalSpy = vi.spyOn(wcTrading, 'sendApprovalViaWalletConnect')
+      .mockResolvedValueOnce({ txHash: '0xRevokeHash' })
+      .mockResolvedValueOnce({});
+    const sendSpy = vi.spyOn(wcTrading, 'sendTransactionViaWalletConnect').mockResolvedValue({ txHash: '0xshouldnothappen' });
+    const quoteId = saveWalletConnectErc20Quote(wcAddress);
+    const { executeBodies } = mockLocalEvmExecute({
+      allowance: 2000000n,
+      executeResponses: [
+        { status: 'Success', txHash: '0xshouldnothappen', chainType: 'evm', broadcaster: 'test' },
+      ],
+    });
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    await expect(cmds.execute([], null, { 'no-simulate': true }, { quote: quoteId })).rejects.toThrow(/All quotes failed/i);
+
+    // Both the revoke and the reapproval were attempted; the swap was never sent.
+    expect(approvalSpy).toHaveBeenCalledTimes(2);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(executeBodies).toHaveLength(0);
+    expect(logs.some(l => l.includes('Allowance revoked in block'))).toBe(true);
+    expect(logs.some(l => l.includes('Approval failed for #1 after revoking the prior allowance (now 0): returned no transaction hash and no signed transaction; cannot confirm approval landed'))).toBe(true);
+  });
 });
 
 describe('Relay aggregator: --gasless flag dispatch', () => {

--- a/src/__tests__/walletconnect-trading.test.js
+++ b/src/__tests__/walletconnect-trading.test.js
@@ -332,6 +332,22 @@ describe('sendApprovalViaWalletConnect', () => {
     const payload = JSON.parse(execFile.mock.calls[0][1][1]);
     expect(payload.gas).toBe('0x186a0'); // 100000 in hex
   });
+
+  it('builds zero-amount revoke calldata when explicitly allowed', async () => {
+    mockExecFile(JSON.stringify({ txHash: '0xrevoke123' }));
+
+    await sendApprovalViaWalletConnect(
+      '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      '0xDef1C0ded9bec7F1a1670819833240f027b25EfF',
+      8453,
+      0n,
+      undefined,
+      { allowZero: true },
+    );
+
+    const payload = JSON.parse(execFile.mock.calls[0][1][1]);
+    expect(payload.data.slice(74)).toBe('0'.repeat(64));
+  });
 });
 
 // ============= sendSolanaTransactionViaWalletConnect =============

--- a/src/cli.js
+++ b/src/cli.js
@@ -190,7 +190,7 @@ export function parseArgs(args) {
       const key = arg.slice(2);
       const next = args[i + 1];
       
-      if (key === 'pretty' || key === 'help' || key === 'version' || key === 'table' || key === 'no-retry' || key === 'cache' || key === 'no-cache' || key === 'stream' || key === 'enrich' || key === 'full' || key === 'human' || key === 'enabled' || key === 'disabled' || key === 'expert' || key === 'json' || key === 'offline') {
+      if (key === 'pretty' || key === 'help' || key === 'version' || key === 'table' || key === 'no-retry' || key === 'cache' || key === 'no-cache' || key === 'stream' || key === 'enrich' || key === 'full' || key === 'human' || key === 'enabled' || key === 'disabled' || key === 'expert' || key === 'json' || key === 'offline' || key === 'no-simulate' || key === 'no-verify-outcome' || key === 'no-revoke-excessive-allowance') {
         result.flags[key] = true;
       } else if (next && (!next.startsWith('-') || /^-\d/.test(next))) {
         // Try to parse as JSON first (for objects/arrays/booleans),

--- a/src/schema.json
+++ b/src/schema.json
@@ -1621,6 +1621,10 @@
             "no-simulate": {
               "type": "boolean",
               "description": "Skip the pre-broadcast simulation."
+            },
+            "no-revoke-excessive-allowance": {
+              "type": "boolean",
+              "description": "Skip revoking an existing on-chain ERC-20 allowance before re-approving when it exceeds 10x this trade's scoped amount. By default, an oversized or legacy allowance is revoked to zero and a fresh trade-scoped allowance is granted. WalletConnect users will see separate wallet prompts for the revoke and re-approval."
             }
           }
         },

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -437,7 +437,8 @@ export function assertValidApprovalSpender(spender) {
  *
  * Guarantees on the returned string:
  *   - spender is a valid 20-byte address (see assertValidApprovalSpender)
- *   - amount is a positive integer strictly below MAX_UINT256 (never unlimited)
+ *   - amount is a positive integer strictly below MAX_UINT256 (never unlimited),
+ *     unless `allowZero` is explicitly set for a revoke-to-zero approval
  *   - amount does not exceed `maxAllowance` when the caller supplies one
  *     (the user's persisted request intent — see assertQuoteMatchesRequest)
  *   - the encoded calldata is exactly 68 bytes (4-byte selector + two 32-byte
@@ -447,9 +448,10 @@ export function assertValidApprovalSpender(spender) {
  * @param {bigint|string|number} amount - Allowance in base units
  * @param {object} [opts]
  * @param {bigint|string|number} [opts.maxAllowance] - Hard cap from request intent
+ * @param {boolean} [opts.allowZero=false] - Allow encoding a zero-amount revoke approval
  * @returns {string} 0x-prefixed approve() calldata (exactly 68 bytes)
  */
-export function encodeApproveCalldata(spender, amount, { maxAllowance } = {}) {
+export function encodeApproveCalldata(spender, amount, { maxAllowance, allowZero = false } = {}) {
   assertValidApprovalSpender(spender);
 
   let amt;
@@ -458,7 +460,7 @@ export function encodeApproveCalldata(spender, amount, { maxAllowance } = {}) {
   } catch {
     throw new Error(`Approval amount is not an integer (${amount}). Refusing to sign an approval.`);
   }
-  if (amt <= 0n) {
+  if (amt < 0n || (amt === 0n && !allowZero)) {
     throw new Error(`Approval amount must be positive (got ${amt}). Refusing to sign an approval.`);
   }
   if (amt >= MAX_UINT256) {
@@ -542,6 +544,23 @@ export function approvalAmountForSwap({ inputAmount, swapMode, slippage }) {
     return buffered;
   }
   return amt;
+}
+
+// Existing allowances above this multiple of the current trade's scoped amount
+// are treated as stale/oversized rather than reusable dust from a prior swap.
+export const OVERSIZED_ALLOWANCE_MULTIPLIER = 10n;
+
+/**
+ * Decide whether an existing on-chain ERC-20 allowance should be revoked before
+ * granting the current trade's scoped approval.
+ *
+ * @param {bigint} existingAllowance - Current on-chain allowance
+ * @param {bigint} approveAmt - This trade's scoped approval amount
+ * @returns {boolean}
+ */
+export function needsAllowanceRevoke(existingAllowance, approveAmt) {
+  if (approveAmt <= 0n) return false;
+  return existingAllowance > approveAmt * OVERSIZED_ALLOWANCE_MULTIPLIER;
 }
 
 // ============= Quote vs. request-intent revalidation =============

--- a/src/trading.js
+++ b/src/trading.js
@@ -857,6 +857,14 @@ export function approvalCapForQuote(quoteData) {
   return quoteData?.swapMode === 'exactOut' ? undefined : quoteData?.request?.amount;
 }
 
+// Decide what to do with a pre-existing on-chain allowance before a swap.
+// `shouldRevoke` describes the allowance ("it's oversized"), NOT the action taken:
+// callers use it both to gate the actual revoke (in the !reuseAllowance branch)
+// and to warn when reuse is forced by --no-revoke-excessive-allowance (in the
+// reuseAllowance branch). Note shouldRevoke ⟹ existingAllowance > approveAmt*10 ⟹
+// existingAllowance >= approveAmt, so with the flag set reuseAllowance is always
+// true and the revoke/"after revoking (now 0)" paths (all in the else branch) are
+// never reached spuriously — keep that invariant if you add branches here.
 function resolveAllowanceAction(existingAllowance, approveAmt, noRevokeExcessiveAllowance) {
   const shouldRevoke = existingAllowance > 0n && needsAllowanceRevoke(existingAllowance, approveAmt);
   const reuseAllowance = existingAllowance >= approveAmt && existingAllowance > 0n
@@ -2151,7 +2159,7 @@ EXAMPLES:
                       const receipt = await waitForReceipt(chain, revokeResult.txHash);
                       log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeResult.txHash}`);
                     } catch (receiptErr) {
-                      log(`  ❌ Allowance revoke may not have confirmed: ${receiptErr.message}`);
+                      log(`  ❌ Allowance revoke may not have confirmed for ${quoteName}: ${receiptErr.message}`);
                       if (qi + 1 < endIndex) log(`  Trying next quote...`);
                       lastQuoteError = `${quoteName} allowance revoke unconfirmed`;
                       continue;
@@ -2729,7 +2737,7 @@ EXAMPLES:
                       const receipt = await waitForReceipt(chain, revokeResult.txHash);
                       log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeResult.txHash}`);
                     } catch (receiptErr) {
-                      log(`  ❌ Allowance revoke may not have confirmed: ${receiptErr.message}`);
+                      log(`  ❌ Allowance revoke may not have confirmed for ${quoteName}: ${receiptErr.message}`);
                       if (qi + 1 < endIndex) log(`  Trying next quote...`);
                       lastQuoteError = `${quoteName} allowance revoke unconfirmed`;
                       continue;

--- a/src/trading.js
+++ b/src/trading.js
@@ -2172,6 +2172,15 @@ EXAMPLES:
                     max_priority_fee_per_gas: toHex(approvalPriorityFee),
                   });
                   const signedApproval = approvalSignResult.data?.signed_transaction || approvalSignResult.signed_transaction;
+                  if (!signedApproval) {
+                    const revokedMsg = shouldRevoke
+                      ? ' after revoking the prior allowance (now 0)'
+                      : '';
+                    log(`  ❌ Approval failed for ${quoteName}${revokedMsg}: Privy returned no signed transaction`);
+                    if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                    lastQuoteError = `${quoteName} approval failed`;
+                    continue;
+                  }
                   const approvalResult = await executeTransaction({ signedTransaction: signedApproval, chain, simulate: !noSimulate });
                   if (approvalResult.status !== 'Success') {
                     const revokedMsg = shouldRevoke

--- a/src/trading.js
+++ b/src/trading.js
@@ -473,8 +473,7 @@ export function cleanupQuotes() {
  * @param {string} privateKeyHex - 128-char hex (64 bytes: seed + pubkey)
  * @returns {string} Base64-encoded signed transaction
  */
-// Pure Solana encode/sign primitive. Quote authorization and request-intent
-// binding happen upstream before this function receives transaction bytes.
+// ⚠️ SECURITY: Solana transaction signing - requires thorough review before production use
 export function signSolanaTransaction(transactionBase64, privateKeyHex) {
   const txBytes = Buffer.from(transactionBase64, 'base64');
 
@@ -818,7 +817,13 @@ export async function checkErc20Allowance(chain, tokenAddress, ownerAddress, spe
     const result = await evmRpcCall(chain, 'eth_call', [{ to: tokenAddress, data }, 'latest']);
     if (!result) return 0n;
     return BigInt(result);
-  } catch {
+  } catch (err) {
+    // Treat an unreadable allowance as 0 so the caller re-approves a fresh scoped
+    // amount (a normal approve() overwrites any real on-chain allowance) rather
+    // than trusting a value we couldn't verify. Surface it so a persistent RPC
+    // problem — which would otherwise silently skip the excessive-allowance
+    // revoke — isn't invisible.
+    process.stderr.write(`⚠️  Could not read ERC-20 allowance on ${chain} (${err.message}); treating as 0.\n`);
     return 0n;
   }
 }
@@ -2196,7 +2201,7 @@ EXAMPLES:
                     const receipt = await waitForReceipt(chain, approvalResult.txHash);
                     log(`  ✓ Approval confirmed in block ${parseInt(receipt.blockNumber, 16)}: ${approvalResult.txHash}`);
                   } catch (receiptErr) {
-                    log(`  ❌ Approval may not have confirmed: ${receiptErr.message}`);
+                    log(`  ❌ Approval may not have confirmed${shouldRevoke ? ' after revoking the prior allowance (now 0)' : ''}: ${receiptErr.message}`);
                     if (qi + 1 < endIndex) log(`  Trying next quote...`);
                     lastQuoteError = `${quoteName} approval unconfirmed`;
                     continue;
@@ -2767,7 +2772,7 @@ EXAMPLES:
                     const receipt = await waitForReceipt(chain, approvalResult.txHash);
                     log(`  ✓ Approval confirmed in block ${parseInt(receipt.blockNumber, 16)}: ${approvalResult.txHash}`);
                   } catch (receiptErr) {
-                    log(`  ❌ Approval may not have confirmed: ${receiptErr.message}`);
+                    log(`  ❌ Approval may not have confirmed${shouldRevoke ? ' after revoking the prior allowance (now 0)' : ''}: ${receiptErr.message}`);
                     if (qi + 1 < endIndex) log(`  Trying next quote...`);
                     lastQuoteError = `${quoteName} approval unconfirmed`;
                     continue;

--- a/src/trading.js
+++ b/src/trading.js
@@ -840,15 +840,38 @@ export async function checkErc20Allowance(chain, tokenAddress, ownerAddress, spe
 /**
  * A successful receipt only proves the revoke/approval call didn't revert —
  * not that approve() actually produced the allowance we expect (a
- * non-standard token, a stale read, or a race with another approval could
- * still leave the wrong value on-chain). Read the allowance back after each
- * step and fail closed — including when it can't be read at all — rather
- * than trusting receipt status alone.
+ * non-standard token or a race with another approval could still leave the
+ * wrong value on-chain). Poll the allowance a few times before failing
+ * closed: an `eth_call` at 'latest' immediately after a receipt can hit an
+ * RPC node that hasn't caught up with the just-mined block yet and read
+ * stale pre-transaction state — confirmed live (PR #509 review follow-up)
+ * against a real Base approval that read back as unset for several seconds
+ * after its receipt landed, then correctly as the approved amount once the
+ * node caught up.
  */
+const ALLOWANCE_VERIFY_ATTEMPTS = 5;
+const ALLOWANCE_VERIFY_DELAY_MS = 1500;
+
+async function pollAllowanceUntil(chain, tokenAddress, ownerAddress, spenderAddress, isExpected) {
+  let allowance, lastErr;
+  for (let attempt = 0; attempt < ALLOWANCE_VERIFY_ATTEMPTS; attempt++) {
+    if (attempt > 0) await new Promise(r => setTimeout(r, ALLOWANCE_VERIFY_DELAY_MS));
+    try {
+      allowance = await readErc20AllowanceOrThrow(chain, tokenAddress, ownerAddress, spenderAddress);
+      lastErr = undefined;
+      if (isExpected(allowance)) return allowance;
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  if (lastErr) throw lastErr;
+  return allowance;
+}
+
 async function assertAllowanceRevoked(chain, tokenAddress, ownerAddress, spenderAddress) {
   let allowance;
   try {
-    allowance = await readErc20AllowanceOrThrow(chain, tokenAddress, ownerAddress, spenderAddress);
+    allowance = await pollAllowanceUntil(chain, tokenAddress, ownerAddress, spenderAddress, a => a === 0n);
   } catch (err) {
     throw new Error(`could not verify the allowance was cleared (${err.message})`, { cause: err });
   }
@@ -860,7 +883,7 @@ async function assertAllowanceRevoked(chain, tokenAddress, ownerAddress, spender
 async function assertAllowanceAtLeast(chain, tokenAddress, ownerAddress, spenderAddress, minAmount) {
   let allowance;
   try {
-    allowance = await readErc20AllowanceOrThrow(chain, tokenAddress, ownerAddress, spenderAddress);
+    allowance = await pollAllowanceUntil(chain, tokenAddress, ownerAddress, spenderAddress, a => a >= minAmount);
   } catch (err) {
     throw new Error(`could not verify the approval took effect (${err.message})`, { cause: err });
   }

--- a/src/trading.js
+++ b/src/trading.js
@@ -889,7 +889,14 @@ async function pollAllowanceUntil(chain, tokenAddress, ownerAddress, spenderAddr
     }
   }
   if (lastErr) throw lastErr;
-  return allowance;
+  throw new Error(
+    `allowance did not reach expected state after ${ALLOWANCE_VERIFY_ATTEMPTS} attempts (last read: ${allowance})`,
+  );
+}
+
+function allowanceRevokeRecoveryHint(txHash) {
+  const txHint = txHash ? ` Tx: ${txHash}.` : '';
+  return `${txHint} Check the transaction on-chain, then retry this execute command or re-quote if needed.`;
 }
 
 async function assertAllowanceRevoked(chain, tokenAddress, ownerAddress, spenderAddress) {
@@ -2248,7 +2255,7 @@ EXAMPLES:
                       log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeResult.txHash}`);
                       await assertAllowanceRevoked(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress);
                     } catch (receiptErr) {
-                      log(`  ❌ Allowance revoke may not have confirmed for ${quoteName}: ${receiptErr.message}`);
+                      log(`  ❌ Allowance revoke may not have confirmed for ${quoteName}: ${receiptErr.message}.${allowanceRevokeRecoveryHint(revokeResult.txHash)}`);
                       if (qi + 1 < endIndex) log(`  Trying next quote...`);
                       lastQuoteError = `${quoteName} allowance revoke unconfirmed`;
                       continue;
@@ -2522,6 +2529,7 @@ EXAMPLES:
                   if (shouldRevoke) {
                     log(`  ⚠ Existing allowance (${existingAllowance}) for ${quoteName} is excessive (>${OVERSIZED_ALLOWANCE_MULTIPLIER}x this trade) — revoking before re-approving`);
                     log(`  Sending allowance revocation via WalletConnect (you'll be asked to approve this separately)...`);
+                    let revokeTxHash;
                     try {
                       const revokeResult = await sendApprovalViaWalletConnect(
                         currentQuote.inputMint,
@@ -2531,7 +2539,7 @@ EXAMPLES:
                         undefined,
                         { allowZero: true },
                       );
-                      let revokeTxHash = revokeResult.txHash;
+                      revokeTxHash = revokeResult.txHash;
                       if (!revokeTxHash && revokeResult.signedTransaction) {
                         log(`  Broadcasting allowance revocation via Trading API...`);
                         const broadcastResult = await executeTransaction({
@@ -2552,7 +2560,7 @@ EXAMPLES:
                       log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeTxHash}`);
                       await assertAllowanceRevoked(chain, currentQuote.inputMint, wcAddress, currentQuote.approvalAddress);
                     } catch (revokeErr) {
-                      log(`  ❌ Allowance revoke failed for ${quoteName}: ${revokeErr.message}`);
+                      log(`  ❌ Allowance revoke failed for ${quoteName}: ${revokeErr.message}.${allowanceRevokeRecoveryHint(revokeTxHash)}`);
                       if (qi + 1 < endIndex) log(`  Trying next quote...`);
                       lastQuoteError = `${quoteName} allowance revoke failed`;
                       continue;
@@ -2836,7 +2844,7 @@ EXAMPLES:
                       log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeResult.txHash}`);
                       await assertAllowanceRevoked(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress);
                     } catch (receiptErr) {
-                      log(`  ❌ Allowance revoke may not have confirmed for ${quoteName}: ${receiptErr.message}`);
+                      log(`  ❌ Allowance revoke may not have confirmed for ${quoteName}: ${receiptErr.message}.${allowanceRevokeRecoveryHint(revokeResult.txHash)}`);
                       if (qi + 1 < endIndex) log(`  Trying next quote...`);
                       lastQuoteError = `${quoteName} allowance revoke unconfirmed`;
                       continue;

--- a/src/trading.js
+++ b/src/trading.js
@@ -816,7 +816,10 @@ async function readErc20AllowanceOrThrow(chain, tokenAddress, ownerAddress, spen
     + ownerAddress.slice(2).toLowerCase().padStart(64, '0')
     + spenderAddress.slice(2).toLowerCase().padStart(64, '0');
   const result = await evmRpcCall(chain, 'eth_call', [{ to: tokenAddress, data }, 'latest']);
-  return result ? BigInt(result) : 0n;
+  if (!/^0x[0-9a-fA-F]{64}$/.test(result || '')) {
+    throw new Error(`invalid allowance() return data: ${result || '<empty>'}`);
+  }
+  return BigInt(result);
 }
 
 /**
@@ -850,12 +853,33 @@ export async function checkErc20Allowance(chain, tokenAddress, ownerAddress, spe
  * node caught up.
  */
 const ALLOWANCE_VERIFY_ATTEMPTS = 5;
-const ALLOWANCE_VERIFY_DELAY_MS = 1500;
+const DEFAULT_ALLOWANCE_VERIFY_DELAY_MS = 1500;
+const DEFAULT_POST_ALLOWANCE_TX_PROPAGATION_MS = 2000;
+let allowanceVerifyDelayMs = DEFAULT_ALLOWANCE_VERIFY_DELAY_MS;
+let postAllowanceTxPropagationMs = DEFAULT_POST_ALLOWANCE_TX_PROPAGATION_MS;
+
+export function __setAllowanceTimingForTests({
+  verifyDelayMs = DEFAULT_ALLOWANCE_VERIFY_DELAY_MS,
+  propagationDelayMs = DEFAULT_POST_ALLOWANCE_TX_PROPAGATION_MS,
+} = {}) {
+  allowanceVerifyDelayMs = verifyDelayMs;
+  postAllowanceTxPropagationMs = propagationDelayMs;
+}
+
+async function waitForAllowanceTxPropagation() {
+  // The receipt + allowance poll verifies token state, but the following swap
+  // still goes through a broadcaster/load-balanced RPC path. Give that path a
+  // short propagation window before signing the next dependent transaction.
+  if (postAllowanceTxPropagationMs <= 0) return;
+  await new Promise(r => setTimeout(r, postAllowanceTxPropagationMs));
+}
 
 async function pollAllowanceUntil(chain, tokenAddress, ownerAddress, spenderAddress, isExpected) {
   let allowance, lastErr;
   for (let attempt = 0; attempt < ALLOWANCE_VERIFY_ATTEMPTS; attempt++) {
-    if (attempt > 0) await new Promise(r => setTimeout(r, ALLOWANCE_VERIFY_DELAY_MS));
+    if (attempt > 0 && allowanceVerifyDelayMs > 0) {
+      await new Promise(r => setTimeout(r, allowanceVerifyDelayMs));
+    }
     try {
       allowance = await readErc20AllowanceOrThrow(chain, tokenAddress, ownerAddress, spenderAddress);
       lastErr = undefined;
@@ -2229,7 +2253,7 @@ EXAMPLES:
                       lastQuoteError = `${quoteName} allowance revoke unconfirmed`;
                       continue;
                     }
-                    await new Promise(r => setTimeout(r, 2000));
+                    await waitForAllowanceTxPropagation();
                   }
                   log(`  ⚠ Approval required → ${currentQuote.approvalAddress}`);
                   const approvalNonce = await getEvmNonce(chain, walletAddress);
@@ -2280,7 +2304,7 @@ EXAMPLES:
                     lastQuoteError = `${quoteName} approval unconfirmed`;
                     continue;
                   }
-                  await new Promise(r => setTimeout(r, 2000));
+                  await waitForAllowanceTxPropagation();
                 }
               }
 
@@ -2533,7 +2557,7 @@ EXAMPLES:
                       lastQuoteError = `${quoteName} allowance revoke failed`;
                       continue;
                     }
-                    await new Promise(r => setTimeout(r, 2000));
+                    await waitForAllowanceTxPropagation();
                   }
                   log(`  ⚠ Approval required → ${currentQuote.approvalAddress}`);
                   log(`  Sending approval via WalletConnect...`);
@@ -2580,7 +2604,7 @@ EXAMPLES:
                     lastQuoteError = `${quoteName} approval failed`;
                     continue;
                   }
-                  await new Promise(r => setTimeout(r, 2000));
+                  await waitForAllowanceTxPropagation();
                   log('');
                 }
               }
@@ -2817,7 +2841,7 @@ EXAMPLES:
                       lastQuoteError = `${quoteName} allowance revoke unconfirmed`;
                       continue;
                     }
-                    await new Promise(r => setTimeout(r, 2000));
+                    await waitForAllowanceTxPropagation();
                   }
                   log(`  ⚠ Approval required → ${currentQuote.approvalAddress}`);
                   log(`  Sending approval tx...`);
@@ -2861,8 +2885,7 @@ EXAMPLES:
                     lastQuoteError = `${quoteName} approval unconfirmed`;
                     continue;
                   }
-                  // Wait for RPC state propagation after approval
-                  await new Promise(r => setTimeout(r, 2000));
+                  await waitForAllowanceTxPropagation();
                   log('');
                 }
               }

--- a/src/trading.js
+++ b/src/trading.js
@@ -2492,11 +2492,17 @@ EXAMPLES:
                       }
                       approvalTxHash = broadcastResult.txHash;
                     }
-                    if (approvalTxHash) {
-                      log(`  Waiting for approval confirmation...`);
-                      const receipt = await waitForReceipt(chain, approvalTxHash);
-                      log(`  ✓ Approval confirmed in block ${parseInt(receipt.blockNumber, 16)}: ${approvalTxHash}`);
+                    if (!approvalTxHash) {
+                      // Fail closed: the wallet returned neither a hash nor a
+                      // signed tx, so we can't confirm the approval landed —
+                      // never fall through to the swap (esp. after a revoke has
+                      // already zeroed the allowance). The catch adds the
+                      // "after revoking (now 0)" context.
+                      throw new Error('returned no transaction hash and no signed transaction; cannot confirm approval landed');
                     }
+                    log(`  Waiting for approval confirmation...`);
+                    const receipt = await waitForReceipt(chain, approvalTxHash);
+                    log(`  ✓ Approval confirmed in block ${parseInt(receipt.blockNumber, 16)}: ${approvalTxHash}`);
                   } catch (approvalErr) {
                     const revokedMsg = shouldRevoke
                       ? ' after revoking the prior allowance (now 0)'

--- a/src/trading.js
+++ b/src/trading.js
@@ -803,20 +803,29 @@ export async function estimateEvmGas(chain, { from, to, data, value }) {
 }
 
 /**
+ * Read the current on-chain ERC-20 allowance, throwing on any RPC failure
+ * instead of masking it. checkErc20Allowance below wraps this with a
+ * catch-to-0 fallback for the pre-trade check (safe there, since a follow-up
+ * approve() overwrites whatever the prior value was); post-action
+ * verification needs the raw, fail-closed read instead.
+ */
+async function readErc20AllowanceOrThrow(chain, tokenAddress, ownerAddress, spenderAddress) {
+  if (!CHAIN_RPCS[chain]) throw new Error(`no RPC configured for chain ${chain}`);
+  // allowance(address,address) selector = 0xdd62ed3e
+  const data = '0xdd62ed3e'
+    + ownerAddress.slice(2).toLowerCase().padStart(64, '0')
+    + spenderAddress.slice(2).toLowerCase().padStart(64, '0');
+  const result = await evmRpcCall(chain, 'eth_call', [{ to: tokenAddress, data }, 'latest']);
+  return result ? BigInt(result) : 0n;
+}
+
+/**
  * Check ERC-20 allowance for a given owner/spender pair.
  * Returns the allowance as a BigInt, or 0n on failure.
  */
 export async function checkErc20Allowance(chain, tokenAddress, ownerAddress, spenderAddress) {
-  if (!CHAIN_RPCS[chain]) return 0n;
-
   try {
-    // allowance(address,address) selector = 0xdd62ed3e
-    const data = '0xdd62ed3e'
-      + ownerAddress.slice(2).toLowerCase().padStart(64, '0')
-      + spenderAddress.slice(2).toLowerCase().padStart(64, '0');
-    const result = await evmRpcCall(chain, 'eth_call', [{ to: tokenAddress, data }, 'latest']);
-    if (!result) return 0n;
-    return BigInt(result);
+    return await readErc20AllowanceOrThrow(chain, tokenAddress, ownerAddress, spenderAddress);
   } catch (err) {
     // Treat an unreadable allowance as 0 so the caller re-approves a fresh scoped
     // amount (a normal approve() overwrites any real on-chain allowance) rather
@@ -825,6 +834,38 @@ export async function checkErc20Allowance(chain, tokenAddress, ownerAddress, spe
     // revoke — isn't invisible.
     process.stderr.write(`⚠️  Could not read ERC-20 allowance on ${chain} (${err.message}); treating as 0.\n`);
     return 0n;
+  }
+}
+
+/**
+ * A successful receipt only proves the revoke/approval call didn't revert —
+ * not that approve() actually produced the allowance we expect (a
+ * non-standard token, a stale read, or a race with another approval could
+ * still leave the wrong value on-chain). Read the allowance back after each
+ * step and fail closed — including when it can't be read at all — rather
+ * than trusting receipt status alone.
+ */
+async function assertAllowanceRevoked(chain, tokenAddress, ownerAddress, spenderAddress) {
+  let allowance;
+  try {
+    allowance = await readErc20AllowanceOrThrow(chain, tokenAddress, ownerAddress, spenderAddress);
+  } catch (err) {
+    throw new Error(`could not verify the allowance was cleared (${err.message})`, { cause: err });
+  }
+  if (allowance !== 0n) {
+    throw new Error(`allowance is still ${allowance}, not 0`);
+  }
+}
+
+async function assertAllowanceAtLeast(chain, tokenAddress, ownerAddress, spenderAddress, minAmount) {
+  let allowance;
+  try {
+    allowance = await readErc20AllowanceOrThrow(chain, tokenAddress, ownerAddress, spenderAddress);
+  } catch (err) {
+    throw new Error(`could not verify the approval took effect (${err.message})`, { cause: err });
+  }
+  if (allowance < minAmount) {
+    throw new Error(`allowance is ${allowance}, below the ${minAmount} this trade requires`);
   }
 }
 
@@ -2158,6 +2199,7 @@ EXAMPLES:
                     try {
                       const receipt = await waitForReceipt(chain, revokeResult.txHash);
                       log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeResult.txHash}`);
+                      await assertAllowanceRevoked(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress);
                     } catch (receiptErr) {
                       log(`  ❌ Allowance revoke may not have confirmed for ${quoteName}: ${receiptErr.message}`);
                       if (qi + 1 < endIndex) log(`  Trying next quote...`);
@@ -2208,6 +2250,7 @@ EXAMPLES:
                   try {
                     const receipt = await waitForReceipt(chain, approvalResult.txHash);
                     log(`  ✓ Approval confirmed in block ${parseInt(receipt.blockNumber, 16)}: ${approvalResult.txHash}`);
+                    await assertAllowanceAtLeast(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress, approveAmt);
                   } catch (receiptErr) {
                     log(`  ❌ Approval may not have confirmed${shouldRevoke ? ' after revoking the prior allowance (now 0)' : ''}: ${receiptErr.message}`);
                     if (qi + 1 < endIndex) log(`  Trying next quote...`);
@@ -2460,6 +2503,7 @@ EXAMPLES:
                       log(`  Waiting for allowance revoke confirmation...`);
                       const receipt = await waitForReceipt(chain, revokeTxHash);
                       log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeTxHash}`);
+                      await assertAllowanceRevoked(chain, currentQuote.inputMint, wcAddress, currentQuote.approvalAddress);
                     } catch (revokeErr) {
                       log(`  ❌ Allowance revoke failed for ${quoteName}: ${revokeErr.message}`);
                       if (qi + 1 < endIndex) log(`  Trying next quote...`);
@@ -2503,6 +2547,7 @@ EXAMPLES:
                     log(`  Waiting for approval confirmation...`);
                     const receipt = await waitForReceipt(chain, approvalTxHash);
                     log(`  ✓ Approval confirmed in block ${parseInt(receipt.blockNumber, 16)}: ${approvalTxHash}`);
+                    await assertAllowanceAtLeast(chain, currentQuote.inputMint, wcAddress, currentQuote.approvalAddress, approveAmt);
                   } catch (approvalErr) {
                     const revokedMsg = shouldRevoke
                       ? ' after revoking the prior allowance (now 0)'
@@ -2742,6 +2787,7 @@ EXAMPLES:
                     try {
                       const receipt = await waitForReceipt(chain, revokeResult.txHash);
                       log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeResult.txHash}`);
+                      await assertAllowanceRevoked(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress);
                     } catch (receiptErr) {
                       log(`  ❌ Allowance revoke may not have confirmed for ${quoteName}: ${receiptErr.message}`);
                       if (qi + 1 < endIndex) log(`  Trying next quote...`);
@@ -2785,6 +2831,7 @@ EXAMPLES:
                   try {
                     const receipt = await waitForReceipt(chain, approvalResult.txHash);
                     log(`  ✓ Approval confirmed in block ${parseInt(receipt.blockNumber, 16)}: ${approvalResult.txHash}`);
+                    await assertAllowanceAtLeast(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress, approveAmt);
                   } catch (receiptErr) {
                     log(`  ❌ Approval may not have confirmed${shouldRevoke ? ' after revoking the prior allowance (now 0)' : ''}: ${receiptErr.message}`);
                     if (qi + 1 < endIndex) log(`  Trying next quote...`);

--- a/src/trading.js
+++ b/src/trading.js
@@ -13,7 +13,7 @@ import { base58Decode } from './transfer.js';
 import { keccak256, signSecp256k1, rlpEncode } from './crypto.js';
 import { getWalletConnectAddress, sendTransactionViaWalletConnect, sendSolanaTransactionViaWalletConnect, sendApprovalViaWalletConnect } from './walletconnect-trading.js';
 import { retrievePassword } from './keychain.js';
-import { validateQuoteInput, validateBalance, resolvePercentAmount, validateGasBalance, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertSwapCalldataNotBareTransfer, approvalAmountForSwap } from './trade-validation.js';
+import { validateQuoteInput, validateBalance, resolvePercentAmount, validateGasBalance, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertSwapCalldataNotBareTransfer, approvalAmountForSwap, needsAllowanceRevoke, OVERSIZED_ALLOWANCE_MULTIPLIER } from './trade-validation.js';
 import { CHAIN_RPCS } from './rpc-urls.js';
 import { packageVersion, CommandError, telemetryHeaders } from './api.js';
 
@@ -450,11 +450,10 @@ export function cleanupQuotes() {
 
 // ============= Transaction Signing =============
 
-// ----------------------------------------------------------------
-// TODO: SECURITY REVIEW REQUIRED
-// The signing functions below construct and sign raw transactions.
-// They MUST be audited before any production/mainnet use.
-// ----------------------------------------------------------------
+// The signing functions below construct and sign raw transactions from quote
+// data. The authorization checks that make them safe to call live upstream:
+// assertQuoteMatchesRequest, assertSwapCalldataNotBareTransfer, scoped ERC-20
+// approvals, and the approval target/amount validators in trade-validation.js.
 
 /**
  * Sign a Solana transaction from quote data.
@@ -473,7 +472,8 @@ export function cleanupQuotes() {
  * @param {string} privateKeyHex - 128-char hex (64 bytes: seed + pubkey)
  * @returns {string} Base64-encoded signed transaction
  */
-// ⚠️ SECURITY: Solana transaction signing - requires thorough review before production use
+// Pure Solana encode/sign primitive. Quote authorization and request-intent
+// binding happen upstream before this function receives transaction bytes.
 export function signSolanaTransaction(transactionBase64, privateKeyHex) {
   const txBytes = Buffer.from(transactionBase64, 'base64');
 
@@ -526,7 +526,8 @@ export function signSolanaTransaction(transactionBase64, privateKeyHex) {
  * @param {number} nonce - Account nonce
  * @returns {string} 0x-prefixed signed transaction hex
  */
-// ⚠️ SECURITY: EVM transaction signing - requires thorough review before production use
+// Pure EVM encode/sign primitive. Quote authorization and request-intent binding
+// happen upstream before this function receives transaction calldata.
 export function signEvmTransaction(txData, privateKeyHex, chain, nonce) {
   const chainConfig = CHAIN_MAP[chain];
   if (!chainConfig || chainConfig.type !== 'evm') {
@@ -764,6 +765,13 @@ export function approvalCapForQuote(quoteData) {
   return quoteData?.swapMode === 'exactOut' ? undefined : quoteData?.request?.amount;
 }
 
+function resolveAllowanceAction(existingAllowance, approveAmt, noRevokeExcessiveAllowance) {
+  const shouldRevoke = existingAllowance > 0n && needsAllowanceRevoke(existingAllowance, approveAmt);
+  const reuseAllowance = existingAllowance >= approveAmt && existingAllowance > 0n
+    && (noRevokeExcessiveAllowance || !shouldRevoke);
+  return { shouldRevoke, reuseAllowance };
+}
+
 export function assertCompleteEvmRequestIntent(request) {
   if (!request) {
     throw new Error('Quote is missing request intent. Re-quote with this CLI version before executing an EVM swap. Refusing to sign.');
@@ -882,10 +890,15 @@ export function assertUsableSpender(spenderAddress) {
  * @param {string|number} gasPrice - Legacy gas price
  * @param {bigint|string|number} amount - Allowance to grant, in base units (see approvalAmountForSwap)
  * @param {bigint|string|number} [maxAllowance] - Hard cap from persisted request intent
+ * @param {object} [opts]
+ * @param {boolean} [opts.allowZero=false] - Allow a zero-amount revoke approval
  * @returns {string} 0x-prefixed signed approval tx hex
  */
-// ⚠️ SECURITY: ERC-20 approval signing - requires thorough review
-export function buildApprovalTransaction(tokenAddress, spenderAddress, privateKeyHex, chain, nonce, gasPrice, amount, maxAllowance) {
+// Approval signing is intentionally narrow: callers pass either the scoped swap
+// amount from approvalAmountForSwap or, for excessive-allowance cleanup, an
+// explicit allowZero revoke. encodeApproveCalldata validates the spender,
+// amount, optional request cap, and final ABI width before signing.
+export function buildApprovalTransaction(tokenAddress, spenderAddress, privateKeyHex, chain, nonce, gasPrice, amount, maxAllowance, { allowZero = false } = {}) {
   const chainConfig = CHAIN_MAP[chain];
   if (!chainConfig) throw new Error(`Unsupported chain: ${chain}`);
 
@@ -893,7 +906,7 @@ export function buildApprovalTransaction(tokenAddress, spenderAddress, privateKe
   // can drain at most this one trade, never the wallet's full token balance.
   // encodeApproveCalldata enforces a valid 20-byte spender, a bounded (< MAX)
   // amount within the request cap, and exactly-68-byte calldata.
-  const data = encodeApproveCalldata(spenderAddress, amount, { maxAllowance });
+  const data = encodeApproveCalldata(spenderAddress, amount, { maxAllowance, allowZero });
 
   const tx = {
     nonce,
@@ -909,7 +922,8 @@ export function buildApprovalTransaction(tokenAddress, spenderAddress, privateKe
 }
 
 // ============= Legacy (Type 0) EVM Transaction Signing =============
-// ⚠️ SECURITY: Legacy EVM transaction signing - requires thorough review before production use
+// Low-level RLP/secp256k1 signing primitive used after upstream quote and
+// allowance validation has already bounded what the transaction can authorize.
 
 /**
  * Strip all leading zero bytes from a buffer.
@@ -1761,6 +1775,7 @@ CROSS-CHAIN NOTES (when using --to-chain):
       const quoteId = options.quote || options['quote-id'] || args[0];
       const walletName = options.wallet;
       const noSimulate = flags['no-simulate'];
+      const noRevokeExcessiveAllowance = flags['no-revoke-excessive-allowance'];
       const gasless = Boolean(flags.gasless);
 
       if (!quoteId) {
@@ -1770,6 +1785,8 @@ OPTIONS:
   --quote <id>              Quote ID from 'nansen quote'
   --wallet <name>           Wallet name (default: default wallet)
   --no-simulate             Skip pre-broadcast simulation
+  --no-revoke-excessive-allowance
+                            Skip auto-revoking an oversized/legacy allowance before re-approving
   --gasless                 Relay-only: have Relay's solver pay gas (no WalletConnect)
 
 EXAMPLES:
@@ -1987,9 +2004,53 @@ EXAMPLES:
                   chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress
                 );
 
-                if (existingAllowance >= approveAmt && existingAllowance > 0n) {
+                const { shouldRevoke, reuseAllowance } = resolveAllowanceAction(existingAllowance, approveAmt, noRevokeExcessiveAllowance);
+                if (reuseAllowance) {
+                  if (noRevokeExcessiveAllowance && shouldRevoke) {
+                    log(`  ⚠ Existing allowance (${existingAllowance}) for ${quoteName} is excessive (>${OVERSIZED_ALLOWANCE_MULTIPLIER}x this trade), but --no-revoke-excessive-allowance was set`);
+                  }
                   log(`  ✓ Sufficient allowance exists for ${quoteName}, skipping approval`);
                 } else {
+                  const approvalMaxFee = currentQuote.transaction?.maxFeePerGas || currentQuote.transaction?.gasPrice || '1000000';
+                  const approvalPriorityFee = currentQuote.transaction?.maxPriorityFeePerGas || '1000000';
+
+                  if (shouldRevoke) {
+                    log(`  ⚠ Existing allowance (${existingAllowance}) for ${quoteName} is excessive (>${OVERSIZED_ALLOWANCE_MULTIPLIER}x this trade) — revoking before re-approving`);
+                    const revokeNonce = await getEvmNonce(chain, walletAddress);
+                    const revokeData = encodeApproveCalldata(currentQuote.approvalAddress, 0n, { allowZero: true });
+                    const revokeSignResult = await privyClient.signEvmTransaction(evmWalletId, {
+                      to: currentQuote.inputMint,
+                      data: revokeData,
+                      value: '0x0',
+                      chain_id: chainConfig.chainId,
+                      nonce: toHex(revokeNonce),
+                      gas_limit: toHex(100000),
+                      max_fee_per_gas: toHex(approvalMaxFee),
+                      max_priority_fee_per_gas: toHex(approvalPriorityFee),
+                    });
+                    const signedRevoke = revokeSignResult.data?.signed_transaction || revokeSignResult.signed_transaction;
+                    if (!signedRevoke) {
+                      throw new Error('Privy returned no signed revoke transaction; refusing to proceed');
+                    }
+                    const revokeResult = await executeTransaction({ signedTransaction: signedRevoke, chain, simulate: !noSimulate });
+                    if (revokeResult.status !== 'Success') {
+                      log(`  ❌ Allowance revoke failed for ${quoteName}: ${revokeResult.error || 'unknown'}`);
+                      if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                      lastQuoteError = `${quoteName} allowance revoke failed`;
+                      continue;
+                    }
+                    log(`  Waiting for allowance revoke confirmation...`);
+                    try {
+                      const receipt = await waitForReceipt(chain, revokeResult.txHash);
+                      log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeResult.txHash}`);
+                    } catch (receiptErr) {
+                      log(`  ❌ Allowance revoke may not have confirmed: ${receiptErr.message}`);
+                      if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                      lastQuoteError = `${quoteName} allowance revoke unconfirmed`;
+                      continue;
+                    }
+                    await new Promise(r => setTimeout(r, 2000));
+                  }
                   log(`  ⚠ Approval required → ${currentQuote.approvalAddress}`);
                   const approvalNonce = await getEvmNonce(chain, walletAddress);
                   // Scope the approval to this trade's input (see approvalAmountForSwap).
@@ -1998,8 +2059,6 @@ EXAMPLES:
                   const approvalData = encodeApproveCalldata(currentQuote.approvalAddress, approveAmt, {
                     maxAllowance: approvalCapForQuote(quoteData),
                   });
-                  const approvalMaxFee = currentQuote.transaction?.maxFeePerGas || currentQuote.transaction?.gasPrice || '1000000';
-                  const approvalPriorityFee = currentQuote.transaction?.maxPriorityFeePerGas || '1000000';
                   const approvalSignResult = await privyClient.signEvmTransaction(evmWalletId, {
                     to: currentQuote.inputMint,
                     data: approvalData,
@@ -2013,7 +2072,10 @@ EXAMPLES:
                   const signedApproval = approvalSignResult.data?.signed_transaction || approvalSignResult.signed_transaction;
                   const approvalResult = await executeTransaction({ signedTransaction: signedApproval, chain, simulate: !noSimulate });
                   if (approvalResult.status !== 'Success') {
-                    log(`  ❌ Approval failed for ${quoteName}: ${approvalResult.error || 'unknown'}`);
+                    const revokedMsg = shouldRevoke
+                      ? ' after revoking the prior allowance (now 0)'
+                      : '';
+                    log(`  ❌ Approval failed for ${quoteName}${revokedMsg}: ${approvalResult.error || 'unknown'}`);
                     if (qi + 1 < endIndex) log(`  Trying next quote...`);
                     lastQuoteError = `${quoteName} approval failed`;
                     continue;
@@ -2222,9 +2284,52 @@ EXAMPLES:
                   chain, currentQuote.inputMint, wcAddress, currentQuote.approvalAddress
                 );
 
-                if (existingAllowance >= approveAmt && existingAllowance > 0n) {
+                const { shouldRevoke, reuseAllowance } = resolveAllowanceAction(existingAllowance, approveAmt, noRevokeExcessiveAllowance);
+                if (reuseAllowance) {
+                  if (noRevokeExcessiveAllowance && shouldRevoke) {
+                    log(`  ⚠ Existing allowance (${existingAllowance}) for ${quoteName} is excessive (>${OVERSIZED_ALLOWANCE_MULTIPLIER}x this trade), but --no-revoke-excessive-allowance was set`);
+                  }
                   log(`  ✓ Sufficient allowance exists for ${quoteName}, skipping approval`);
                 } else {
+                  if (shouldRevoke) {
+                    log(`  ⚠ Existing allowance (${existingAllowance}) for ${quoteName} is excessive (>${OVERSIZED_ALLOWANCE_MULTIPLIER}x this trade) — revoking before re-approving`);
+                    log(`  Sending allowance revocation via WalletConnect (you'll be asked to approve this separately)...`);
+                    try {
+                      const revokeResult = await sendApprovalViaWalletConnect(
+                        currentQuote.inputMint,
+                        currentQuote.approvalAddress,
+                        chainConfig.chainId,
+                        0n,
+                        undefined,
+                        { allowZero: true },
+                      );
+                      let revokeTxHash = revokeResult.txHash;
+                      if (!revokeTxHash && revokeResult.signedTransaction) {
+                        log(`  Broadcasting allowance revocation via Trading API...`);
+                        const broadcastResult = await executeTransaction({
+                          signedTransaction: revokeResult.signedTransaction,
+                          chain,
+                          simulate: !noSimulate,
+                        });
+                        if (broadcastResult.status !== 'Success') {
+                          throw new Error(broadcastResult.error || 'broadcast failed');
+                        }
+                        revokeTxHash = broadcastResult.txHash;
+                      }
+                      if (!revokeTxHash) {
+                        throw new Error('Allowance revoke returned no transaction hash and no signed transaction; cannot confirm allowance was cleared');
+                      }
+                      log(`  Waiting for allowance revoke confirmation...`);
+                      const receipt = await waitForReceipt(chain, revokeTxHash);
+                      log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeTxHash}`);
+                    } catch (revokeErr) {
+                      log(`  ❌ Allowance revoke failed for ${quoteName}: ${revokeErr.message}`);
+                      if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                      lastQuoteError = `${quoteName} allowance revoke failed`;
+                      continue;
+                    }
+                    await new Promise(r => setTimeout(r, 2000));
+                  }
                   log(`  ⚠ Approval required → ${currentQuote.approvalAddress}`);
                   log(`  Sending approval via WalletConnect...`);
                   try {
@@ -2255,7 +2360,10 @@ EXAMPLES:
                       log(`  ✓ Approval confirmed in block ${parseInt(receipt.blockNumber, 16)}: ${approvalTxHash}`);
                     }
                   } catch (approvalErr) {
-                    log(`  ❌ Approval failed for ${quoteName}: ${approvalErr.message}`);
+                    const revokedMsg = shouldRevoke
+                      ? ' after revoking the prior allowance (now 0)'
+                      : '';
+                    log(`  ❌ Approval failed for ${quoteName}${revokedMsg}: ${approvalErr.message}`);
                     if (qi + 1 < endIndex) log(`  Trying next quote...`);
                     lastQuoteError = `${quoteName} approval failed`;
                     continue;
@@ -2434,14 +2542,60 @@ EXAMPLES:
                   chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress
                 );
 
-                if (existingAllowance >= approveAmt && existingAllowance > 0n) {
+                const { shouldRevoke, reuseAllowance } = resolveAllowanceAction(existingAllowance, approveAmt, noRevokeExcessiveAllowance);
+                if (reuseAllowance) {
+                  if (noRevokeExcessiveAllowance && shouldRevoke) {
+                    log(`  ⚠ Existing allowance (${existingAllowance}) for ${quoteName} is excessive (>${OVERSIZED_ALLOWANCE_MULTIPLIER}x this trade), but --no-revoke-excessive-allowance was set`);
+                  }
                   log(`  ✓ Sufficient allowance exists for ${quoteName}, skipping approval`);
                 } else {
+                  const approvalGasPrice = currentQuote.transaction?.gasPrice || currentQuote.transaction?.maxFeePerGas || '1000000';
+
+                  if (shouldRevoke) {
+                    log(`  ⚠ Existing allowance (${existingAllowance}) for ${quoteName} is excessive (>${OVERSIZED_ALLOWANCE_MULTIPLIER}x this trade) — revoking before re-approving`);
+                    log(`  Sending allowance revocation tx...`);
+                    const revokeNonce = await getEvmNonce(chain, walletAddress);
+                    const revokeTxHex = buildApprovalTransaction(
+                      currentQuote.inputMint,
+                      currentQuote.approvalAddress,
+                      exported.evm.privateKey,
+                      chain,
+                      revokeNonce,
+                      approvalGasPrice,
+                      0n,
+                      undefined,
+                      { allowZero: true },
+                    );
+
+                    const revokeResult = await executeTransaction({
+                      signedTransaction: revokeTxHex,
+                      chain,
+                      simulate: !noSimulate,
+                    });
+
+                    if (revokeResult.status !== 'Success') {
+                      log(`  ❌ Allowance revoke failed for ${quoteName}: ${revokeResult.error || 'unknown error'}`);
+                      if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                      lastQuoteError = `${quoteName} allowance revoke failed`;
+                      continue;
+                    }
+
+                    log(`  Waiting for allowance revoke confirmation...`);
+                    try {
+                      const receipt = await waitForReceipt(chain, revokeResult.txHash);
+                      log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeResult.txHash}`);
+                    } catch (receiptErr) {
+                      log(`  ❌ Allowance revoke may not have confirmed: ${receiptErr.message}`);
+                      if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                      lastQuoteError = `${quoteName} allowance revoke unconfirmed`;
+                      continue;
+                    }
+                    await new Promise(r => setTimeout(r, 2000));
+                  }
                   log(`  ⚠ Approval required → ${currentQuote.approvalAddress}`);
                   log(`  Sending approval tx...`);
                   const approvalNonce = await getEvmNonce(chain, walletAddress);
 
-                  const approvalGasPrice = currentQuote.transaction?.gasPrice || currentQuote.transaction?.maxFeePerGas || '1000000';
                   const approvalTxHex = buildApprovalTransaction(
                     currentQuote.inputMint,
                     currentQuote.approvalAddress,
@@ -2460,7 +2614,10 @@ EXAMPLES:
                   });
 
                   if (approvalResult.status !== 'Success') {
-                    log(`  ❌ Approval failed for ${quoteName}: ${approvalResult.error || 'unknown error'}`);
+                    const revokedMsg = shouldRevoke
+                      ? ' after revoking the prior allowance (now 0)'
+                      : '';
+                    log(`  ❌ Approval failed for ${quoteName}${revokedMsg}: ${approvalResult.error || 'unknown error'}`);
                     if (qi + 1 < endIndex) log(`  Trying next quote...`);
                     lastQuoteError = `${quoteName} approval failed`;
                     continue;

--- a/src/trading.js
+++ b/src/trading.js
@@ -862,6 +862,9 @@ export function __setAllowanceTimingForTests({
   verifyDelayMs = DEFAULT_ALLOWANCE_VERIFY_DELAY_MS,
   propagationDelayMs = DEFAULT_POST_ALLOWANCE_TX_PROPAGATION_MS,
 } = {}) {
+  if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
+    throw new Error('__setAllowanceTimingForTests is for tests only');
+  }
   allowanceVerifyDelayMs = verifyDelayMs;
   postAllowanceTxPropagationMs = propagationDelayMs;
 }
@@ -2253,11 +2256,18 @@ EXAMPLES:
                     try {
                       const receipt = await waitForReceipt(chain, revokeResult.txHash);
                       log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeResult.txHash}`);
-                      await assertAllowanceRevoked(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress);
                     } catch (receiptErr) {
                       log(`  ❌ Allowance revoke may not have confirmed for ${quoteName}: ${receiptErr.message}.${allowanceRevokeRecoveryHint(revokeResult.txHash)}`);
                       if (qi + 1 < endIndex) log(`  Trying next quote...`);
                       lastQuoteError = `${quoteName} allowance revoke unconfirmed`;
+                      continue;
+                    }
+                    try {
+                      await assertAllowanceRevoked(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress);
+                    } catch (pollErr) {
+                      log(`  ❌ Revoke tx confirmed but allowance was not cleared for ${quoteName}: ${pollErr.message}.${allowanceRevokeRecoveryHint(revokeResult.txHash)}`);
+                      if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                      lastQuoteError = `${quoteName} allowance revoke verification failed`;
                       continue;
                     }
                     await waitForAllowanceTxPropagation();
@@ -2304,11 +2314,18 @@ EXAMPLES:
                   try {
                     const receipt = await waitForReceipt(chain, approvalResult.txHash);
                     log(`  ✓ Approval confirmed in block ${parseInt(receipt.blockNumber, 16)}: ${approvalResult.txHash}`);
-                    await assertAllowanceAtLeast(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress, approveAmt);
                   } catch (receiptErr) {
                     log(`  ❌ Approval may not have confirmed${shouldRevoke ? ' after revoking the prior allowance (now 0)' : ''}: ${receiptErr.message}`);
                     if (qi + 1 < endIndex) log(`  Trying next quote...`);
                     lastQuoteError = `${quoteName} approval unconfirmed`;
+                    continue;
+                  }
+                  try {
+                    await assertAllowanceAtLeast(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress, approveAmt);
+                  } catch (pollErr) {
+                    log(`  ❌ Approval tx confirmed but allowance did not reach the required amount for ${quoteName}${shouldRevoke ? ' after revoking the prior allowance (now 0)' : ''}: ${pollErr.message}`);
+                    if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                    lastQuoteError = `${quoteName} approval verification failed`;
                     continue;
                   }
                   await waitForAllowanceTxPropagation();
@@ -2555,20 +2572,35 @@ EXAMPLES:
                       if (!revokeTxHash) {
                         throw new Error('Allowance revoke returned no transaction hash and no signed transaction; cannot confirm allowance was cleared');
                       }
-                      log(`  Waiting for allowance revoke confirmation...`);
-                      const receipt = await waitForReceipt(chain, revokeTxHash);
-                      log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeTxHash}`);
-                      await assertAllowanceRevoked(chain, currentQuote.inputMint, wcAddress, currentQuote.approvalAddress);
                     } catch (revokeErr) {
                       log(`  ❌ Allowance revoke failed for ${quoteName}: ${revokeErr.message}.${allowanceRevokeRecoveryHint(revokeTxHash)}`);
                       if (qi + 1 < endIndex) log(`  Trying next quote...`);
                       lastQuoteError = `${quoteName} allowance revoke failed`;
                       continue;
                     }
+                    log(`  Waiting for allowance revoke confirmation...`);
+                    try {
+                      const receipt = await waitForReceipt(chain, revokeTxHash);
+                      log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeTxHash}`);
+                    } catch (receiptErr) {
+                      log(`  ❌ Allowance revoke may not have confirmed for ${quoteName}: ${receiptErr.message}.${allowanceRevokeRecoveryHint(revokeTxHash)}`);
+                      if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                      lastQuoteError = `${quoteName} allowance revoke unconfirmed`;
+                      continue;
+                    }
+                    try {
+                      await assertAllowanceRevoked(chain, currentQuote.inputMint, wcAddress, currentQuote.approvalAddress);
+                    } catch (pollErr) {
+                      log(`  ❌ Revoke tx confirmed but allowance was not cleared for ${quoteName}: ${pollErr.message}.${allowanceRevokeRecoveryHint(revokeTxHash)}`);
+                      if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                      lastQuoteError = `${quoteName} allowance revoke verification failed`;
+                      continue;
+                    }
                     await waitForAllowanceTxPropagation();
                   }
                   log(`  ⚠ Approval required → ${currentQuote.approvalAddress}`);
                   log(`  Sending approval via WalletConnect...`);
+                  let approvalTxHash;
                   try {
                     const approvalResult = await sendApprovalViaWalletConnect(
                       currentQuote.inputMint,
@@ -2577,7 +2609,7 @@ EXAMPLES:
                       approveAmt,
                       approvalCapForQuote(quoteData),
                     );
-                    let approvalTxHash = approvalResult.txHash;
+                    approvalTxHash = approvalResult.txHash;
                     if (!approvalTxHash && approvalResult.signedTransaction) {
                       // Wallet returned a signed tx instead of broadcasting — broadcast via Trading API
                       log(`  Broadcasting approval via Trading API...`);
@@ -2599,10 +2631,6 @@ EXAMPLES:
                       // "after revoking (now 0)" context.
                       throw new Error('returned no transaction hash and no signed transaction; cannot confirm approval landed');
                     }
-                    log(`  Waiting for approval confirmation...`);
-                    const receipt = await waitForReceipt(chain, approvalTxHash);
-                    log(`  ✓ Approval confirmed in block ${parseInt(receipt.blockNumber, 16)}: ${approvalTxHash}`);
-                    await assertAllowanceAtLeast(chain, currentQuote.inputMint, wcAddress, currentQuote.approvalAddress, approveAmt);
                   } catch (approvalErr) {
                     const revokedMsg = shouldRevoke
                       ? ' after revoking the prior allowance (now 0)'
@@ -2610,6 +2638,30 @@ EXAMPLES:
                     log(`  ❌ Approval failed for ${quoteName}${revokedMsg}: ${approvalErr.message}`);
                     if (qi + 1 < endIndex) log(`  Trying next quote...`);
                     lastQuoteError = `${quoteName} approval failed`;
+                    continue;
+                  }
+                  log(`  Waiting for approval confirmation...`);
+                  try {
+                    const receipt = await waitForReceipt(chain, approvalTxHash);
+                    log(`  ✓ Approval confirmed in block ${parseInt(receipt.blockNumber, 16)}: ${approvalTxHash}`);
+                  } catch (receiptErr) {
+                    const revokedMsg = shouldRevoke
+                      ? ' after revoking the prior allowance (now 0)'
+                      : '';
+                    log(`  ❌ Approval may not have confirmed${revokedMsg}: ${receiptErr.message}`);
+                    if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                    lastQuoteError = `${quoteName} approval unconfirmed`;
+                    continue;
+                  }
+                  try {
+                    await assertAllowanceAtLeast(chain, currentQuote.inputMint, wcAddress, currentQuote.approvalAddress, approveAmt);
+                  } catch (pollErr) {
+                    const revokedMsg = shouldRevoke
+                      ? ' after revoking the prior allowance (now 0)'
+                      : '';
+                    log(`  ❌ Approval tx confirmed but allowance did not reach the required amount for ${quoteName}${revokedMsg}: ${pollErr.message}`);
+                    if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                    lastQuoteError = `${quoteName} approval verification failed`;
                     continue;
                   }
                   await waitForAllowanceTxPropagation();
@@ -2842,11 +2894,18 @@ EXAMPLES:
                     try {
                       const receipt = await waitForReceipt(chain, revokeResult.txHash);
                       log(`  ✓ Allowance revoked in block ${parseInt(receipt.blockNumber, 16)}: ${revokeResult.txHash}`);
-                      await assertAllowanceRevoked(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress);
                     } catch (receiptErr) {
                       log(`  ❌ Allowance revoke may not have confirmed for ${quoteName}: ${receiptErr.message}.${allowanceRevokeRecoveryHint(revokeResult.txHash)}`);
                       if (qi + 1 < endIndex) log(`  Trying next quote...`);
                       lastQuoteError = `${quoteName} allowance revoke unconfirmed`;
+                      continue;
+                    }
+                    try {
+                      await assertAllowanceRevoked(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress);
+                    } catch (pollErr) {
+                      log(`  ❌ Revoke tx confirmed but allowance was not cleared for ${quoteName}: ${pollErr.message}.${allowanceRevokeRecoveryHint(revokeResult.txHash)}`);
+                      if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                      lastQuoteError = `${quoteName} allowance revoke verification failed`;
                       continue;
                     }
                     await waitForAllowanceTxPropagation();
@@ -2886,11 +2945,18 @@ EXAMPLES:
                   try {
                     const receipt = await waitForReceipt(chain, approvalResult.txHash);
                     log(`  ✓ Approval confirmed in block ${parseInt(receipt.blockNumber, 16)}: ${approvalResult.txHash}`);
-                    await assertAllowanceAtLeast(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress, approveAmt);
                   } catch (receiptErr) {
                     log(`  ❌ Approval may not have confirmed${shouldRevoke ? ' after revoking the prior allowance (now 0)' : ''}: ${receiptErr.message}`);
                     if (qi + 1 < endIndex) log(`  Trying next quote...`);
                     lastQuoteError = `${quoteName} approval unconfirmed`;
+                    continue;
+                  }
+                  try {
+                    await assertAllowanceAtLeast(chain, currentQuote.inputMint, walletAddress, currentQuote.approvalAddress, approveAmt);
+                  } catch (pollErr) {
+                    log(`  ❌ Approval tx confirmed but allowance did not reach the required amount for ${quoteName}${shouldRevoke ? ' after revoking the prior allowance (now 0)' : ''}: ${pollErr.message}`);
+                    if (qi + 1 < endIndex) log(`  Trying next quote...`);
+                    lastQuoteError = `${quoteName} approval verification failed`;
                     continue;
                   }
                   await waitForAllowanceTxPropagation();

--- a/src/walletconnect-trading.js
+++ b/src/walletconnect-trading.js
@@ -114,13 +114,15 @@ export async function sendTransactionViaWalletConnect(txData, timeoutMs = 120000
  * @param {number} chainId - EIP-155 chain ID
  * @param {bigint|string|number} amount - Allowance to grant, in base units
  * @param {bigint|string|number} [maxAllowance] - Hard cap from persisted request intent
+ * @param {object} [opts]
+ * @param {boolean} [opts.allowZero=false] - Allow a zero-amount revoke approval
  * @returns {{ txHash?: string, signedTransaction?: string }}
  */
-export async function sendApprovalViaWalletConnect(tokenAddress, spenderAddress, chainId, amount, maxAllowance) {
+export async function sendApprovalViaWalletConnect(tokenAddress, spenderAddress, chainId, amount, maxAllowance, { allowZero = false } = {}) {
   // encodeApproveCalldata enforces a valid 20-byte spender, a bounded (< MAX)
   // amount within the request cap, and exactly-68-byte calldata — so a
   // malformed or tampered spender/amount can't reshape the ABI word layout.
-  const data = encodeApproveCalldata(spenderAddress, amount, { maxAllowance });
+  const data = encodeApproveCalldata(spenderAddress, amount, { maxAllowance, allowZero });
 
   return sendTransactionViaWalletConnect({
     to: tokenAddress,


### PR DESCRIPTION
## Summary
- Revoke oversized existing ERC-20 allowances before granting a fresh trade-scoped approval
- Add an opt-out flag that preserves existing sufficient allowances without sending approval transactions
- Add execute-path coverage for revoke/reapprove ordering, fail-closed behavior, and allowance reuse cases

## Validation
- npm run lint
- npx vitest run src/__tests__/trading.test.js
- npm test
- Live Base smoke test with a small trade confirmed revoke, scoped reapproval, swap success, and no oversized final allowance