### PR TITLE
Reject unsafe Solana instructions before signing

### DIFF
--- a/.changeset/solana-static-instruction-safety.md
+++ b/.changeset/solana-static-instruction-safety.md
@@ -1,5 +1,5 @@
 ---
-"nansen-cli": patch
+"nansen-cli": minor
 ---
 
-`trade execute` on Solana now statically checks the aggregator's compiled instructions before signing, and rejects a transaction that grants a token delegate, changes a token account's authority, closes an account with its rent redirected to a stranger, or sets an excessive compute-budget priority fee — closing a class of drain vector a balance-delta simulation alone can't see.
+`trade execute` and `trade limit-order` on Solana now statically check the aggregator's compiled instructions before signing, and reject a transaction that grants a token delegate, changes a token account's authority, closes an account with its rent redirected to a stranger, or sets an excessive compute-budget priority fee — closing a class of drain vector a balance-delta simulation alone can't see.

--- a/.changeset/solana-static-instruction-safety.md
+++ b/.changeset/solana-static-instruction-safety.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+`trade execute` on Solana now statically checks the aggregator's compiled instructions before signing, and rejects a transaction that grants a token delegate, changes a token account's authority, closes an account with its rent redirected to a stranger, or sets an excessive compute-budget priority fee — closing a class of drain vector a balance-delta simulation alone can't see.

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -1047,10 +1047,21 @@ describe('buildLimitOrderCommands', () => {
  * by signSolanaTransaction (compact-u16 sig count + 64-byte sig slot + message).
  */
 function buildFakeBase64Tx() {
-  // 1 signature slot (compact-u16 = 0x01), 64 zero bytes for sig, then some message bytes
+  // A valid, parseable legacy transaction with a single benign instruction:
+  // 1 signature slot, then a legacy message [header][2 account keys][blockhash]
+  // [1 instruction referencing a non-SPL program]. It must actually parse —
+  // assertSolanaInstructionsSafe (run before signing on this path) now rejects
+  // unparseable transactions rather than silently ignoring them.
   const sigCount = Buffer.from([0x01]);
   const emptySig = Buffer.alloc(64, 0);
-  const fakeMessage = Buffer.alloc(32, 0xAB); // Minimal "message"
-  const tx = Buffer.concat([sigCount, emptySig, fakeMessage]);
-  return tx.toString('base64');
+  const header = Buffer.from([1, 0, 1]); // 1 signer (writable), 1 readonly unsigned (the program)
+  const numKeys = Buffer.from([0x02]);
+  const signerKey = Buffer.alloc(32, 0x01); // account index 0 = signer / fee payer
+  const programKey = Buffer.alloc(32, 0x02); // account index 1 = an arbitrary (non-SPL) program
+  const blockhash = Buffer.alloc(32, 0x03);
+  const numInstructions = Buffer.from([0x01]);
+  // instruction: programIdIndex=1, 1 account (index 0), 1 data byte
+  const instruction = Buffer.from([0x01, 0x01, 0x00, 0x01, 0x00]);
+  const message = Buffer.concat([header, numKeys, signerKey, programKey, blockhash, numInstructions, instruction]);
+  return Buffer.concat([sigCount, emptySig, message]).toString('base64');
 }

--- a/src/__tests__/solana-tx.test.js
+++ b/src/__tests__/solana-tx.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { parseTransactionMessage, resolveStaticAccount, isSignerIndex } from '../solana-tx.js';
+import { base58Decode, base58Encode, generateSolanaWallet } from '../wallet.js';
+
+function encodeCompactU16(value) {
+  if (value < 0x80) return Buffer.from([value]);
+  if (value < 0x4000) return Buffer.from([(value & 0x7f) | 0x80, (value >> 7) & 0x7f]);
+  return Buffer.from([(value & 0x7f) | 0x80, ((value >> 7) & 0x7f) | 0x80, (value >> 14) & 0x03]);
+}
+
+// Minimal, hand-rolled builder for test fixtures — deliberately independent
+// of solana-tx.js so the parser is verified against an independent encoding,
+// not against itself.
+function buildMessageBytes({ versioned, accountKeys, header, recentBlockhash, instructions, addressTableLookups = [] }) {
+  const parts = [];
+  if (versioned) parts.push(Buffer.from([0x80]));
+  parts.push(Buffer.from([header.numRequiredSignatures, header.numReadonlySignedAccounts, header.numReadonlyUnsignedAccounts]));
+  parts.push(encodeCompactU16(accountKeys.length));
+  for (const k of accountKeys) parts.push(base58Decode(k));
+  parts.push(base58Decode(recentBlockhash));
+  parts.push(encodeCompactU16(instructions.length));
+  for (const ix of instructions) {
+    parts.push(Buffer.from([ix.programIdIndex]));
+    parts.push(encodeCompactU16(ix.accountIndexes.length));
+    for (const idx of ix.accountIndexes) parts.push(Buffer.from([idx]));
+    parts.push(encodeCompactU16(ix.data.length));
+    parts.push(ix.data);
+  }
+  if (versioned) {
+    parts.push(encodeCompactU16(addressTableLookups.length));
+    for (const alt of addressTableLookups) {
+      parts.push(base58Decode(alt.lookupTableAddress));
+      parts.push(encodeCompactU16(alt.writableIndexes.length));
+      for (const idx of alt.writableIndexes) parts.push(Buffer.from([idx]));
+      parts.push(encodeCompactU16(alt.readonlyIndexes.length));
+      for (const idx of alt.readonlyIndexes) parts.push(Buffer.from([idx]));
+    }
+  }
+  return Buffer.concat(parts);
+}
+
+function wrapTransaction(messageBytes, numSignatures = 1) {
+  return Buffer.concat([encodeCompactU16(numSignatures), Buffer.alloc(numSignatures * 64), messageBytes]).toString('base64');
+}
+
+describe('parseTransactionMessage', () => {
+  it('round-trips a legacy (non-versioned) message', () => {
+    const signer = generateSolanaWallet().address;
+    const programId = generateSolanaWallet().address;
+    const recentBlockhash = generateSolanaWallet().address;
+    const messageBytes = buildMessageBytes({
+      versioned: false,
+      accountKeys: [signer, programId],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 1 },
+      recentBlockhash,
+      instructions: [{ programIdIndex: 1, accountIndexes: [0], data: Buffer.from([0xde, 0xad]) }],
+    });
+    const parsed = parseTransactionMessage(wrapTransaction(messageBytes));
+
+    expect(parsed.isVersioned).toBe(false);
+    expect(parsed.header).toEqual({ numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 1 });
+    expect(parsed.staticAccountKeys).toEqual([signer, programId]);
+    expect(parsed.recentBlockhash).toBe(recentBlockhash);
+    expect(parsed.instructions).toHaveLength(1);
+    expect(parsed.instructions[0].programIdIndex).toBe(1);
+    expect(parsed.instructions[0].accountIndexes).toEqual([0]);
+    expect(Buffer.from(parsed.instructions[0].data)).toEqual(Buffer.from([0xde, 0xad]));
+    expect(parsed.addressTableLookups).toEqual([]);
+  });
+
+  it('round-trips a v0 message with address-table lookups', () => {
+    const signer = generateSolanaWallet().address;
+    const programId = generateSolanaWallet().address;
+    const recentBlockhash = generateSolanaWallet().address;
+    const altAddress = generateSolanaWallet().address;
+    const messageBytes = buildMessageBytes({
+      versioned: true,
+      accountKeys: [signer, programId],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 1 },
+      recentBlockhash,
+      instructions: [{ programIdIndex: 1, accountIndexes: [0, 2], data: Buffer.from([0x01]) }],
+      addressTableLookups: [{ lookupTableAddress: altAddress, writableIndexes: [5], readonlyIndexes: [] }],
+    });
+    const parsed = parseTransactionMessage(wrapTransaction(messageBytes));
+
+    expect(parsed.isVersioned).toBe(true);
+    expect(parsed.addressTableLookups).toEqual([{ lookupTableAddress: altAddress, writableIndexes: [5], readonlyIndexes: [] }]);
+    // Account index 2 is beyond the 2 static keys — only resolvable via the ALT above.
+    expect(resolveStaticAccount(parsed, 0)).toBe(signer);
+    expect(resolveStaticAccount(parsed, 2)).toBe(null);
+  });
+
+  it('reports signer indexes from the header, independent of static-key count', () => {
+    const parsed = { header: { numRequiredSignatures: 2, numReadonlySignedAccounts: 1, numReadonlyUnsignedAccounts: 0 } };
+    expect(isSignerIndex(parsed, 0)).toBe(true);
+    expect(isSignerIndex(parsed, 1)).toBe(true);
+    expect(isSignerIndex(parsed, 2)).toBe(false);
+  });
+
+  it('decodes a real base58 pubkey identically to the existing wallet helper', () => {
+    // Sanity check against a known-good encode/decode pair rather than relying
+    // solely on this module's own round-trip.
+    const wallet = generateSolanaWallet();
+    const messageBytes = buildMessageBytes({
+      versioned: false,
+      accountKeys: [wallet.address],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 0 },
+      recentBlockhash: wallet.address,
+      instructions: [],
+    });
+    const parsed = parseTransactionMessage(wrapTransaction(messageBytes));
+    expect(base58Encode(base58Decode(parsed.staticAccountKeys[0]))).toBe(wallet.address);
+  });
+});

