### PR TITLE
Fix cross-chain bridges into native SOL being refused at signing

### DIFF
--- a/.changeset/solana-native-token-equivalence.md
+++ b/.changeset/solana-native-token-equivalence.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix cross-chain bridges into native SOL being refused at execute time. The quote/intent binding compared the wrapped-SOL mint (how `--to SOL` resolves) against the System Program address that aggregators use as the native-SOL sentinel and rejected them as different tokens. Both spellings are now treated as the same asset.

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -1316,6 +1316,30 @@ describe('assertQuoteMatchesRequest', () => {
     const mangled = { ...q, outputMint: SOL_TOKEN.toLowerCase() };
     expect(() => assertQuoteMatchesRequest(xchain, mangled, { chain: 'base' })).toThrow(/buy token .* does not match/i);
   });
+
+  it('treats the two native-SOL spellings as the same asset (cross-chain destination)', () => {
+    // Regression: `--to SOL` resolves to the wrapped-SOL mint (stored as the
+    // request intent), but a Relay bridge quote names native SOL as the System
+    // Program sentinel. They are the same asset and must not be rejected as a
+    // token mismatch, which previously blocked every bridge into native SOL.
+    const WSOL = 'So11111111111111111111111111111111111111112';
+    const NATIVE_SOL_SENTINEL = '11111111111111111111111111111111';
+    const USDC_SOL = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+    const xchain = {
+      chain: 'base', toChain: 'solana', walletAddress: '0xWallet',
+      fromToken: USDC, toToken: WSOL, swapMode: 'exactIn', amount: '1000000',
+    };
+    const q = { inputMint: USDC, outputMint: NATIVE_SOL_SENTINEL, inputAmount: '1000000', inAmount: '1000000' };
+    // WSOL requested, native-sentinel delivered — same asset, passes.
+    expect(() => assertQuoteMatchesRequest(xchain, q, { chain: 'base' })).not.toThrow();
+    // Reverse spelling (sentinel requested, WSOL delivered) also passes.
+    const xchain2 = { ...xchain, toToken: NATIVE_SOL_SENTINEL };
+    const q2 = { ...q, outputMint: WSOL };
+    expect(() => assertQuoteMatchesRequest(xchain2, q2, { chain: 'base' })).not.toThrow();
+    // A genuinely different Solana token is still rejected.
+    const qBad = { ...q, outputMint: USDC_SOL };
+    expect(() => assertQuoteMatchesRequest(xchain, qBad, { chain: 'base' })).toThrow(/buy token .* does not match/i);
+  });
 });
 
 describe('assertInputWithinMax', () => {

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -122,6 +122,17 @@ const NATIVE_TOKEN_ADDRESSES = {
   base: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
 };
 
+// Native SOL has two on-chain spellings that denote the same asset: the
+// canonical wrapped-SOL mint (what the CLI resolves `SOL` to and persists as
+// the request intent) and the System Program address that aggregators and
+// bridges (e.g. Relay) use as the native-lamport sentinel in their quotes.
+// tokensEqual treats them as equivalent so the intent-binding check doesn't
+// false-reject a legitimate quote that names native SOL the other way.
+const SOLANA_NATIVE_SOL_ALIASES = new Set([
+  'So11111111111111111111111111111111111111112', // wrapped SOL mint
+  '11111111111111111111111111111111', // System Program — native SOL sentinel
+]);
+
 // USDC contract addresses per chain.
 const USDC_ADDRESSES = {
   solana: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
@@ -571,7 +582,11 @@ export function needsAllowanceRevoke(existingAllowance, approveAmt) {
  */
 function tokensEqual(a, b, chain) {
   if (!a || !b) return false;
-  if (chain === 'solana') return a === b;
+  if (chain === 'solana') {
+    // Both sides naming native SOL (in either spelling) is a match.
+    if (SOLANA_NATIVE_SOL_ALIASES.has(a) && SOLANA_NATIVE_SOL_ALIASES.has(b)) return true;
+    return a === b;
+  }
   return a.toLowerCase() === b.toLowerCase();
 }
 


### PR DESCRIPTION
## Summary

Cross-chain bridges into native SOL (e.g. `trade execute` for a Base → Solana quote) are refused at execute time with a spurious token-mismatch error:

```
Quote buy token (11111111111111111111111111111111) does not match the requested token (So11111111111111111111111111111111111111112). Refusing to sign.
```

`--to SOL` resolves to the **wrapped-SOL mint** (`So1…112`, persisted as the request intent), but aggregators/bridges (e.g. Relay) name native SOL as the **System Program sentinel** (`111…111`) in their quotes. The quote/intent binding compared them with strict equality on Solana and rejected the pair as different tokens.

This is a regression introduced by the earlier swap-signing hardening that added `assertQuoteMatchesRequest` — before that there was no token-match guard and these bridges signed fine.

## Fix

`tokensEqual` now treats the wrapped-SOL mint and the System Program sentinel as the same asset for Solana, while still rejecting genuinely different tokens. Scoped to native SOL; EVM comparison is unchanged.

## Blast radius

Currently only the EVM cross-chain execute path calls `assertQuoteMatchesRequest`, so that's where the bug manifests today. The same gap would also bite same-chain Solana SOL swaps once the intent binding is wired into the Solana execute path, so this fix is a prerequisite for that work.

## Test plan

- [x] `npm test` — new regression test in `assertQuoteMatchesRequest`: WSOL-requested/sentinel-delivered (and the reverse) pass; a genuinely different Solana token still throws.
- [x] `npm run lint`
- [ ] E2E: real Base → SOL bridge round-trip (the path that surfaced this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)