### PR TITLE
Add nansen mcp install/verify for local MCP clients (Cursor first)

### DIFF
--- a/.changeset/mcp-install-command.md
+++ b/.changeset/mcp-install-command.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add `nansen mcp install <client>` and `nansen mcp verify <client>` (Cursor first). `install` merges a native url+headers Nansen entry into the client's `mcp.json` using the saved login key (or `--api-key`), preserves other configured servers, refuses to clobber invalid JSON, and restricts the file to owner-only permissions. `verify` proves the endpoint with a streamable-HTTP initialize handshake and — because the handshake succeeds even unauthenticated — validates the configured key with a credit-free account check.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,14 @@ Connect any MCP client to Nansen's streamable HTTP server:
 - **Authentication:** `NANSEN-API-KEY` header
 - **API key:** [app.nansen.ai/auth/agent-setup](https://app.nansen.ai/auth/agent-setup)
 
-**Claude Desktop and Cursor:** setup instructions for both — the Claude Desktop `.dxt` bundle and the Cursor install deep link — are in the connection docs: [docs.nansen.ai/mcp/connecting](https://docs.nansen.ai/mcp/connecting).
+**Claude Desktop and Cursor:** setup instructions for both — the Claude Desktop `.dxt` bundle and the Cursor configuration — are in the connection docs: [docs.nansen.ai/mcp/connecting](https://docs.nansen.ai/mcp/connecting).
+
+**One-command (Cursor):** after `nansen login`, install and check the config with:
+
+```bash
+nansen mcp install cursor
+nansen mcp verify cursor
+```
 
 **One-command (Claude Code):**
 

--- a/src/__tests__/mcp.test.js
+++ b/src/__tests__/mcp.test.js
@@ -1,0 +1,262 @@
+/**
+ * MCP install/verify command tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { buildMcpCommands, parseMcpResponseBody, MCP_URL, MCP_SERVER_NAME, MCP_HEADER } from '../commands/mcp.js';
+import { ErrorCode, NansenError } from '../api.js';
+
+// ── Helpers ──
+
+/** Build a mock apiInstance. */
+function mockApi(overrides = {}) {
+  return {
+    apiKey: 'test-key',
+    baseUrl: 'https://api.nansen.ai',
+    defaultHeaders: {},
+    ...overrides,
+  };
+}
+
+/** A fetch mock returning a successful SSE initialize response. */
+function okHandshakeFetch() {
+  const sse = 'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"nansen-mcp","version":"3.2.4"}}}\n\n';
+  return async () => ({
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': 'text/event-stream' }),
+    text: async () => sse,
+  });
+}
+
+/** A NansenAPI stand-in whose getAccount resolves (valid key). */
+class OkAccountAPI {
+  constructor(apiKey) { this.apiKey = apiKey; }
+  async getAccount() { return { plan: 'professional' }; }
+}
+
+/** A NansenAPI stand-in whose getAccount rejects as unauthorized (bad key). */
+class UnauthorizedAPI {
+  async getAccount() { throw new NansenError('Not logged in', ErrorCode.UNAUTHORIZED, 401); }
+}
+
+describe('mcp command', () => {
+  let tmpDir, configPath, cmd;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nansen-mcp-test-'));
+    configPath = path.join(tmpDir, 'sub', 'mcp.json');
+    cmd = buildMcpCommands({}).mcp;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const installArgs = ['install', 'cursor'];
+  const verifyArgs = ['verify', 'cursor'];
+
+  describe('install', () => {
+    it('creates a fresh config with the nansen entry and restricted permissions', async () => {
+      const result = await cmd(installArgs, mockApi(), {}, { 'config-path': configPath });
+
+      expect(result.action).toBe('created');
+      expect(result.config_path).toBe(configPath);
+      const written = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      expect(written.mcpServers[MCP_SERVER_NAME]).toEqual({
+        url: MCP_URL,
+        headers: { [MCP_HEADER]: 'test-key' },
+      });
+      if (process.platform !== 'win32') {
+        expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+      }
+    });
+
+    it('merges into an existing config without touching other servers', async () => {
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, JSON.stringify({
+        mcpServers: { other: { command: 'npx', args: ['-y', 'other-mcp'] } },
+        theme: 'dark',
+      }));
+
+      const result = await cmd(installArgs, mockApi(), {}, { 'config-path': configPath });
+
+      expect(result.action).toBe('created');
+      const written = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      expect(written.mcpServers.other).toEqual({ command: 'npx', args: ['-y', 'other-mcp'] });
+      expect(written.theme).toBe('dark');
+      expect(written.mcpServers[MCP_SERVER_NAME].url).toBe(MCP_URL);
+    });
+
+    it('reports "updated" when a nansen entry already exists and overwrites it', async () => {
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, JSON.stringify({
+        mcpServers: { [MCP_SERVER_NAME]: { url: 'https://old.example', headers: { [MCP_HEADER]: 'stale' } } },
+      }));
+
+      const result = await cmd(installArgs, mockApi(), {}, { 'config-path': configPath });
+
+      expect(result.action).toBe('updated');
+      const written = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      expect(written.mcpServers[MCP_SERVER_NAME]).toEqual({
+        url: MCP_URL,
+        headers: { [MCP_HEADER]: 'test-key' },
+      });
+    });
+
+    it('prefers --api-key over the resolved login key', async () => {
+      await cmd(installArgs, mockApi(), {}, { 'config-path': configPath, 'api-key': 'flag-key' });
+      const written = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      expect(written.mcpServers[MCP_SERVER_NAME].headers[MCP_HEADER]).toBe('flag-key');
+    });
+
+    it('refuses to clobber an existing file that is not valid JSON', async () => {
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, '{not json');
+
+      await expect(cmd(installArgs, mockApi(), {}, { 'config-path': configPath }))
+        .rejects.toThrow(/not valid JSON/);
+      expect(fs.readFileSync(configPath, 'utf8')).toBe('{not json');
+    });
+
+    it('rejects a config whose mcpServers is not an object', async () => {
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, JSON.stringify({ mcpServers: ['nope'] }));
+
+      await expect(cmd(installArgs, mockApi(), {}, { 'config-path': configPath }))
+        .rejects.toThrow(/non-object "mcpServers"/);
+    });
+
+    it('errors with API_KEY_REQUIRED when no key is available', async () => {
+      await expect(cmd(installArgs, mockApi({ apiKey: null }), {}, { 'config-path': configPath }))
+        .rejects.toMatchObject({ code: 'API_KEY_REQUIRED' });
+      expect(fs.existsSync(configPath)).toBe(false);
+    });
+
+    it('rejects an unknown client', async () => {
+      await expect(cmd(['install', 'emacs'], mockApi(), {}, {}))
+        .rejects.toThrow(/Unknown MCP client: emacs/);
+    });
+
+    it('requires a client argument', async () => {
+      await expect(cmd(['install'], mockApi(), {}, {}))
+        .rejects.toThrow(/Client is required/);
+    });
+  });
+
+  describe('verify', () => {
+    async function install() {
+      await cmd(installArgs, mockApi(), {}, { 'config-path': configPath });
+    }
+
+    it('passes when the handshake succeeds and the key is valid', async () => {
+      await install();
+      const verify = buildMcpCommands({ fetchFn: okHandshakeFetch(), NansenAPIClass: OkAccountAPI }).mcp;
+
+      const result = await verify(verifyArgs, mockApi(), {}, { 'config-path': configPath });
+
+      expect(result).toMatchObject({
+        client: 'cursor',
+        transport: 'ok',
+        server: 'nansen-mcp',
+        server_version: '3.2.4',
+        auth: 'ok',
+        plan: 'professional',
+      });
+    });
+
+    it('errors with MCP_NOT_INSTALLED when no nansen entry exists', async () => {
+      const verify = buildMcpCommands({ fetchFn: okHandshakeFetch(), NansenAPIClass: OkAccountAPI }).mcp;
+      await expect(verify(verifyArgs, mockApi(), {}, { 'config-path': configPath }))
+        .rejects.toMatchObject({ code: 'MCP_NOT_INSTALLED' });
+    });
+
+    it('errors with MCP_CONFIG_INVALID when the entry lacks the auth header', async () => {
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, JSON.stringify({ mcpServers: { [MCP_SERVER_NAME]: { url: MCP_URL } } }));
+      const verify = buildMcpCommands({ fetchFn: okHandshakeFetch(), NansenAPIClass: OkAccountAPI }).mcp;
+
+      await expect(verify(verifyArgs, mockApi(), {}, { 'config-path': configPath }))
+        .rejects.toMatchObject({ code: 'MCP_CONFIG_INVALID' });
+    });
+
+    it('fails on a non-2xx handshake without reaching the auth check', async () => {
+      await install();
+      let authChecked = false;
+      class TrackingAPI { async getAccount() { authChecked = true; return {}; } }
+      const verify = buildMcpCommands({
+        fetchFn: async () => ({ ok: false, status: 404, headers: new Headers(), text: async () => '' }),
+        NansenAPIClass: TrackingAPI,
+      }).mcp;
+
+      await expect(verify(verifyArgs, mockApi(), {}, { 'config-path': configPath }))
+        .rejects.toThrow(/HTTP 404/);
+      expect(authChecked).toBe(false);
+    });
+
+    it('surfaces network failures as MCP endpoint unreachable', async () => {
+      await install();
+      const verify = buildMcpCommands({
+        fetchFn: async () => { throw new TypeError('fetch failed', { cause: { code: 'ENOTFOUND' } }); },
+        NansenAPIClass: OkAccountAPI,
+      }).mcp;
+
+      await expect(verify(verifyArgs, mockApi(), {}, { 'config-path': configPath }))
+        .rejects.toThrow(/MCP endpoint unreachable/);
+    });
+
+    it('reports INVALID_API_KEY when the configured key fails the auth check', async () => {
+      await install();
+      const verify = buildMcpCommands({ fetchFn: okHandshakeFetch(), NansenAPIClass: UnauthorizedAPI }).mcp;
+
+      await expect(verify(verifyArgs, mockApi(), {}, { 'config-path': configPath }))
+        .rejects.toMatchObject({ code: 'INVALID_API_KEY' });
+    });
+
+    it('sends the configured key on the handshake request', async () => {
+      await install();
+      let sentHeaders = null;
+      const verify = buildMcpCommands({
+        fetchFn: async (_url, init) => {
+          sentHeaders = init.headers;
+          return okHandshakeFetch()();
+        },
+        NansenAPIClass: OkAccountAPI,
+      }).mcp;
+
+      await verify(verifyArgs, mockApi(), {}, { 'config-path': configPath });
+      expect(sentHeaders[MCP_HEADER]).toBe('test-key');
+    });
+  });
+
+  describe('help and dispatch', () => {
+    it('defaults to help with subcommand list', async () => {
+      const result = await cmd([], mockApi(), {}, {});
+      expect(result.subcommands).toEqual(['install', 'verify']);
+    });
+
+    it('rejects unknown subcommands', async () => {
+      await expect(cmd(['upgrade'], mockApi(), {}, {}))
+        .rejects.toThrow(/Unknown mcp subcommand: upgrade/);
+    });
+  });
+
+  describe('parseMcpResponseBody', () => {
+    it('parses the first data line of an SSE body', () => {
+      const message = parseMcpResponseBody('event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n', 'text/event-stream');
+      expect(message.jsonrpc).toBe('2.0');
+    });
+
+    it('parses a plain JSON body', () => {
+      const message = parseMcpResponseBody('{"jsonrpc":"2.0"}', 'application/json');
+      expect(message.jsonrpc).toBe('2.0');
+    });
+
+    it('throws when an event stream has no data line', () => {
+      expect(() => parseMcpResponseBody('event: ping\n\n', 'text/event-stream')).toThrow(/no data/);
+    });
+  });
+});

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,6 +11,7 @@ import { buildTradingCommands } from './trading.js';
 import { buildLimitOrderCommands } from './limit-order.js';
 import { formatAlertsTable, buildAlertsCommands } from './commands/alerts.js';
 import { buildAgentCommands } from './commands/agent.js';