--- a/src/__tests__/solana-tx.test.js
+++ b/src/__tests__/solana-tx.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseTransactionMessage, resolveStaticAccount, isSignerIndex } from '../solana-tx.js';
+import { parseTransactionMessage, resolveStaticAccount } from '../solana-tx.js';
 import { base58Decode, base58Encode, generateSolanaWallet } from '../wallet.js';
 
 function encodeCompactU16(value) {
@@ -88,13 +88,6 @@ describe('parseTransactionMessage', () => {
     // Account index 2 is beyond the 2 static keys — only resolvable via the ALT above.
     expect(resolveStaticAccount(parsed, 0)).toBe(signer);
     expect(resolveStaticAccount(parsed, 2)).toBe(null);
-  });
-
-  it('reports signer indexes from the header, independent of static-key count', () => {
-    const parsed = { header: { numRequiredSignatures: 2, numReadonlySignedAccounts: 1, numReadonlyUnsignedAccounts: 0 } };
-    expect(isSignerIndex(parsed, 0)).toBe(true);
-    expect(isSignerIndex(parsed, 1)).toBe(true);
-    expect(isSignerIndex(parsed, 2)).toBe(false);
   });
 
   it('throws on a truncated transaction rather than silently misparsing', () => {

--- a/src/__tests__/solana-tx.test.js
+++ b/src/__tests__/solana-tx.test.js
@@ -97,6 +97,24 @@ describe('parseTransactionMessage', () => {
     expect(isSignerIndex(parsed, 2)).toBe(false);
   });
 
+  it('throws on a truncated transaction rather than silently misparsing', () => {
+    const signer = generateSolanaWallet().address;
+    const programId = generateSolanaWallet().address;
+    const recentBlockhash = generateSolanaWallet().address;
+    const messageBytes = buildMessageBytes({
+      versioned: false,
+      accountKeys: [signer, programId],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 1 },
+      recentBlockhash,
+      instructions: [{ programIdIndex: 1, accountIndexes: [0], data: Buffer.from([0xde, 0xad]) }],
+    });
+    const full = Buffer.from(wrapTransaction(messageBytes), 'base64');
+    // Cut the buffer partway through the account-key section: a naive parser
+    // would read `undefined` bytes and drift its offset; this one must fail closed.
+    const truncated = full.subarray(0, full.length - 40).toString('base64');
+    expect(() => parseTransactionMessage(truncated)).toThrow(/past end of buffer/);
+  });
+
   it('decodes a real base58 pubkey identically to the existing wallet helper', () => {
     // Sanity check against a known-good encode/decode pair rather than relying
     // solely on this module's own round-trip.

--- a/src/__tests__/solana-tx.test.js
+++ b/src/__tests__/solana-tx.test.js
@@ -11,9 +11,9 @@ function encodeCompactU16(value) {
 // Minimal, hand-rolled builder for test fixtures — deliberately independent
 // of solana-tx.js so the parser is verified against an independent encoding,
 // not against itself.
-function buildMessageBytes({ versioned, accountKeys, header, recentBlockhash, instructions, addressTableLookups = [] }) {
+function buildMessageBytes({ versioned, versionByte = 0x80, accountKeys, header, recentBlockhash, instructions, addressTableLookups = [] }) {
   const parts = [];
-  if (versioned) parts.push(Buffer.from([0x80]));
+  if (versioned) parts.push(Buffer.from([versionByte]));
   parts.push(Buffer.from([header.numRequiredSignatures, header.numReadonlySignedAccounts, header.numReadonlyUnsignedAccounts]));
   parts.push(encodeCompactU16(accountKeys.length));
   for (const k of accountKeys) parts.push(base58Decode(k));
@@ -106,6 +106,25 @@ describe('parseTransactionMessage', () => {
     // would read `undefined` bytes and drift its offset; this one must fail closed.
     const truncated = full.subarray(0, full.length - 40).toString('base64');
     expect(() => parseTransactionMessage(truncated)).toThrow(/past end of buffer/);
+  });
+
+  it('fails closed on an unsupported transaction version rather than parsing it as v0', () => {
+    // A versioned prefix whose low 7 bits are non-zero (here version 1, 0x81).
+    // Only legacy and v0 exist today; the rest of the parser assumes the v0
+    // layout, so an unknown version must be rejected, not skipped and misparsed.
+    const signer = generateSolanaWallet().address;
+    const programId = generateSolanaWallet().address;
+    const recentBlockhash = generateSolanaWallet().address;
+    const messageBytes = buildMessageBytes({
+      versioned: true,
+      versionByte: 0x81,
+      accountKeys: [signer, programId],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 1 },
+      recentBlockhash,
+      instructions: [{ programIdIndex: 1, accountIndexes: [0], data: Buffer.from([0x01]) }],
+    });
+    expect(() => parseTransactionMessage(wrapTransaction(messageBytes)))
+      .toThrow(/Unsupported Solana transaction version 1/);
   });
 
   it('decodes a real base58 pubkey identically to the existing wallet helper', () => {

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -1844,6 +1844,65 @@ describe('assertSolanaInstructionsSafe', () => {
       .toThrow(/closes a token account and sends the reclaimed rent/);
   });
 
+  it('rejects a multisig Approve where the wallet signs after the multisig authority account', () => {
+    // Multisig layout: the authority position holds the multisig account, and
+    // the m-of-n signer accounts (one of them our wallet) follow it. The wallet
+    // still authorizes the delegate grant even though it isn't in the authority
+    // slot itself.
+    const wallet = generateSolanaWallet().address;
+    const sourceAccount = generateSolanaWallet().address;
+    const delegate = generateSolanaWallet().address;
+    const multisigOwner = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, sourceAccount, delegate, multisigOwner, TOKEN_PROGRAM],
+      // Approve: [source, delegate, multisig_owner, signer(=wallet)]
+      instructions: [{ programIdIndex: 4, accountIndexes: [1, 2, 3, 0], data: Buffer.from([4]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet }))
+      .toThrow(/grants a token delegate/);
+  });
+
+  it('rejects a multisig CloseAccount to a stranger where the wallet signs after the multisig authority', () => {
+    const wallet = generateSolanaWallet().address;
+    const account = generateSolanaWallet().address;
+    const stranger = generateSolanaWallet().address;
+    const multisigOwner = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, account, stranger, multisigOwner, TOKEN_PROGRAM],
+      // CloseAccount: [account, destination(=stranger), multisig_owner, signer(=wallet)]
+      instructions: [{ programIdIndex: 4, accountIndexes: [1, 2, 3, 0], data: Buffer.from([9]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet }))
+      .toThrow(/closes a token account and sends the reclaimed rent/);
+  });
+
+  it('allows a multisig CloseAccount that returns rent to the wallet even though the wallet signs', () => {
+    // The wallet authorizes the close (as a multisig signer), but the rent comes
+    // back to it — that's the legitimate WSOL-unwrap shape, not a drain.
+    const wallet = generateSolanaWallet().address;
+    const account = generateSolanaWallet().address;
+    const multisigOwner = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, account, multisigOwner, TOKEN_PROGRAM],
+      // CloseAccount: [account, destination(=wallet, index 0), multisig_owner, signer(=wallet)]
+      instructions: [{ programIdIndex: 3, accountIndexes: [1, 0, 2, 0], data: Buffer.from([9]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet })).not.toThrow();
+  });
+
+  it('skips an SPL Token instruction with empty data rather than misreading a missing discriminator', () => {
+    // No discriminator byte — `ix.data[0]` would be undefined. The runtime would
+    // reject this too; the check must skip it explicitly, not fall through the
+    // discriminant comparisons on an `undefined`.
+    const wallet = generateSolanaWallet().address;
+    const account = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, account, TOKEN_PROGRAM],
+      instructions: [{ programIdIndex: 2, accountIndexes: [1, 0], data: Buffer.alloc(0) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet })).not.toThrow();
+  });
+
   it('rejects an excessive compute-budget priority fee', () => {
     const wallet = generateSolanaWallet().address;
     const tx = buildTransaction({

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -1756,6 +1756,46 @@ describe('assertSolanaInstructionsSafe', () => {
       .toThrow(/closes a token account and sends the reclaimed rent/);
   });
 
+  it('fails closed on an Approve whose authority index is out of bounds (unresolvable)', () => {
+    // A crafted authority index past the static keys resolves to null. The
+    // authority of an SPL Approve must be a signer, so it can never legitimately
+    // be null — refuse rather than let `null === walletAddress` pass silently.
+    const wallet = generateSolanaWallet().address;
+    const sourceAccount = generateSolanaWallet().address;
+    const delegate = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, sourceAccount, delegate, TOKEN_PROGRAM],
+      // authority position (index 2) points at 9 — well past the 4 static keys
+      instructions: [{ programIdIndex: 3, accountIndexes: [1, 2, 9], data: Buffer.from([4]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet }))
+      .toThrow(/grants a token delegate/);
+  });
+
+  it('fails closed on a SetAuthority whose authority index is out of bounds (unresolvable)', () => {
+    const wallet = generateSolanaWallet().address;
+    const account = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, account, TOKEN_PROGRAM],
+      // authority position (index 1) points at 9 — past the 3 static keys
+      instructions: [{ programIdIndex: 2, accountIndexes: [1, 9], data: Buffer.from([6, 2]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet }))
+      .toThrow(/changes a token account's authority/);
+  });
+
+  it('fails closed on a CloseAccount whose authority index is out of bounds (unresolvable)', () => {
+    const wallet = generateSolanaWallet().address;
+    const account = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, account, TOKEN_PROGRAM],
+      // authority position (index 2) points at 9 — past the 3 static keys
+      instructions: [{ programIdIndex: 2, accountIndexes: [1, 0, 9], data: Buffer.from([9]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet }))
+      .toThrow(/closes a token account and sends the reclaimed rent/);
+  });
+
   it('rejects an excessive compute-budget priority fee', () => {
     const wallet = generateSolanaWallet().address;
     const tx = buildTransaction({

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -1664,6 +1664,22 @@ describe('assertSolanaInstructionsSafe', () => {
     expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet })).not.toThrow();
   });
 
+  it('fails closed when no wallet address is provided rather than silently passing', () => {
+    // An Approve authorized by the (unknown) signer must not slip through just
+    // because walletAddress is missing — the check would otherwise compare
+    // against undefined and never fire.
+    const wallet = generateSolanaWallet().address;
+    const sourceAccount = generateSolanaWallet().address;
+    const delegate = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, sourceAccount, delegate, TOKEN_PROGRAM],
+      instructions: [{ programIdIndex: 3, accountIndexes: [1, 2, 0], data: Buffer.from([4]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, {})).toThrow(/without the signing wallet address/);
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: null })).toThrow(/without the signing wallet address/);
+    expect(() => assertSolanaInstructionsSafe(tx)).toThrow(/without the signing wallet address/);
+  });
+
   it('rejects an Approve instruction authorized by the wallet', () => {
     const wallet = generateSolanaWallet().address;
     const sourceAccount = generateSolanaWallet().address;

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -1938,4 +1938,40 @@ describe('assertSolanaInstructionsSafe', () => {
     });
     expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet })).not.toThrow();
   });
+
+  // The limit-order deposit/withdrawal paths run this same gate (see
+  // limit-order.js). Their legitimate transactions move the input token with an
+  // SPL Transfer/TransferChecked — which the gate intentionally does NOT classify
+  // (a swap or vault deposit can't function without one) — so they must pass. If
+  // a future change made the gate reject bare transfers it would brick both the
+  // swap and limit-order flows; these lock in that they don't.
+  it('allows a plain SPL Transfer of the sell token authorized by the wallet (the input leg)', () => {
+    const wallet = generateSolanaWallet().address;
+    const sourceAta = generateSolanaWallet().address;
+    const destAta = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, sourceAta, destAta, TOKEN_PROGRAM],
+      // Transfer (disc 3): [source, destination, authority(=wallet)]
+      instructions: [{ programIdIndex: 3, accountIndexes: [1, 2, 0], data: Buffer.from([3, 0, 0, 0, 0, 0, 0, 0, 0]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet })).not.toThrow();
+  });
+
+  it('allows a limit-order-style vault deposit (input TransferChecked into the vault + WSOL close-to-self)', () => {
+    const wallet = generateSolanaWallet().address;
+    const sourceAta = generateSolanaWallet().address;
+    const mint = generateSolanaWallet().address;
+    const vaultAta = generateSolanaWallet().address;
+    const tempWsol = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, sourceAta, mint, vaultAta, tempWsol, TOKEN_PROGRAM],
+      instructions: [
+        // TransferChecked (disc 12): [source, mint, destination(=vault), authority(=wallet)]
+        { programIdIndex: 5, accountIndexes: [1, 2, 3, 0], data: Buffer.from([12, 0, 0, 0, 0, 0, 0, 0, 0, 9]) },
+        // CloseAccount (disc 9) of the temp WSOL account, rent back to the wallet (index 0)
+        { programIdIndex: 5, accountIndexes: [4, 0, 0], data: Buffer.from([9]) },
+      ],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet })).not.toThrow();
+  });
 });

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { validateQuoteInput, fetchNativeBalance, fetchTokenBalance, validateBalance, resolvePercentAmount, validateGasBalance, GASLESS_MIN_TRADE_USD, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertInputWithinMax, assertSwapCalldataNotBareTransfer, assertSwapOutcome, MAX_UINT256, needsAllowanceRevoke } from '../trade-validation.js';
+import { validateQuoteInput, fetchNativeBalance, fetchTokenBalance, validateBalance, resolvePercentAmount, validateGasBalance, GASLESS_MIN_TRADE_USD, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertInputWithinMax, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, MAX_UINT256, needsAllowanceRevoke } from '../trade-validation.js';
+import { base58Decode, generateSolanaWallet } from '../wallet.js';
 
 describe('validateQuoteInput', () => {
   const validSolana = {
@@ -1608,5 +1609,170 @@ describe('assertSwapOutcome', () => {
   it('fails closed on a corrupt (non-integer) simulated delta', () => {
     const sim = { deltas: { [USDC]: 'not-a-number' }, approvals: [] };
     expect(() => assertSwapOutcome(exactInRequest, exactInQuote, sim, {})).toThrow(/SWAP_OUTCOME_MISMATCH/i);
+  });
+});
+
+describe('assertSolanaInstructionsSafe', () => {
+  const TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+  const COMPUTE_BUDGET_PROGRAM = 'ComputeBudget111111111111111111111111111111';
+
+  function encodeCompactU16(value) {
+    if (value < 0x80) return Buffer.from([value]);
+    if (value < 0x4000) return Buffer.from([(value & 0x7f) | 0x80, (value >> 7) & 0x7f]);
+    return Buffer.from([(value & 0x7f) | 0x80, ((value >> 7) & 0x7f) | 0x80, (value >> 14) & 0x03]);
+  }
+
+  // Minimal legacy-message builder — accountKeys[0] is always the wallet
+  // (fee payer / sole signer) unless a test overrides the ordering directly.
+  function buildTransaction({ accountKeys, instructions }) {
+    const parts = [Buffer.from([1, 0, accountKeys.length - 1])]; // 1 signer, that signer is writable
+    parts.push(encodeCompactU16(accountKeys.length));
+    for (const k of accountKeys) parts.push(base58Decode(k));
+    parts.push(base58Decode(accountKeys[0])); // recentBlockhash placeholder — any 32 bytes
+    parts.push(encodeCompactU16(instructions.length));
+    for (const ix of instructions) {
+      parts.push(Buffer.from([ix.programIdIndex]));
+      parts.push(encodeCompactU16(ix.accountIndexes.length));
+      for (const idx of ix.accountIndexes) parts.push(Buffer.from([idx]));
+      parts.push(encodeCompactU16(ix.data.length));
+      parts.push(ix.data);
+    }
+    const messageBytes = Buffer.concat(parts);
+    return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), messageBytes]).toString('base64');
+  }
+
+  function computeBudgetSetLimit(units) {
+    const data = Buffer.alloc(5);
+    data[0] = 2;
+    data.writeUInt32LE(units, 1);
+    return data;
+  }
+  function computeBudgetSetPrice(microLamports) {
+    const data = Buffer.alloc(9);
+    data[0] = 3;
+    data.writeBigUInt64LE(BigInt(microLamports), 1);
+    return data;
+  }
+
+  it('passes a benign transaction with no SPL Token or ComputeBudget instructions', () => {
+    const wallet = generateSolanaWallet().address;
+    const programId = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, programId],
+      instructions: [{ programIdIndex: 1, accountIndexes: [0], data: Buffer.from([0x01]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet })).not.toThrow();
+  });
+
+  it('rejects an Approve instruction authorized by the wallet', () => {
+    const wallet = generateSolanaWallet().address;
+    const sourceAccount = generateSolanaWallet().address;
+    const delegate = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, sourceAccount, delegate, TOKEN_PROGRAM],
+      // Approve: [source, delegate, owner(authority, signer)]
+      instructions: [{ programIdIndex: 3, accountIndexes: [1, 2, 0], data: Buffer.from([4]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet }))
+      .toThrow(/grants a token delegate/);
+  });
+
+  it('rejects an ApproveChecked instruction authorized by the wallet', () => {
+    const wallet = generateSolanaWallet().address;
+    const sourceAccount = generateSolanaWallet().address;
+    const mint = generateSolanaWallet().address;
+    const delegate = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, sourceAccount, mint, delegate, TOKEN_PROGRAM],
+      // ApproveChecked: [source, mint, delegate, owner(authority, signer)]
+      instructions: [{ programIdIndex: 4, accountIndexes: [1, 2, 3, 0], data: Buffer.from([13]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet }))
+      .toThrow(/grants a token delegate/);
+  });
+
+  it('does not reject an Approve instruction whose authority is not the wallet', () => {
+    // Can't actually execute with our signature anyway — SPL Token requires
+    // the authority to sign, and we're not providing that account's signature.
+    const wallet = generateSolanaWallet().address;
+    const sourceAccount = generateSolanaWallet().address;
+    const delegate = generateSolanaWallet().address;
+    const someoneElse = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, sourceAccount, delegate, someoneElse, TOKEN_PROGRAM],
+      instructions: [{ programIdIndex: 4, accountIndexes: [1, 2, 3], data: Buffer.from([4]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet })).not.toThrow();
+  });
+
+  it('rejects a SetAuthority instruction authorized by the wallet', () => {
+    const wallet = generateSolanaWallet().address;
+    const account = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, account, TOKEN_PROGRAM],
+      // SetAuthority: [account, current authority(signer)]
+      instructions: [{ programIdIndex: 2, accountIndexes: [1, 0], data: Buffer.from([6, 2]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet }))
+      .toThrow(/changes a token account's authority/);
+  });
+
+  it('allows a CloseAccount instruction that returns rent to the wallet itself', () => {
+    const wallet = generateSolanaWallet().address;
+    const account = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, account, TOKEN_PROGRAM],
+      // CloseAccount: [account, destination, authority(signer)] — destination == wallet (index 0)
+      instructions: [{ programIdIndex: 2, accountIndexes: [1, 0, 0], data: Buffer.from([9]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet })).not.toThrow();
+  });
+
+  it('rejects a CloseAccount instruction that sends rent to a stranger', () => {
+    const wallet = generateSolanaWallet().address;
+    const account = generateSolanaWallet().address;
+    const stranger = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, account, stranger, TOKEN_PROGRAM],
+      instructions: [{ programIdIndex: 3, accountIndexes: [1, 2, 0], data: Buffer.from([9]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet }))
+      .toThrow(/closes a token account and sends the reclaimed rent/);
+  });
+
+  it('rejects an excessive compute-budget priority fee', () => {
+    const wallet = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, COMPUTE_BUDGET_PROGRAM],
+      instructions: [
+        { programIdIndex: 1, accountIndexes: [], data: computeBudgetSetLimit(1_400_000) },
+        { programIdIndex: 1, accountIndexes: [], data: computeBudgetSetPrice(10_000_000) }, // 0.014 SOL priority fee, over the 0.01 SOL cap
+      ],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet }))
+      .toThrow(/excessive priority fee/);
+  });
+
+  it('assumes the max compute-unit ceiling when a price is set with no explicit limit', () => {
+    const wallet = generateSolanaWallet().address;
+    // A price that's fine at a small limit but excessive at Solana's 1.4M-unit ceiling.
+    const tx = buildTransaction({
+      accountKeys: [wallet, COMPUTE_BUDGET_PROGRAM],
+      instructions: [{ programIdIndex: 1, accountIndexes: [], data: computeBudgetSetPrice(10_000_000) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet }))
+      .toThrow(/excessive priority fee/);
+  });
+
+  it('allows a modest, explicitly-bounded compute-budget priority fee', () => {
+    const wallet = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, COMPUTE_BUDGET_PROGRAM],
+      instructions: [
+        { programIdIndex: 1, accountIndexes: [], data: computeBudgetSetLimit(200_000) },
+        { programIdIndex: 1, accountIndexes: [], data: computeBudgetSetPrice(1000) },
+      ],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet })).not.toThrow();
   });
 });

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -3863,6 +3863,72 @@ describe('ERC-20 excessive allowance handling', () => {
   });
 });
 