+import { buildMcpCommands } from './commands/mcp.js';
 import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from './commands/research.js';
 import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
@@ -734,6 +735,7 @@ COMMANDS:
   agent       Ask the Nansen AI research agent (fast/expert modes)
   alerts      list, create, update, toggle, delete
   web         search, fetch
+  mcp         install/verify the Nansen MCP server in local clients (cursor)
   account     Show API key status, plan, and remaining credits
   auth        status — offline auth status: key source, wallets (no network)
   login       Save API key (--api-key <key>, --human, or NANSEN_API_KEY env var)
@@ -1871,7 +1873,7 @@ export async function runCLI(rawArgs, deps = {}) {
     return '';
   };
 
-  const commands = { ...buildCommands(deps), ...buildWalletCommands(deps), ...buildTradingCommands(deps), ...buildAlertsCommands(deps), ...buildAgentCommands(deps), ...commandOverrides };
+  const commands = { ...buildCommands(deps), ...buildWalletCommands(deps), ...buildTradingCommands(deps), ...buildAlertsCommands(deps), ...buildAgentCommands(deps), ...buildMcpCommands(deps), ...commandOverrides };
 
   if (flags.version || flags.v) {
     output(VERSION);

--- a/src/commands/mcp.js
+++ b/src/commands/mcp.js
@@ -1,0 +1,242 @@
+/**
+ * Nansen CLI - MCP client configuration
+ * Installs and verifies the Nansen MCP server entry in local MCP clients (Cursor first).
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { NansenAPI, NansenError, CommandError, ErrorCode } from '../api.js';
+
+export const MCP_URL = 'https://mcp.nansen.ai/ra/mcp';
+export const MCP_SERVER_NAME = 'nansen';
+export const MCP_HEADER = 'NANSEN-API-KEY';
+
+// Per-client config locations. Every supported client reads the standard
+// `mcpServers` map and supports native url+headers entries (no stdio bridge).
+export const MCP_CLIENTS = {
+  cursor: {
+    configPath: () => path.join(os.homedir(), '.cursor', 'mcp.json'),
+    restartHint: 'Restart Cursor (or toggle the server in Cursor Settings > MCP) to pick up the change.',
+  },
+};
+
+/**
+ * Parse a streamable-HTTP MCP response body: either plain JSON or an SSE
+ * stream whose first `data:` line carries the JSON-RPC message.
+ */
+export function parseMcpResponseBody(text, contentType = '') {
+  if (contentType.includes('text/event-stream')) {
+    for (const line of text.split('\n')) {
+      if (line.startsWith('data:')) {
+        return JSON.parse(line.slice(5).trim());
+      }
+    }
+    throw new NansenError('MCP server returned an event stream with no data', ErrorCode.UNKNOWN);
+  }
+  return JSON.parse(text);
+}
+
+function resolveClient(subArgs, action) {
+  const client = subArgs[0];
+  const supported = Object.keys(MCP_CLIENTS).join(', ');
+  if (!client) {
+    throw new NansenError(`Client is required. Usage: nansen mcp ${action} cursor. Supported: ${supported}`, ErrorCode.MISSING_PARAM);
+  }
+  if (!MCP_CLIENTS[client]) {
+    throw new NansenError(`Unknown MCP client: ${client}. Supported: ${supported}`, ErrorCode.INVALID_PARAMS);
+  }
+  return client;
+}
+
+function resolveConfigPath(client, options) {
+  return options['config-path'] || MCP_CLIENTS[client].configPath();
+}
+
+/**
+ * Read and parse the client's mcp.json. Returns null when the file does not
+ * exist; throws (rather than clobbering) when it exists but is invalid JSON.
+ */
+function readClientConfig(configPath) {
+  if (!fs.existsSync(configPath)) return null;
+  const raw = fs.readFileSync(configPath, 'utf8');
+  try {
+    return JSON.parse(raw);
+  } catch (_e) {
+    throw new NansenError(`Existing ${configPath} is not valid JSON. Fix or remove it, then re-run.`, ErrorCode.INVALID_PARAMS);
+  }
+}
+
+export function buildMcpCommands(deps = {}) {
+  const {
+    NansenAPIClass = NansenAPI,
+    fetchFn = fetch,
+    timeoutMs = 10000,
+  } = deps;
+
+  return {
+    'mcp': async (args, apiInstance, _flags, options) => {
+      const subcommand = args[0] || 'help';
+      const subArgs = args.slice(1);
+
+      const handlers = {
+        'install': async () => {
+          const client = resolveClient(subArgs, 'install');
+          const apiKey = (options['api-key'] || apiInstance.apiKey || '').trim();
+          if (!apiKey) {
+            throw new CommandError('No API key found.', 'API_KEY_REQUIRED', {
+              error: 'API_KEY_REQUIRED',
+              message: 'No API key found.',
+              resolution: [
+                'Run: nansen login --api-key <key>',
+                'Or pass --api-key <key>',
+                'Get your API key at: https://app.nansen.ai/auth/agent-setup',
+              ],
+            });
+          }
+
+          const configPath = resolveConfigPath(client, options);
+          const config = readClientConfig(configPath) || {};
+          if (config.mcpServers !== undefined && (typeof config.mcpServers !== 'object' || Array.isArray(config.mcpServers))) {
+            throw new NansenError(`Existing ${configPath} has a non-object "mcpServers" field. Fix or remove it, then re-run.`, ErrorCode.INVALID_PARAMS);
+          }
+          config.mcpServers = config.mcpServers || {};
+          const existed = Boolean(config.mcpServers[MCP_SERVER_NAME]);
+          config.mcpServers[MCP_SERVER_NAME] = {
+            url: MCP_URL,
+            headers: { [MCP_HEADER]: apiKey },
+          };
+
+          fs.mkdirSync(path.dirname(configPath), { recursive: true });
+          fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+          // The file now contains a credential; owner-only on POSIX, no-op on Windows.
+          try { fs.chmodSync(configPath, 0o600); } catch (_e) { /* ignore */ }
+
+          return {
+            client,
+            config_path: configPath,
+            server: MCP_SERVER_NAME,
+            url: MCP_URL,
+            action: existed ? 'updated' : 'created',
+            next_steps: [
+              MCP_CLIENTS[client].restartHint,
+              `Run: nansen mcp verify ${client}`,
+            ],
+          };
+        },
+
+        'verify': async () => {
+          const client = resolveClient(subArgs, 'verify');
+          const configPath = resolveConfigPath(client, options);
+          const config = readClientConfig(configPath);
+          const entry = config?.mcpServers?.[MCP_SERVER_NAME];
+          if (!entry) {
+            throw new CommandError(`No "${MCP_SERVER_NAME}" MCP server configured in ${configPath}.`, 'MCP_NOT_INSTALLED', {
+              error: 'MCP_NOT_INSTALLED',
+              message: `No "${MCP_SERVER_NAME}" MCP server configured in ${configPath}.`,
+              resolution: [`Run: nansen mcp install ${client}`],
+            });
+          }
+          const url = entry.url;
+          const apiKey = entry.headers?.[MCP_HEADER];
+          if (!url || !apiKey) {
+            throw new CommandError(`The "${MCP_SERVER_NAME}" entry in ${configPath} is missing its url or ${MCP_HEADER} header.`, 'MCP_CONFIG_INVALID', {
+              error: 'MCP_CONFIG_INVALID',
+              message: `The "${MCP_SERVER_NAME}" entry in ${configPath} is missing its url or ${MCP_HEADER} header.`,
+              resolution: [`Run: nansen mcp install ${client}`],
+            });
+          }
+
+          // Step 1 - transport: a streamable-HTTP initialize handshake proves the
+          // endpoint is reachable and speaks MCP. It does NOT prove the key works:
+          // the server accepts initialize and tools/list unauthenticated.
+          let serverInfo;
+          const controller = new AbortController();
+          const timer = setTimeout(() => controller.abort(), timeoutMs);
+          try {
+            const response = await fetchFn(url, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json, text/event-stream',
+                [MCP_HEADER]: apiKey,
+              },
+              body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'initialize',
+                params: {
+                  protocolVersion: '2025-03-26',
+                  capabilities: {},
+                  clientInfo: { name: 'nansen-cli', version: 'verify' },
+                },
+              }),
+              signal: controller.signal,
+            });
+            if (!response.ok) {
+              throw new NansenError(`MCP handshake failed: ${url} returned HTTP ${response.status}`, ErrorCode.UNKNOWN, response.status);
+            }
+            const message = parseMcpResponseBody(await response.text(), response.headers.get('content-type') || '');
+            serverInfo = message?.result?.serverInfo || null;
+            if (!serverInfo) {
+              throw new NansenError(`MCP handshake failed: ${url} did not return a server identity`, ErrorCode.UNKNOWN);
+            }
+          } catch (error) {
+            if (error instanceof NansenError) throw error;
+            const reason = error.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : (error.cause?.code || error.message);
+            throw new NansenError(`MCP endpoint unreachable: ${url} (${reason})`, ErrorCode.NETWORK_ERROR);
+          } finally {
+            clearTimeout(timer);
+          }
+
+          // Step 2 - auth: validate the configured key with a credit-free account
+          // check against the API the MCP server fronts.
+          let account;
+          try {
+            const api = new NansenAPIClass(apiKey, undefined, { retry: { maxRetries: 1 }, cache: { enabled: false } });
+            account = await api.getAccount();
+          } catch (error) {
+            if (error.code === ErrorCode.UNAUTHORIZED) {
+              throw new CommandError(`The API key configured in ${configPath} is not valid.`, 'INVALID_API_KEY', {
+                error: 'INVALID_API_KEY',
+                message: `The API key configured in ${configPath} is not valid.`,
+                resolution: [
+                  'Get your API key at: https://app.nansen.ai/auth/agent-setup',
+                  `Then run: nansen mcp install ${client} --api-key <key>`,
+                ],
+              });
+            }
+            throw error;
+          }
+
+          return {
+            client,
+            config_path: configPath,
+            url,
+            transport: 'ok',
+            server: serverInfo.name,
+            server_version: serverInfo.version,
+            auth: 'ok',
+            ...(account?.plan ? { plan: account.plan } : {}),
+          };
+        },
+
+        'help': async () => ({
+          subcommands: ['install', 'verify'],
+          description: 'Install and verify the Nansen MCP server in local MCP clients',
+          examples: [
+            'nansen mcp install cursor',
+            'nansen mcp install cursor --api-key <key>',
+            'nansen mcp verify cursor',
+          ],
+        }),
+      };
+
+      if (!handlers[subcommand]) {
+        throw new NansenError(`Unknown mcp subcommand: ${subcommand}. Available: install, verify`, ErrorCode.UNKNOWN);
+      }
+
+      return handlers[subcommand]();
+    },
+  };
+}