+describe('Solana execute: static instruction safety check', () => {
+  function encodeCompactU16(value) {
+    if (value < 0x80) return Buffer.from([value]);
+    if (value < 0x4000) return Buffer.from([(value & 0x7f) | 0x80, (value >> 7) & 0x7f]);
+    return Buffer.from([(value & 0x7f) | 0x80, ((value >> 7) & 0x7f) | 0x80, (value >> 14) & 0x03]);
+  }
+
+  // A Jupiter-shaped (plain base64) transaction whose sole instruction is an
+  // SPL Token CloseAccount authorized by `walletAddress` that sends the
+  // reclaimed rent to a stranger instead of back to the wallet.
+  function buildCloseToStrangerTransaction(walletAddress, strangerAddress) {
+    const TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+    const tokenAccount = generateSolanaWallet().address;
+    const accountKeys = [walletAddress, tokenAccount, strangerAddress, TOKEN_PROGRAM];
+    const parts = [Buffer.from([1, 0, 3])];
+    parts.push(encodeCompactU16(accountKeys.length));
+    for (const k of accountKeys) parts.push(base58Decode(k));
+    parts.push(base58Decode(walletAddress)); // recentBlockhash placeholder
+    parts.push(encodeCompactU16(1));
+    // CloseAccount: [account, destination(=stranger), authority(=wallet, signer)]
+    parts.push(Buffer.from([3])); // programIdIndex → TOKEN_PROGRAM
+    parts.push(encodeCompactU16(3));
+    parts.push(Buffer.from([1, 2, 0]));
+    parts.push(encodeCompactU16(1));
+    parts.push(Buffer.from([9])); // CloseAccount discriminator
+    const messageBytes = Buffer.concat(parts);
+    return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), messageBytes]).toString('base64');
+  }
+
+  it('blocks execute before signing when the compiled instructions close an account to a stranger', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const wallet = showWallet('default');
+    const stranger = generateSolanaWallet().address;
+
+    const fetchCalls = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url) => {
+      fetchCalls.push(typeof url === 'string' ? url : url.toString());
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ status: 'Success' })) });
+    }));
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'jupiter',
+        inputMint: '11111111111111111111111111111111',
+        outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        inAmount: '1000000000',
+        outAmount: '100000000',
+        transaction: buildCloseToStrangerTransaction(wallet.solana, stranger),
+      }],
+    }, 'solana', 'local');
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    await expect(cmds.execute([], null, {}, { quote: quoteId })).rejects.toThrow();
+
+    expect(fetchCalls.some(u => u.includes('trading-api') && u.endsWith('/execute'))).toBe(false);
+    expect(logs.some(l => l.includes('reclaimed rent'))).toBe(true);
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
+    vi.unstubAllGlobals();
+  });
+});
+
+
 describe('Relay aggregator: --gasless flag dispatch', () => {
   it('forwards aggregator/gasless/steps/requestId to /execute when gasless flag is set', async () => {
     createWallet('default', 'testpass');

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -1413,14 +1413,23 @@ describe('Privy execute support', () => {
         outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
         inAmount: '1000000000',
         outAmount: '50000000',
-        transaction: 'AQAAAA==',
+        // A valid, parseable benign transaction (one non-SPL instruction) — the
+        // pre-signing safety check now parses this before Privy signs it.
+        transaction: 'AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAECAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQECAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAQEBAAEA',
         metadata: { requestId: 'req-123' },
       }],
     }, 'solana', 'privy', { evm: 'wl_evm_1', solana: 'wl_sol_1' });
 
-    vi.stubGlobal('fetch', vi.fn().mockImplementation((url) => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
       const urlStr = typeof url === 'string' ? url : url.toString();
-      // Privy signSolanaTransaction
+      // Privy getWallet (GET) — resolves the signing wallet's address
+      if (urlStr.includes('privy.io') && opts?.method === 'GET') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ id: 'wl_sol_1', address: 'So11111111111111111111111111111111111111112', chain_type: 'solana' }),
+        });
+      }
+      // Privy signSolanaTransaction (POST)
       if (urlStr.includes('privy.io')) {
         return Promise.resolve({
           ok: true,

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -324,6 +324,12 @@ describe('readCompactU16', () => {
   it('should read with offset', () => {
     expect(readCompactU16(Buffer.from([0xff, 0x05]), 1)).toEqual({ value: 5, size: 1 });
   });
+
+  it('fails closed on a length byte that runs past the end of the buffer', () => {
+    // Continuation bit set with no following byte — must throw, not silently
+    // read past the buffer and return a wrong length.
+    expect(() => readCompactU16(Buffer.from([0x80]), 0)).toThrow(/past end of buffer/);
+  });
 });
 
 // ============= RLP Encoding =============
@@ -3934,6 +3940,35 @@ describe('Solana execute: static instruction safety check', () => {
 
     delete process.env.NANSEN_WALLET_PASSWORD;
     vi.unstubAllGlobals();
+  });
+
+  it('gives an actionable local-wallet error (not a WalletConnect message) when the wallet file has no Solana key', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+
+    // Simulate a hand-edited/legacy wallet file missing the `solana` key.
+    const walletFile = path.join(tempDir, '.nansen', 'wallets', 'default.json');
+    const data = JSON.parse(fs.readFileSync(walletFile, 'utf8'));
+    delete data.solana;
+    fs.writeFileSync(walletFile, JSON.stringify(data, null, 2));
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'jupiter',
+        inputMint: '11111111111111111111111111111111',
+        outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        inAmount: '1000000000',
+        outAmount: '100000000',
+        transaction: 'irrelevant-not-reached',
+      }],
+    }, 'solana', 'local');
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    await expect(cmds.execute([], null, {}, { quote: quoteId }))
+      .rejects.toThrow(/No Solana address on this wallet/);
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
   });
 });
 

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -674,6 +674,16 @@ EXAMPLES:
         });
 
         // 5. Sign deposit transaction
+        // Same pre-signing drain gate the swap path uses. The legitimate deposit
+        // moves the input token into the already-registered vault (step 3) with an
+        // SPL Transfer/TransferChecked — which this gate does not classify — plus,
+        // when selling native SOL, a temp-WSOL CloseAccount whose rent returns to
+        // the wallet (permitted). Neither trips the delegate/authority/
+        // close-to-stranger checks, so this does not reject a well-formed deposit;
+        // it only fires if the crafted tx additionally grants a delegate, reassigns
+        // authority, or closes to a stranger. Verified live: a real SOL→USDC create
+        // round-trip clears this gate (the API-crafted deposit is a SOL-wrap
+        // transfer into the vault plus a temp-WSOL close-to-self).
         assertSolanaInstructionsSafe(deposit.transaction, { walletAddress: pubkey });
         log('  Signing deposit transaction...');
         const signedDepositTx = await signTransaction(deposit.transaction, walletType, walletInfo);
@@ -809,6 +819,13 @@ EXAMPLES:
         const cancelResult = await cancelOrderRequest(token, orderId);
 
         // 3. Sign the withdrawal transaction
+        // Withdrawal moves the deposited token back out of the vault; that transfer
+        // is authorized by the vault program's PDA, not our wallet, so it isn't a
+        // wallet-authorized drain even if it were classified. Any temp-WSOL close
+        // returns rent to the wallet. This gate is defense-in-depth against a
+        // crafted withdrawal that instead grants a delegate, reassigns authority, or
+        // closes to a stranger. Verified live alongside the deposit path via a real
+        // cancel round-trip.
         assertSolanaInstructionsSafe(cancelResult.transaction, { walletAddress: pubkey });
         log('  Signing withdrawal transaction...');
         const signedTx = await signTransaction(cancelResult.transaction, walletType, walletInfo);

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -11,6 +11,7 @@ import path from 'path';
 import { base58Encode, exportWallet, getWalletConfig, showWallet } from './wallet.js';
 import { signEd25519, base58Decode, parseAmount, getTokenInfo } from './transfer.js';
 import { signSolanaTransaction, resolveTokenAddress } from './trading.js';
+import { assertSolanaInstructionsSafe } from './trade-validation.js';
 import { validateTokenAddress, telemetryHeaders, packageVersion } from './api.js';
 import { getWalletConnectAddress, sendSolanaTransactionViaWalletConnect, signSolanaMessageViaWalletConnect } from './walletconnect-trading.js';
 import { retrievePassword } from './keychain.js';
@@ -673,6 +674,7 @@ EXAMPLES:
         });
 
         // 5. Sign deposit transaction
+        assertSolanaInstructionsSafe(deposit.transaction, { walletAddress: pubkey });
         log('  Signing deposit transaction...');
         const signedDepositTx = await signTransaction(deposit.transaction, walletType, walletInfo);
 
@@ -807,6 +809,7 @@ EXAMPLES:
         const cancelResult = await cancelOrderRequest(token, orderId);
 
         // 3. Sign the withdrawal transaction
+        assertSolanaInstructionsSafe(cancelResult.transaction, { walletAddress: pubkey });
         log('  Signing withdrawal transaction...');
         const signedTx = await signTransaction(cancelResult.transaction, walletType, walletInfo);
 

--- a/src/solana-tx.js
+++ b/src/solana-tx.js
@@ -11,6 +11,9 @@ function readCompactU16(buf, offset) {
   let shift = 0;
   let size = 0;
   for (let i = 0; i < 3; i++) {
+    if (offset + i >= buf.length) {
+      throw new Error('Malformed Solana transaction: compact-u16 length runs past end of buffer');
+    }
     const byte = buf[offset + i];
     value |= (byte & 0x7f) << shift;
     size++;
@@ -28,13 +31,23 @@ function readCompactU16(buf, offset) {
  */
 export function parseTransactionMessage(base64) {
   const bytes = Buffer.from(base64, 'base64');
+  // Fail closed on any read past the end of the buffer: a truncated or crafted
+  // transaction must throw here rather than silently misparse into a wrong
+  // (possibly drain-hiding) instruction list before signing.
+  const requireBytes = (off, need) => {
+    if (off + need > bytes.length) {
+      throw new Error('Malformed Solana transaction: read past end of buffer');
+    }
+  };
   const { value: numSignatures, size: sigCountSize } = readCompactU16(bytes, 0);
   let offset = sigCountSize + numSignatures * 64;
 
+  requireBytes(offset, 1);
   const first = bytes[offset];
   const isVersioned = (first & 0x80) !== 0;
   if (isVersioned) offset += 1; // skip the version-prefix byte; header follows
 
+  requireBytes(offset, 3);
   const numRequiredSignatures = bytes[offset];
   const numReadonlySignedAccounts = bytes[offset + 1];
   const numReadonlyUnsignedAccounts = bytes[offset + 2];
@@ -44,10 +57,12 @@ export function parseTransactionMessage(base64) {
   offset += keysCountSize;
   const staticAccountKeys = [];
   for (let i = 0; i < numAccountKeys; i++) {
+    requireBytes(offset, 32);
     staticAccountKeys.push(base58Encode(bytes.subarray(offset, offset + 32)));
     offset += 32;
   }
 
+  requireBytes(offset, 32);
   const recentBlockhash = base58Encode(bytes.subarray(offset, offset + 32));
   offset += 32;
 
@@ -55,10 +70,12 @@ export function parseTransactionMessage(base64) {
   offset += ixCountSize;
   const instructions = [];
   for (let i = 0; i < numInstructions; i++) {
+    requireBytes(offset, 1);
     const programIdIndex = bytes[offset];
     offset += 1;
     const { value: numAccounts, size: accCountSize } = readCompactU16(bytes, offset);
     offset += accCountSize;
+    requireBytes(offset, numAccounts);
     const accountIndexes = [];
     for (let j = 0; j < numAccounts; j++) {
       accountIndexes.push(bytes[offset]);
@@ -66,6 +83,7 @@ export function parseTransactionMessage(base64) {
     }
     const { value: dataLen, size: dataLenSize } = readCompactU16(bytes, offset);
     offset += dataLenSize;
+    requireBytes(offset, dataLen);
     const data = bytes.subarray(offset, offset + dataLen);
     offset += dataLen;
     instructions.push({ programIdIndex, accountIndexes, data });
@@ -76,10 +94,12 @@ export function parseTransactionMessage(base64) {
     const { value: numLookups, size: lookupCountSize } = readCompactU16(bytes, offset);
     offset += lookupCountSize;
     for (let i = 0; i < numLookups; i++) {
+      requireBytes(offset, 32);
       const lookupTableAddress = base58Encode(bytes.subarray(offset, offset + 32));
       offset += 32;
       const { value: numWritable, size: writableCountSize } = readCompactU16(bytes, offset);
       offset += writableCountSize;
+      requireBytes(offset, numWritable);
       const writableIndexes = [];
       for (let j = 0; j < numWritable; j++) {
         writableIndexes.push(bytes[offset]);
@@ -87,6 +107,7 @@ export function parseTransactionMessage(base64) {
       }
       const { value: numReadonly, size: readonlyCountSize } = readCompactU16(bytes, offset);
       offset += readonlyCountSize;
+      requireBytes(offset, numReadonly);
       const readonlyIndexes = [];
       for (let j = 0; j < numReadonly; j++) {
         readonlyIndexes.push(bytes[offset]);

--- a/src/solana-tx.js
+++ b/src/solana-tx.js
@@ -45,7 +45,19 @@ export function parseTransactionMessage(base64) {
   requireBytes(offset, 1);
   const first = bytes[offset];
   const isVersioned = (first & 0x80) !== 0;
-  if (isVersioned) offset += 1; // skip the version-prefix byte; header follows
+  if (isVersioned) {
+    // The low 7 bits are the version number. Only v0 exists today, and the rest
+    // of this parser assumes the v0 message layout (static keys, instructions,
+    // then address-table lookups). A future/unknown version could lay out its
+    // bytes differently, so as a pre-signing safety gate we fail closed rather
+    // than skip the prefix and misparse an unsupported format into a
+    // wrong-and-possibly-drain-hiding instruction list.
+    const version = first & 0x7f;
+    if (version !== 0) {
+      throw new Error(`Unsupported Solana transaction version ${version}. Refusing to sign.`);
+    }
+    offset += 1; // skip the version-prefix byte; header follows
+  }
 
   requireBytes(offset, 3);
   const numRequiredSignatures = bytes[offset];

--- a/src/solana-tx.js
+++ b/src/solana-tx.js
@@ -1,0 +1,124 @@
+/**
+ * Nansen CLI - Solana Transaction Deserialization
+ * Parses a serialized (legacy or v0) Solana VersionedTransaction so its
+ * instructions can be statically inspected before signing.
+ */
+
+import { base58Encode } from './wallet.js';
+
+function readCompactU16(buf, offset) {
+  let value = 0;
+  let shift = 0;
+  let size = 0;
+  for (let i = 0; i < 3; i++) {
+    const byte = buf[offset + i];
+    value |= (byte & 0x7f) << shift;
+    size++;
+    if ((byte & 0x80) === 0) break;
+    shift += 7;
+  }
+  return { value, size };
+}
+
+/**
+ * Parse a base64-encoded Solana transaction (wire format:
+ * [compact-u16 sigCount][sigCount * 64-byte signatures][message]) into its
+ * header, static account keys, instructions, and (v0 only) address-table
+ * lookups. `data` on instructions is returned undecoded (raw Buffer).
+ */
+export function parseTransactionMessage(base64) {
+  const bytes = Buffer.from(base64, 'base64');
+  const { value: numSignatures, size: sigCountSize } = readCompactU16(bytes, 0);
+  let offset = sigCountSize + numSignatures * 64;
+
+  const first = bytes[offset];
+  const isVersioned = (first & 0x80) !== 0;
+  if (isVersioned) offset += 1; // skip the version-prefix byte; header follows
+
+  const numRequiredSignatures = bytes[offset];
+  const numReadonlySignedAccounts = bytes[offset + 1];
+  const numReadonlyUnsignedAccounts = bytes[offset + 2];
+  offset += 3;
+
+  const { value: numAccountKeys, size: keysCountSize } = readCompactU16(bytes, offset);
+  offset += keysCountSize;
+  const staticAccountKeys = [];
+  for (let i = 0; i < numAccountKeys; i++) {
+    staticAccountKeys.push(base58Encode(bytes.subarray(offset, offset + 32)));
+    offset += 32;
+  }
+
+  const recentBlockhash = base58Encode(bytes.subarray(offset, offset + 32));
+  offset += 32;
+
+  const { value: numInstructions, size: ixCountSize } = readCompactU16(bytes, offset);
+  offset += ixCountSize;
+  const instructions = [];
+  for (let i = 0; i < numInstructions; i++) {
+    const programIdIndex = bytes[offset];
+    offset += 1;
+    const { value: numAccounts, size: accCountSize } = readCompactU16(bytes, offset);
+    offset += accCountSize;
+    const accountIndexes = [];
+    for (let j = 0; j < numAccounts; j++) {
+      accountIndexes.push(bytes[offset]);
+      offset += 1;
+    }
+    const { value: dataLen, size: dataLenSize } = readCompactU16(bytes, offset);
+    offset += dataLenSize;
+    const data = bytes.subarray(offset, offset + dataLen);
+    offset += dataLen;
+    instructions.push({ programIdIndex, accountIndexes, data });
+  }
+
+  const addressTableLookups = [];
+  if (isVersioned) {
+    const { value: numLookups, size: lookupCountSize } = readCompactU16(bytes, offset);
+    offset += lookupCountSize;
+    for (let i = 0; i < numLookups; i++) {
+      const lookupTableAddress = base58Encode(bytes.subarray(offset, offset + 32));
+      offset += 32;
+      const { value: numWritable, size: writableCountSize } = readCompactU16(bytes, offset);
+      offset += writableCountSize;
+      const writableIndexes = [];
+      for (let j = 0; j < numWritable; j++) {
+        writableIndexes.push(bytes[offset]);
+        offset += 1;
+      }
+      const { value: numReadonly, size: readonlyCountSize } = readCompactU16(bytes, offset);
+      offset += readonlyCountSize;
+      const readonlyIndexes = [];
+      for (let j = 0; j < numReadonly; j++) {
+        readonlyIndexes.push(bytes[offset]);
+        offset += 1;
+      }
+      addressTableLookups.push({ lookupTableAddress, writableIndexes, readonlyIndexes });
+    }
+  }
+
+  return {
+    isVersioned,
+    header: { numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts },
+    staticAccountKeys,
+    recentBlockhash,
+    instructions,
+    addressTableLookups,
+  };
+}
+
+/**
+ * Resolve an account index to its base58 pubkey, or null if it's only
+ * resolvable via an address-lookup-table entry (requires an RPC fetch this
+ * module intentionally doesn't make). Lookup-table entries can never be
+ * signers — Solana's message format requires every signer to be a static
+ * account key — so a null result here only ever means "not a signer, and
+ * this specific pubkey can't be verified without a network call."
+ */
+export function resolveStaticAccount(parsed, index) {
+  if (index < parsed.staticAccountKeys.length) return parsed.staticAccountKeys[index];
+  return null;
+}
+
+export function isSignerIndex(parsed, index) {
+  return index < parsed.header.numRequiredSignatures;
+}

--- a/src/solana-tx.js
+++ b/src/solana-tx.js
@@ -6,7 +6,7 @@
 
 import { base58Encode } from './wallet.js';
 
-function readCompactU16(buf, offset) {
+export function readCompactU16(buf, offset) {
   let value = 0;
   let shift = 0;
   let size = 0;
@@ -138,8 +138,4 @@ export function parseTransactionMessage(base64) {
 export function resolveStaticAccount(parsed, index) {
   if (index < parsed.staticAccountKeys.length) return parsed.staticAccountKeys[index];
   return null;
-}
-
-export function isSignerIndex(parsed, index) {
-  return index < parsed.header.numRequiredSignatures;
 }

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1127,6 +1127,14 @@ export function assertSwapOutcome(request, quote, sim, { slippage, expectedSpend
  * Throws on any of those patterns. Returns the parsed transaction otherwise.
  */
 export function assertSolanaInstructionsSafe(txBase64, { walletAddress } = {}) {
+  // Fail closed on a missing wallet address: every authority check below is
+  // `authority === walletAddress`, so a null/undefined address would make each
+  // comparison silently false and disable the drain protection rather than
+  // over-reject. Refuse to run the check without knowing whose signature we're
+  // guarding.
+  if (!walletAddress) {
+    throw new Error('Cannot verify Solana instruction safety without the signing wallet address. Refusing to sign.');
+  }
   const parsed = parseTransactionMessage(txBase64);
   const accountAt = (ix, position) => resolveStaticAccount(parsed, ix.accountIndexes[position]);
 

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -6,8 +6,31 @@
 
 import { validateAddress } from './api.js';
 import { CHAIN_RPCS } from './rpc-urls.js';
+import { parseTransactionMessage, resolveStaticAccount } from './solana-tx.js';
 
 const SUPPORTED_CHAINS = ['solana', 'base'];
+
+// SPL Token / Token-2022 instruction discriminators (first data byte) that can
+// move control of a user's token account without moving its balance — the
+// class of drain vector a balance-delta simulation can't see (see
+// assertSolanaInstructionsSafe).
+const SPL_TOKEN_PROGRAMS = new Set([
+  'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+  'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+]);
+const SPL_APPROVE = 4;
+const SPL_SET_AUTHORITY = 6;
+const SPL_CLOSE_ACCOUNT = 9;
+const SPL_APPROVE_CHECKED = 13;
+
+const COMPUTE_BUDGET_PROGRAM = 'ComputeBudget111111111111111111111111111111';
+const COMPUTE_BUDGET_SET_UNIT_LIMIT = 2;
+const COMPUTE_BUDGET_SET_UNIT_PRICE = 3;
+const SOLANA_MAX_COMPUTE_UNITS = 1_400_000; // Solana's per-transaction compute-unit ceiling — the
+                                             // worst-case bound used when a price is set with no
+                                             // explicit limit instruction.
+const MAX_PRIORITY_FEE_LAMPORTS = 10_000_000n; // 0.01 SOL sanity ceiling on the priority fee a
+                                                // single trade can be made to pay.
 
 /**
  * Validate quote inputs before any network call.
@@ -1082,4 +1105,83 @@ export function assertSwapOutcome(request, quote, sim, { slippage, expectedSpend
   }
 
   return { verified: true };
+}
+
+/**
+ * Statically inspect a Solana transaction's instructions for drain vectors a
+ * balance-delta simulation can't see — granting a token delegate, changing a
+ * token account's authority, or closing an account to a stranger — and for an
+ * excessive compute-budget priority fee. Runs before signing, on the raw
+ * instructions rather than trusting the aggregator's intent.
+ *
+ * The SPL Token program requires the *authority* account of Approve/
+ * ApproveChecked/SetAuthority/CloseAccount to be a signer of the transaction,
+ * so checking "is the authority our own wallet" is both necessary (no other
+ * authority could actually get this instruction to execute with our
+ * signature) and sufficient — no RPC-based account-ownership lookup needed.
+ * Address-lookup-table-resolved accounts can never be signers, so the
+ * authority position is always statically resolvable; only CloseAccount's
+ * destination can legitimately be ALT-resolved, and an unresolvable
+ * destination is treated the same as a stranger (fail closed).
+ *
+ * Throws on any of those patterns. Returns the parsed transaction otherwise.
+ */
+export function assertSolanaInstructionsSafe(txBase64, { walletAddress } = {}) {
+  const parsed = parseTransactionMessage(txBase64);
+  const accountAt = (ix, position) => resolveStaticAccount(parsed, ix.accountIndexes[position]);
+
+  let computeUnitLimit = null;
+  let computeUnitPriceMicroLamports = null;
+
+  for (const ix of parsed.instructions) {
+    const programId = resolveStaticAccount(parsed, ix.programIdIndex);
+    if (!programId) continue; // program invoked via an ALT entry — not a pattern we classify
+
+    if (SPL_TOKEN_PROGRAMS.has(programId)) {
+      const discriminator = ix.data[0];
+      if (discriminator === SPL_APPROVE || discriminator === SPL_APPROVE_CHECKED) {
+        const authority = accountAt(ix, discriminator === SPL_APPROVE_CHECKED ? 3 : 2);
+        if (authority === walletAddress) {
+          throw new Error(
+            'Solana transaction grants a token delegate (Approve) authorized by your wallet. Refusing to sign.',
+          );
+        }
+      } else if (discriminator === SPL_SET_AUTHORITY) {
+        const authority = accountAt(ix, 1);
+        if (authority === walletAddress) {
+          throw new Error(
+            "Solana transaction changes a token account's authority (SetAuthority) using your wallet's signature. Refusing to sign.",
+          );
+        }
+      } else if (discriminator === SPL_CLOSE_ACCOUNT) {
+        const authority = accountAt(ix, 2);
+        const destination = accountAt(ix, 1);
+        if (authority === walletAddress && destination !== walletAddress) {
+          throw new Error(
+            `Solana transaction closes a token account and sends the reclaimed rent to ` +
+            `${destination || 'an address only resolvable via an address lookup table'} instead of your wallet. Refusing to sign.`,
+          );
+        }
+      }
+    } else if (programId === COMPUTE_BUDGET_PROGRAM) {
+      const discriminator = ix.data[0];
+      if (discriminator === COMPUTE_BUDGET_SET_UNIT_LIMIT) {
+        computeUnitLimit = ix.data.readUInt32LE(1);
+      } else if (discriminator === COMPUTE_BUDGET_SET_UNIT_PRICE) {
+        computeUnitPriceMicroLamports = ix.data.readBigUInt64LE(1);
+      }
+    }
+  }
+
+  if (computeUnitPriceMicroLamports != null) {
+    const units = BigInt(computeUnitLimit ?? SOLANA_MAX_COMPUTE_UNITS);
+    const feeLamports = (computeUnitPriceMicroLamports * units) / 1_000_000n;
+    if (feeLamports > MAX_PRIORITY_FEE_LAMPORTS) {
+      throw new Error(
+        `Solana transaction sets an excessive priority fee (~${feeLamports} lamports, cap ${MAX_PRIORITY_FEE_LAMPORTS}). Refusing to sign.`,
+      );
+    }
+  }
+
+  return parsed;
 }

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1130,8 +1130,24 @@ export function assertSwapOutcome(request, quote, sim, { slippage, expectedSpend
  * message — the SPL Token and ComputeBudget programs. It does not, and by
  * design cannot, see instructions a program issues via CPI at runtime, nor
  * does it classify calls to programs it doesn't recognize. It is one layer
- * (paired with the intent-binding metadata check and a balance-delta
- * simulation), not a complete authorization audit of the transaction.
+ * (paired with the intent-binding metadata check), not a complete
+ * authorization audit of the transaction.
+ *
+ * IMPORTANT — no outcome simulation backs this on Solana. Unlike the EVM path,
+ * which pairs its static calldata checks with a balance-delta simulation
+ * (verifySwapOutcome), there is no Solana simulation RPC (SIMULATION_RPCS is
+ * Base-only), so this static check plus the metadata binding are the ONLY
+ * transaction-level guards on the Solana signing path. In particular this
+ * check does NOT classify SPL Transfer/TransferChecked: a legitimate swap or
+ * vault deposit moves the input token (and WSOL) with exactly those
+ * instructions, so they can't be blanket-rejected, and without a balance-delta
+ * simulation there's nothing here to bound their destination or amount. The
+ * consequence is a residual gap: a transaction that also transfers an
+ * unrelated ("sibling") token the wallet holds, authorized by the wallet,
+ * would pass. Closing it needs either a Solana outcome simulation or a positive
+ * check that every wallet-authorized transfer moves only the declared input
+ * mint (TransferChecked carries the mint; plain Transfer does not, so this
+ * needs an RPC account lookup) — tracked as a follow-up, not covered here.
  *
  * Within that scope, the SPL Token program requires the *authority* of
  * Approve/ApproveChecked/SetAuthority/CloseAccount to sign the transaction,

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1165,9 +1165,12 @@ export function assertSolanaInstructionsSafe(txBase64, { walletAddress } = {}) {
       }
     } else if (programId === COMPUTE_BUDGET_PROGRAM) {
       const discriminator = ix.data[0];
-      if (discriminator === COMPUTE_BUDGET_SET_UNIT_LIMIT) {
+      if (discriminator === COMPUTE_BUDGET_SET_UNIT_LIMIT && ix.data.length >= 5) {
         computeUnitLimit = ix.data.readUInt32LE(1);
       } else if (discriminator === COMPUTE_BUDGET_SET_UNIT_PRICE) {
+        if (ix.data.length < 9) {
+          throw new Error('Solana transaction has a malformed compute-budget price instruction. Refusing to sign.');
+        }
         computeUnitPriceMicroLamports = ix.data.readBigUInt64LE(1);
       }
     }

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1126,29 +1126,55 @@ export function assertSwapOutcome(request, quote, sim, { slippage, expectedSpend
  * excessive compute-budget priority fee. Runs before signing, on the raw
  * instructions rather than trusting the aggregator's intent.
  *
- * The SPL Token program requires the *authority* account of Approve/
- * ApproveChecked/SetAuthority/CloseAccount to be a signer of the transaction,
- * so checking "is the authority our own wallet" is both necessary (no other
- * authority could actually get this instruction to execute with our
- * signature) and sufficient — no RPC-based account-ownership lookup needed.
- * Address-lookup-table-resolved accounts can never be signers, so the
- * authority position is always statically resolvable; only CloseAccount's
- * destination can legitimately be ALT-resolved, and an unresolvable
- * destination is treated the same as a stranger (fail closed).
+ * Scope: this inspects only the recognized top-level instructions of the
+ * message — the SPL Token and ComputeBudget programs. It does not, and by
+ * design cannot, see instructions a program issues via CPI at runtime, nor
+ * does it classify calls to programs it doesn't recognize. It is one layer
+ * (paired with the intent-binding metadata check and a balance-delta
+ * simulation), not a complete authorization audit of the transaction.
+ *
+ * Within that scope, the SPL Token program requires the *authority* of
+ * Approve/ApproveChecked/SetAuthority/CloseAccount to sign the transaction,
+ * so checking "does our wallet authorize this instruction" catches the drain
+ * without an RPC-based account-ownership lookup. For a single-owner authority
+ * the wallet sits in the authority position itself; for a multisig authority
+ * the authority account is the multisig and our wallet appears among the
+ * signer accounts that follow it — so we treat the wallet signing *anywhere
+ * from the authority position onward* as authorizing the instruction.
+ * Address-lookup-table-resolved accounts can never be signers, so those
+ * positions are always statically resolvable; only CloseAccount's destination
+ * can legitimately be ALT-resolved, and an unresolvable destination is treated
+ * the same as a stranger (fail closed).
  *
  * Throws on any of those patterns. Returns the parsed transaction otherwise.
  */
 export function assertSolanaInstructionsSafe(txBase64, { walletAddress } = {}) {
-  // Fail closed on a missing wallet address: every authority check below is
-  // `authority === walletAddress`, so a null/undefined address would make each
-  // comparison silently false and disable the drain protection rather than
-  // over-reject. Refuse to run the check without knowing whose signature we're
-  // guarding.
+  // Fail closed on a missing wallet address: every authority check below
+  // compares resolved accounts against `walletAddress`, so a null/undefined
+  // address would make each comparison silently false and disable the drain
+  // protection rather than over-reject. Refuse to run the check without knowing
+  // whose signature we're guarding.
   if (!walletAddress) {
     throw new Error('Cannot verify Solana instruction safety without the signing wallet address. Refusing to sign.');
   }
   const parsed = parseTransactionMessage(txBase64);
   const accountAt = (ix, position) => resolveStaticAccount(parsed, ix.accountIndexes[position]);
+
+  // Does our wallet authorize this SPL instruction? For a single-owner
+  // authority the wallet is at `authorityPos`; for a multisig authority the
+  // authority account is the multisig and our wallet is one of the signer
+  // accounts that follow it. Scanning from `authorityPos` to the end covers
+  // both. Returns true on an unresolvable authority (null): the authority must
+  // be a signer, so it can never legitimately be ALT-resolved — a null means an
+  // out-of-bounds or ALT index there, i.e. a crafted/malformed transaction, and
+  // we fail closed rather than let a silent misparse pass.
+  const walletAuthorizes = (ix, authorityPos) => {
+    if (accountAt(ix, authorityPos) === null) return true;
+    for (let i = authorityPos; i < ix.accountIndexes.length; i++) {
+      if (accountAt(ix, i) === walletAddress) return true;
+    }
+    return false;
+  };
 
   let computeUnitLimit = null;
   let computeUnitPriceMicroLamports = null;
@@ -1158,22 +1184,19 @@ export function assertSolanaInstructionsSafe(txBase64, { walletAddress } = {}) {
     if (!programId) continue; // program invoked via an ALT entry — not a pattern we classify
 
     if (SPL_TOKEN_PROGRAMS.has(programId)) {
+      // No discriminator byte — not a valid SPL Token instruction (the runtime
+      // would reject it too). Skip explicitly so the fail-closed intent doesn't
+      // rest on `undefined` never equalling a discriminant constant.
+      if (ix.data.length === 0) continue;
       const discriminator = ix.data[0];
-      // The authority of these SPL instructions must be a signer, so it can
-      // never legitimately be ALT-resolved — a null here means an out-of-bounds
-      // or ALT index in the authority position, i.e. a crafted/malformed
-      // transaction. Treat null the same as "our wallet" and fail closed rather
-      // than let the `=== walletAddress` comparison silently pass on a misparse.
       if (discriminator === SPL_APPROVE || discriminator === SPL_APPROVE_CHECKED) {
-        const authority = accountAt(ix, discriminator === SPL_APPROVE_CHECKED ? 3 : 2);
-        if (authority === null || authority === walletAddress) {
+        if (walletAuthorizes(ix, discriminator === SPL_APPROVE_CHECKED ? 3 : 2)) {
           throw new Error(
             'Solana transaction grants a token delegate (Approve) authorized by your wallet. Refusing to sign.',
           );
         }
       } else if (discriminator === SPL_SET_AUTHORITY) {
-        const authority = accountAt(ix, 1);
-        if (authority === null || authority === walletAddress) {
+        if (walletAuthorizes(ix, 1)) {
           throw new Error(
             "Solana transaction changes a token account's authority (SetAuthority) using your wallet's signature. Refusing to sign.",
           );
@@ -1181,7 +1204,10 @@ export function assertSolanaInstructionsSafe(txBase64, { walletAddress } = {}) {
       } else if (discriminator === SPL_CLOSE_ACCOUNT) {
         const authority = accountAt(ix, 2);
         const destination = accountAt(ix, 1);
-        if (authority === null || (authority === walletAddress && destination !== walletAddress)) {
+        // Fail closed on an unresolvable authority regardless of destination;
+        // otherwise reject only when our wallet authorizes the close and the
+        // rent goes anywhere but back to us.
+        if (authority === null || (walletAuthorizes(ix, 2) && destination !== walletAddress)) {
           throw new Error(
             `Solana transaction closes a token account and sends the reclaimed rent to ` +
             `${destination || 'an address only resolvable via an address lookup table'} instead of your wallet. Refusing to sign.`,
@@ -1189,6 +1215,7 @@ export function assertSolanaInstructionsSafe(txBase64, { walletAddress } = {}) {
         }
       }
     } else if (programId === COMPUTE_BUDGET_PROGRAM) {
+      if (ix.data.length === 0) continue; // no discriminator — not a valid ComputeBudget instruction
       const discriminator = ix.data[0];
       if (discriminator === COMPUTE_BUDGET_SET_UNIT_LIMIT && ix.data.length >= 5) {
         computeUnitLimit = ix.data.readUInt32LE(1);

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1147,16 +1147,21 @@ export function assertSolanaInstructionsSafe(txBase64, { walletAddress } = {}) {
 
     if (SPL_TOKEN_PROGRAMS.has(programId)) {
       const discriminator = ix.data[0];
+      // The authority of these SPL instructions must be a signer, so it can
+      // never legitimately be ALT-resolved — a null here means an out-of-bounds
+      // or ALT index in the authority position, i.e. a crafted/malformed
+      // transaction. Treat null the same as "our wallet" and fail closed rather
+      // than let the `=== walletAddress` comparison silently pass on a misparse.
       if (discriminator === SPL_APPROVE || discriminator === SPL_APPROVE_CHECKED) {
         const authority = accountAt(ix, discriminator === SPL_APPROVE_CHECKED ? 3 : 2);
-        if (authority === walletAddress) {
+        if (authority === null || authority === walletAddress) {
           throw new Error(
             'Solana transaction grants a token delegate (Approve) authorized by your wallet. Refusing to sign.',
           );
         }
       } else if (discriminator === SPL_SET_AUTHORITY) {
         const authority = accountAt(ix, 1);
-        if (authority === walletAddress) {
+        if (authority === null || authority === walletAddress) {
           throw new Error(
             "Solana transaction changes a token account's authority (SetAuthority) using your wallet's signature. Refusing to sign.",
           );
@@ -1164,7 +1169,7 @@ export function assertSolanaInstructionsSafe(txBase64, { walletAddress } = {}) {
       } else if (discriminator === SPL_CLOSE_ACCOUNT) {
         const authority = accountAt(ix, 2);
         const destination = accountAt(ix, 1);
-        if (authority === walletAddress && destination !== walletAddress) {
+        if (authority === null || (authority === walletAddress && destination !== walletAddress)) {
           throw new Error(
             `Solana transaction closes a token account and sends the reclaimed rent to ` +
             `${destination || 'an address only resolvable via an address lookup table'} instead of your wallet. Refusing to sign.`,

--- a/src/trading.js
+++ b/src/trading.js
@@ -13,7 +13,7 @@ import { base58Decode } from './transfer.js';
 import { keccak256, signSecp256k1, rlpEncode } from './crypto.js';
 import { getWalletConnectAddress, sendTransactionViaWalletConnect, sendSolanaTransactionViaWalletConnect, sendApprovalViaWalletConnect } from './walletconnect-trading.js';
 import { retrievePassword } from './keychain.js';
-import { validateQuoteInput, validateBalance, resolvePercentAmount, validateGasBalance, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertSwapCalldataNotBareTransfer, assertSwapOutcome, approvalAmountForSwap, needsAllowanceRevoke, OVERSIZED_ALLOWANCE_MULTIPLIER } from './trade-validation.js';
+import { validateQuoteInput, validateBalance, resolvePercentAmount, validateGasBalance, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, approvalAmountForSwap, needsAllowanceRevoke, OVERSIZED_ALLOWANCE_MULTIPLIER } from './trade-validation.js';
 import { CHAIN_RPCS } from './rpc-urls.js';
 import { simulateAssetChanges, SwapSimulationError, hasSimulationRpc } from './swap-simulation.js';
 import { packageVersion, CommandError, telemetryHeaders, loadConfig } from './api.js';
@@ -2141,9 +2141,16 @@ EXAMPLES:
               if (typeof txBase64 === 'object' && txBase64.data) {
                 txBase64 = base58Decode(txBase64.data).toString('base64');
               }
-              log('  Signing Solana transaction via Privy...');
               const solWalletId = quoteData.privyWalletIds?.solana;
               if (!solWalletId) throw new Error('No Solana Privy wallet ID in quote');
+              const privySolWallet = await privyClient.getWallet(solWalletId);
+
+              // Static instruction check ahead of signing — catches a delegate
+              // grant, authority change, close-to-stranger, or excessive fee that
+              // a balance-delta simulation alone wouldn't see.
+              assertSolanaInstructionsSafe(txBase64, { walletAddress: privySolWallet.address });
+
+              log('  Signing Solana transaction via Privy...');
               const signResult = await privyClient.signSolanaTransaction(solWalletId, txBase64);
               signedTransaction = signResult.data?.signed_transaction || signResult.signed_transaction;
               requestId = currentQuote.metadata?.requestId;
@@ -2410,16 +2417,22 @@ EXAMPLES:
             } else if (chainType === 'solana') {
               // NB: validateSwapTarget (the EVM `to`/`data` guard) intentionally does
               // not apply here — Solana quotes are a pre-built serialized
-              // VersionedTransaction with no `to`/`data`/approval split to validate,
-              // and this path (including the WalletConnect sub-branch below) signs it
-              // as supplied. Deeper Solana inspection (e.g. checking instruction
-              // program IDs) is tracked as a follow-up, not an oversight.
+              // VersionedTransaction with no `to`/`data`/approval split to validate.
               // Solana: transaction is either a base64 string (Jupiter) or an object
               // with a base58-encoded `data` field (OKX). Normalize to base64.
               let txBase64 = currentQuote.transaction;
               if (typeof txBase64 === 'object' && txBase64.data) {
                 txBase64 = base58Decode(txBase64.data).toString('base64');
               }
+
+              const solanaWalletAddress = isWalletConnect ? await getWalletConnectAddress(chainType) : exported.solana.address;
+              if (!solanaWalletAddress) {
+                throw new CommandError('WalletConnect session lost during execute. Reconnect with `walletconnect connect` and retry.', 'NO_WALLET');
+              }
+              // Static instruction check ahead of signing — catches a delegate
+              // grant, authority change, close-to-stranger, or excessive fee that
+              // a balance-delta simulation alone wouldn't see.
+              assertSolanaInstructionsSafe(txBase64, { walletAddress: solanaWalletAddress });
 
               if (isWalletConnect) {
                 // Solana via WalletConnect: convert base64 → base58 for WC protocol

--- a/src/trading.js
+++ b/src/trading.js
@@ -2172,7 +2172,10 @@ EXAMPLES:
               // Then statically inspect the serialized transaction's own
               // instructions ahead of signing — catches a delegate grant, authority
               // change, close-to-stranger, or excessive fee that the metadata check
-              // and a balance-delta simulation alone wouldn't see.
+              // alone wouldn't see. Solana has no balance-delta simulation (that
+              // layer is Base-only), so this static check plus the metadata binding
+              // are the only transaction-level guards here — see
+              // assertSolanaInstructionsSafe for the residual sibling-transfer gap.
               assertSolanaInstructionsSafe(txBase64, { walletAddress });
 
               log('  Signing Solana transaction via Privy...');
@@ -2479,7 +2482,10 @@ EXAMPLES:
               // Then statically inspect the serialized transaction's own
               // instructions ahead of signing — catches a delegate grant, authority
               // change, close-to-stranger, or excessive fee that the metadata check
-              // and a balance-delta simulation alone wouldn't see.
+              // alone wouldn't see. Solana has no balance-delta simulation (that
+              // layer is Base-only), so this static check plus the metadata binding
+              // are the only transaction-level guards here — see
+              // assertSolanaInstructionsSafe for the residual sibling-transfer gap.
               assertSolanaInstructionsSafe(txBase64, { walletAddress: solanaWalletAddress });
 
               if (isWalletConnect) {

--- a/src/trading.js
+++ b/src/trading.js
@@ -14,6 +14,8 @@ import { keccak256, signSecp256k1, rlpEncode } from './crypto.js';
 import { getWalletConnectAddress, sendTransactionViaWalletConnect, sendSolanaTransactionViaWalletConnect, sendApprovalViaWalletConnect } from './walletconnect-trading.js';
 import { retrievePassword } from './keychain.js';
 import { validateQuoteInput, validateBalance, resolvePercentAmount, validateGasBalance, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, approvalAmountForSwap, needsAllowanceRevoke, OVERSIZED_ALLOWANCE_MULTIPLIER } from './trade-validation.js';
+import { readCompactU16 } from './solana-tx.js';
+export { readCompactU16 };
 import { CHAIN_RPCS } from './rpc-urls.js';
 import { simulateAssetChanges, SwapSimulationError, hasSimulationRpc } from './swap-simulation.js';
 import { packageVersion, CommandError, telemetryHeaders, loadConfig } from './api.js';
@@ -1257,23 +1259,6 @@ function rlpNormalize(val) {
   return toBuffer(val);
 }
 
-// ============= Compact-u16 (Solana) =============
-
-/**
- * Read a compact-u16 from a buffer (Solana transaction format).
- */
-export function readCompactU16(buf, offset) {
-  let value = 0;
-  let size = 0;
-  for (let i = 0; i < 3; i++) {
-    const byte = buf[offset + i];
-    value |= (byte & 0x7f) << (7 * i);
-    size++;
-    if ((byte & 0x80) === 0) break;
-  }
-  return { value, size };
-}
-
 // ============= Chain Utilities =============
 
 /**
@@ -2143,12 +2128,18 @@ EXAMPLES:
               }
               const solWalletId = quoteData.privyWalletIds?.solana;
               if (!solWalletId) throw new Error('No Solana Privy wallet ID in quote');
-              const privySolWallet = await privyClient.getWallet(solWalletId);
+
+              // The signing wallet address was already resolved and persisted at
+              // quote time; prefer it over a fresh getWallet round-trip on the hot
+              // path. Fall back to getWallet only for older quote files that
+              // predate the persisted request.walletAddress field.
+              const solSignerAddress = quoteData.request?.walletAddress
+                ?? (await privyClient.getWallet(solWalletId)).address;
 
               // Static instruction check ahead of signing — catches a delegate
               // grant, authority change, close-to-stranger, or excessive fee that
               // a balance-delta simulation alone wouldn't see.
-              assertSolanaInstructionsSafe(txBase64, { walletAddress: privySolWallet.address });
+              assertSolanaInstructionsSafe(txBase64, { walletAddress: solSignerAddress });
 
               log('  Signing Solana transaction via Privy...');
               const signResult = await privyClient.signSolanaTransaction(solWalletId, txBase64);
@@ -2427,7 +2418,12 @@ EXAMPLES:
 
               const solanaWalletAddress = isWalletConnect ? await getWalletConnectAddress(chainType) : exported.solana.address;
               if (!solanaWalletAddress) {
-                throw new CommandError('WalletConnect session lost during execute. Reconnect with `walletconnect connect` and retry.', 'NO_WALLET');
+                throw new CommandError(
+                  isWalletConnect
+                    ? 'WalletConnect session lost during execute. Reconnect with `walletconnect connect` and retry.'
+                    : 'No Solana address on this wallet. Run: nansen wallet show',
+                  'NO_WALLET',
+                );
               }
               // Static instruction check ahead of signing — catches a delegate
               // grant, authority change, close-to-stranger, or excessive fee that


### PR DESCRIPTION
## Summary

- All three Solana `trade execute` paths (Privy, local, WalletConnect) sign whatever transaction an aggregator quote returns with zero inspection of what the instructions actually authorize. A wrong-pair/inflated-amount check alone doesn't catch a token delegate grant, an authority change, or an account close that redirects rent to a stranger — none of which show up as a simple balance discrepancy, and all of which fully execute once signed.
- Adds a parser for Solana's legacy/v0 transaction wire format (`src/solana-tx.js`) and a static safety check (`assertSolanaInstructionsSafe`) wired into all three execute paths ahead of signing.
- The SPL Token program requires the authority of `Approve`/`SetAuthority`/`CloseAccount` to be a signer of the transaction, so checking whether that authority resolves to the wallet about to sign is both necessary and sufficient to catch these patterns — no RPC-based account-ownership lookup needed.
- Also caps an excessive compute-budget priority fee (assumes the max per-transaction compute-unit ceiling when a price is set with no explicit limit).

This is one piece of broader Solana signing hardening (intent-binding is a separate, already-open PR) — scoped here to the static instruction-safety checks specifically.

## Test plan

- [x] `npm test` — new parser round-trip tests, static-check unit tests (delegate grant, authority change, close-to-stranger vs close-to-self, excessive fee vs modest fee, ALT-unresolvable destination treated as unsafe), and an execute-path integration test proving a crafted close-to-stranger transaction is rejected before signing or broadcasting.
- [x] `npm run lint`
- [x] Sanity-checked against real, live Solana quotes (read-only `trade quote`, no signing/broadcast) to confirm no false positives on legitimate swaps — one of them genuinely exercises the `CloseAccount` check via its WSOL-unwrap step and correctly passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)