--- a/src/schema.json
+++ b/src/schema.json
@@ -1889,6 +1889,37 @@
         "nansen doctor --json --pretty"
       ]
     },
+    "mcp": {
+      "description": "Install and verify the Nansen MCP server in local MCP clients",
+      "subcommands": {
+        "install": {
+          "description": "Write the Nansen MCP server entry (native url + headers) into the client's mcp.json, merging with existing servers and restricting file permissions",
+          "options": {
+            "api-key": {
+              "description": "API key to embed (defaults to saved login or NANSEN_API_KEY)"
+            },
+            "config-path": {
+              "description": "Override the client's default config file path"
+            }
+          },
+          "examples": [
+            "nansen mcp install cursor",
+            "nansen mcp install cursor --api-key <key>"
+          ]
+        },
+        "verify": {
+          "description": "Check the installed entry: MCP endpoint handshake plus a credit-free auth check of the configured key (the handshake alone succeeds unauthenticated)",
+          "options": {
+            "config-path": {
+              "description": "Override the client's default config file path"
+            }
+          },
+          "examples": [
+            "nansen mcp verify cursor"
+          ]
+        }
+      }
+    },
     "web": {
       "description": "Web search and fetch commands",
       "subcommands": {


### PR DESCRIPTION
## What

Adds a real one-command MCP setup to the CLI — the command the docs always wanted to exist (see nansen-api#1803, API-317):

```bash
nansen login --api-key <key>
nansen mcp install cursor
nansen mcp verify cursor
```

- **`nansen mcp install cursor`** merges a native `url` + `headers` Nansen entry into `~/.cursor/mcp.json` (or `--config-path`), using the saved login key, `NANSEN_API_KEY`, or `--api-key`. It preserves other configured servers, refuses to clobber a file that isn't valid JSON, and chmods the file to `0600` since it embeds a credential.
- **`nansen mcp verify cursor`** proves the setup in two steps: a streamable-HTTP `initialize` handshake against the configured URL (transport), then a credit-free account check with the configured key (auth). The second step exists because the MCP server accepts `initialize` and `tools/list` unauthenticated — a handshake alone never proves the key works.

The client registry is a map, so adding e.g. `claude-desktop` later is one entry.

## Why

API-317 flagged that the documented Cursor "one-click" deep link shipped a placeholder key inside an opaque base64 payload. nansen-api#1803 replaces it with copy-paste JSON; this PR gives users the actual one-command path and a machine-checkable verify step.

## Testing

- 21 new unit tests (`src/__tests__/mcp.test.js`); full suite passes (2115 passed, 2 skipped), eslint clean.
- Verified live against `mcp.nansen.ai`:
  - happy path with a valid key → `transport: ok`, `auth: ok`, server `nansen-mcp 3.2.4`, exit 0
  - invalid key → handshake passes, auth step fails with structured `INVALID_API_KEY` + resolution steps, exit 1
  - merge behavior, invalid-JSON refusal, and `0600` permissions confirmed on disk

## Follow-up

Once released, nansen-api's `gitbook/mcp/connecting.md` Cursor section can add these commands back (they were removed from #1803 because they didn't exist yet). README here already documents them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)