### PR TITLE
Verify Solana swap outcome via balance-delta simulation before signing

### DIFF
--- a/.changeset/solana-swap-outcome-simulation.md
+++ b/.changeset/solana-swap-outcome-simulation.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Verify a Solana swap's simulated on-chain outcome before signing (local, Privy, and WalletConnect wallets), mirroring the existing EVM balance-delta check. The CLI simulates the aggregator's transaction and confirms the wallet's balance changes match the quote — input spent within your max, expected output received, no other asset drained — refusing to sign on a mismatch or an in-simulation revert. Covered by the existing `--no-verify-outcome` flag; degrades with a warning (and still signs) when no simulation-capable RPC is available, so an RPC outage never blocks a trade. New env var: `NANSEN_SOLANA_SIM_RPC`.

--- a/src/__tests__/solana-simulation.test.js
+++ b/src/__tests__/solana-simulation.test.js
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SIMULATION_RPCS } from '../rpc-urls.js';
+import { generateSolanaWallet, base58Decode } from '../wallet.js';
+import {
+  simulateSolanaAssetChanges,
+  SolanaSimulationError,
+  hasSolanaSimulationRpc,
+  SOL_SENTINEL,
+} from '../solana-simulation.js';
+
+const TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+const WSOL_MINT = 'So11111111111111111111111111111111111111112';
+
+// Same hand-rolled builder as solana-tx.test.js, kept independent of
+// solana-tx.js so these fixtures aren't verified against the code under test.
+function encodeCompactU16(value) {
+  if (value < 0x80) return Buffer.from([value]);
+  if (value < 0x4000) return Buffer.from([(value & 0x7f) | 0x80, (value >> 7) & 0x7f]);
+  return Buffer.from([(value & 0x7f) | 0x80, ((value >> 7) & 0x7f) | 0x80, (value >> 14) & 0x03]);
+}
+
+function buildMessageBytes({ versioned, accountKeys, header, recentBlockhash, instructions = [], addressTableLookups = [] }) {
+  const parts = [];
+  if (versioned) parts.push(Buffer.from([0x80]));
+  parts.push(Buffer.from([header.numRequiredSignatures, header.numReadonlySignedAccounts, header.numReadonlyUnsignedAccounts]));
+  parts.push(encodeCompactU16(accountKeys.length));
+  for (const k of accountKeys) parts.push(base58Decode(k));
+  parts.push(base58Decode(recentBlockhash));
+  parts.push(encodeCompactU16(instructions.length));
+  for (const ix of instructions) {
+    parts.push(Buffer.from([ix.programIdIndex]));
+    parts.push(encodeCompactU16(ix.accountIndexes.length));
+    for (const idx of ix.accountIndexes) parts.push(Buffer.from([idx]));
+    parts.push(encodeCompactU16(ix.data.length));
+    parts.push(ix.data);
+  }
+  if (versioned) {
+    parts.push(encodeCompactU16(addressTableLookups.length));
+    for (const alt of addressTableLookups) {
+      parts.push(base58Decode(alt.lookupTableAddress));
+      parts.push(encodeCompactU16(alt.writableIndexes.length));
+      for (const idx of alt.writableIndexes) parts.push(Buffer.from([idx]));
+      parts.push(encodeCompactU16(alt.readonlyIndexes.length));
+      for (const idx of alt.readonlyIndexes) parts.push(Buffer.from([idx]));
+    }
+  }
+  return Buffer.concat(parts);
+}
+
+function wrapTransaction(messageBytes, numSignatures = 1) {
+  return Buffer.concat([encodeCompactU16(numSignatures), Buffer.alloc(numSignatures * 64), messageBytes]).toString('base64');
+}
+
+// A minimal single-instruction legacy tx: [wallet (signer, writable), tokenAccount
+// (writable), programId (readonly)]. The instruction contents don't matter —
+// simulation only cares about the accounts snapshot, not what the tx does.
+function buildLegacyTx({ wallet, extraWritableKeys = [], readonlyKeys = [] }) {
+  const programId = generateSolanaWallet().address;
+  const recentBlockhash = generateSolanaWallet().address;
+  const accountKeys = [wallet, ...extraWritableKeys, ...readonlyKeys, programId];
+  const messageBytes = buildMessageBytes({
+    versioned: false,
+    accountKeys,
+    header: {
+      numRequiredSignatures: 1,
+      numReadonlySignedAccounts: 0,
+      numReadonlyUnsignedAccounts: readonlyKeys.length + 1, // + programId
+    },
+    recentBlockhash,
+    instructions: [{ programIdIndex: accountKeys.length - 1, accountIndexes: [0], data: Buffer.from([0x01]) }],
+  });
+  return wrapTransaction(messageBytes);
+}
+
+function nativeAccountInfo(lamports) {
+  return { lamports, owner: '11111111111111111111111111111111', data: ['', 'base64'], executable: false, rentEpoch: 0 };
+}
+
+function tokenAccountInfo({ mint, owner, amount }) {
+  return {
+    lamports: 2039280,
+    owner: TOKEN_PROGRAM,
+    data: { program: 'spl-token', parsed: { type: 'account', info: { mint, owner, tokenAmount: { amount: String(amount), decimals: 6 } } } },
+    executable: false,
+    rentEpoch: 0,
+  };
+}
+
+function jsonRpcResponse(result) {
+  return { ok: true, status: 200, text: async () => JSON.stringify({ jsonrpc: '2.0', id: 1, result }) };
+}
+
+/**
+ * Mock the Solana simulation RPC. `trackedAccounts`/`altAccounts` key raw
+ * account infos by pubkey; `simValue(params)` builds the simulateTransaction
+ * result from the actual request params (so tests can assert on
+ * replaceRecentBlockhash / the accounts list it was asked to snapshot).
+ */
+function mockSolanaRpc({ trackedAccounts = {}, altAccounts = {}, simValue, onRequest } = {}) {
+  return vi.fn().mockImplementation(async (url, opts) => {
+    const body = JSON.parse(opts.body);
+    onRequest?.(body);
+    if (body.method === 'getMultipleAccounts') {
+      const [pubkeys, rpcOpts] = body.params;
+      const table = rpcOpts.encoding === 'base64' ? altAccounts : trackedAccounts;
+      return jsonRpcResponse({ value: pubkeys.map((pk) => table[pk] ?? null) });
+    }
+    if (body.method === 'simulateTransaction') {
+      return jsonRpcResponse(simValue(body.params));
+    }
+    throw new Error(`solana-simulation.test.js: unhandled RPC method ${body.method}`);
+  });
+}
+
+describe('solana-simulation', () => {
+  let originalSolanaRpc;
+  beforeEach(() => {
+    originalSolanaRpc = SIMULATION_RPCS.solana;
+    SIMULATION_RPCS.solana = 'http://sol-sim.test';
+  });
+  afterEach(() => {
+    SIMULATION_RPCS.solana = originalSolanaRpc;
+    vi.unstubAllGlobals();
+  });
+
+  describe('hasSolanaSimulationRpc', () => {
+    it('is true for solana when an endpoint is configured', () => {
+      expect(hasSolanaSimulationRpc('solana')).toBe(true);
+    });
+    it('is false when no endpoint is configured', () => {
+      SIMULATION_RPCS.solana = null;
+      expect(hasSolanaSimulationRpc('solana')).toBe(false);
+    });
+    it('is false for a non-solana chain', () => {
+      expect(hasSolanaSimulationRpc('base')).toBe(false);
+    });
+  });
+
+  it('throws a SolanaSimulationError with code NO_SIM_RPC when no endpoint is configured', async () => {
+    SIMULATION_RPCS.solana = null;
+    await expect(simulateSolanaAssetChanges('solana', 'AA==', { walletAddress: 'x' }))
+      .rejects.toBeInstanceOf(SolanaSimulationError);
+    await expect(simulateSolanaAssetChanges('solana', 'AA==', { walletAddress: 'x' }))
+      .rejects.toMatchObject({ code: 'NO_SIM_RPC' });
+  });
+
+  it('benign Jupiter native-in fixture: folds a WSOL leg into the native SOL bucket', async () => {
+    const wallet = generateSolanaWallet().address;
+    const wsolAccount = generateSolanaWallet().address;
+    const usdcAccount = generateSolanaWallet().address;
+    const usdcMint = generateSolanaWallet().address;
+    const txBase64 = buildLegacyTx({ wallet, extraWritableKeys: [wsolAccount, usdcAccount] });
+
+    vi.stubGlobal('fetch', mockSolanaRpc({
+      trackedAccounts: {
+        [wallet]: nativeAccountInfo(10_000_000_000),
+        [wsolAccount]: tokenAccountInfo({ mint: WSOL_MINT, owner: wallet, amount: 0 }),
+        [usdcAccount]: tokenAccountInfo({ mint: usdcMint, owner: wallet, amount: 100_000_000 }),
+      },
+      simValue: (params) => {
+        const addrs = params[1].accounts.addresses;
+        const post = {
+          [wallet]: nativeAccountInfo(8_995_000_000), // paid 1 SOL input + ~5000 lamports fee
+          [wsolAccount]: tokenAccountInfo({ mint: WSOL_MINT, owner: wallet, amount: 5000 }), // unwrap left dust
+          [usdcAccount]: tokenAccountInfo({ mint: usdcMint, owner: wallet, amount: 150_000_000 }),
+        };
+        return { value: { err: null, accounts: addrs.map((a) => post[a]) } };
+      },
+    }));
+
+    const result = await simulateSolanaAssetChanges('solana', txBase64, { walletAddress: wallet });
+    expect(result.method).toBe('simulateTransaction');
+    // -1,005,000,000 (native) + 5,000 (WSOL dust) folded into one SOL_SENTINEL bucket
+    expect(result.deltas[SOL_SENTINEL]).toBe(-1_004_995_000n);
+    expect(result.deltas[usdcMint]).toBe(50_000_000n);
+    expect(result.deltas[WSOL_MINT]).toBeUndefined(); // folded, not reported separately
+  });
+
+  it('OKX SPL-token-in fixture: reports a clean token delta alongside native', async () => {
+    const wallet = generateSolanaWallet().address;
+    const usdtAccount = generateSolanaWallet().address;
+    const usdtMint = generateSolanaWallet().address;
+    const txBase64 = buildLegacyTx({ wallet, extraWritableKeys: [usdtAccount] });
+
+    vi.stubGlobal('fetch', mockSolanaRpc({
+      trackedAccounts: {
+        [wallet]: nativeAccountInfo(2_000_000_000),
+        [usdtAccount]: tokenAccountInfo({ mint: usdtMint, owner: wallet, amount: 1_000_000_000 }),
+      },
+      simValue: (params) => {
+        const addrs = params[1].accounts.addresses;
+        const post = {
+          [wallet]: nativeAccountInfo(2_002_000_000), // received native output + reclaimed rent, minus fee
+          [usdtAccount]: tokenAccountInfo({ mint: usdtMint, owner: wallet, amount: 0 }), // fully spent
+        };
+        return { value: { err: null, accounts: addrs.map((a) => post[a]) } };
+      },
+    }));
+
+    const result = await simulateSolanaAssetChanges('solana', txBase64, { walletAddress: wallet });
+    expect(result.deltas[usdtMint]).toBe(-1_000_000_000n);
+    expect(result.deltas[SOL_SENTINEL]).toBe(2_000_000n);
+  });
+
+  it('resolves a tracked account that lives only in an address-lookup table (v0 tx)', async () => {
+    const wallet = generateSolanaWallet().address;
+    const programId = generateSolanaWallet().address;
+    const recentBlockhash = generateSolanaWallet().address;
+    const altAddress = generateSolanaWallet().address;
+    const altTokenAccount = generateSolanaWallet().address;
+    const mint = generateSolanaWallet().address;
+
+    // ALT-writable index 3 resolves to altTokenAccount; earlier slots are filler.
+    const altAddresses = [generateSolanaWallet().address, generateSolanaWallet().address, generateSolanaWallet().address, altTokenAccount];
+    const altTableData = Buffer.concat([Buffer.alloc(56), ...altAddresses.map((a) => base58Decode(a))]).toString('base64');
+
+    const messageBytes = buildMessageBytes({
+      versioned: true,
+      accountKeys: [wallet, programId],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 1 },
+      recentBlockhash,
+      instructions: [{ programIdIndex: 1, accountIndexes: [0, 2], data: Buffer.from([0x01]) }],
+      addressTableLookups: [{ lookupTableAddress: altAddress, writableIndexes: [3], readonlyIndexes: [] }],
+    });
+    const txBase64 = wrapTransaction(messageBytes);
+
+    vi.stubGlobal('fetch', mockSolanaRpc({
+      altAccounts: { [altAddress]: { data: [altTableData, 'base64'], owner: 'AddressLookupTab1e1111111111111111111111', lamports: 1 } },
+      trackedAccounts: {
+        [wallet]: nativeAccountInfo(1_000_000_000),
+        [altTokenAccount]: tokenAccountInfo({ mint, owner: wallet, amount: 500 }),
+      },
+      simValue: (params) => {
+        const addrs = params[1].accounts.addresses;
+        const post = {
+          [wallet]: nativeAccountInfo(999_995_000),
+          [altTokenAccount]: tokenAccountInfo({ mint, owner: wallet, amount: 700 }),
+        };
+        return { value: { err: null, accounts: addrs.map((a) => post[a]) } };
+      },
+    }));
+
+    const result = await simulateSolanaAssetChanges('solana', txBase64, { walletAddress: wallet });
+    expect(result.deltas[mint]).toBe(200n);
+  });
+
+  it('throws SIM_REVERTED when the simulated transaction errors', async () => {
+    const wallet = generateSolanaWallet().address;
+    const txBase64 = buildLegacyTx({ wallet });
+
+    vi.stubGlobal('fetch', mockSolanaRpc({
+      trackedAccounts: { [wallet]: nativeAccountInfo(1_000_000_000) },
+      simValue: () => ({ value: { err: { InstructionError: [0, 'Custom'] }, accounts: null } }),
+    }));
+
+    await expect(simulateSolanaAssetChanges('solana', txBase64, { walletAddress: wallet }))
+      .rejects.toMatchObject({ code: 'SIM_REVERTED' });
+  });
+
+  it('surfaces a transport failure as SIM_RPC_ERROR (degrade)', async () => {
+    const wallet = generateSolanaWallet().address;
+    const txBase64 = buildLegacyTx({ wallet });
+
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+
+    await expect(simulateSolanaAssetChanges('solana', txBase64, { walletAddress: wallet }))
+      .rejects.toMatchObject({ code: 'SIM_RPC_ERROR' });
+  });
+
+  it('always sends replaceRecentBlockhash:true (the quote blockhash is stale by execute)', async () => {
+    const wallet = generateSolanaWallet().address;
+    const txBase64 = buildLegacyTx({ wallet });
+    let capturedOptions;
+
+    vi.stubGlobal('fetch', mockSolanaRpc({
+      trackedAccounts: { [wallet]: nativeAccountInfo(1_000_000_000) },
+      onRequest: (body) => { if (body.method === 'simulateTransaction') capturedOptions = body.params[1]; },
+      simValue: (params) => {
+        const addrs = params[1].accounts.addresses;
+        return { value: { err: null, accounts: addrs.map(() => nativeAccountInfo(1_000_000_000)) } };
+      },
+    }));
+
+    await simulateSolanaAssetChanges('solana', txBase64, { walletAddress: wallet });
+    expect(capturedOptions.replaceRecentBlockhash).toBe(true);
+    expect(capturedOptions.sigVerify).toBe(false);
+  });
+
+  it('fails closed when the signer wallet cannot be resolved as a writable account', async () => {
+    const wallet = generateSolanaWallet().address;
+    const someoneElse = generateSolanaWallet().address;
+    const txBase64 = buildLegacyTx({ wallet: someoneElse });
+
+    vi.stubGlobal('fetch', mockSolanaRpc({
+      trackedAccounts: { [someoneElse]: nativeAccountInfo(1_000_000_000) },
+      simValue: () => ({ value: { err: null, accounts: [] } }),
+    }));
+
+    await expect(simulateSolanaAssetChanges('solana', txBase64, { walletAddress: wallet }))
+      .rejects.toMatchObject({ code: 'SIM_RESULT_UNPARSEABLE' });
+  });
+});

--- a/src/__tests__/solana-simulation.test.js
+++ b/src/__tests__/solana-simulation.test.js
@@ -386,6 +386,24 @@ describe('solana-simulation', () => {
       .rejects.toMatchObject({ code: 'SIM_RPC_ERROR' });
   });
 
+  it('degrades as SIM_RPC_ERROR when getMultipleAccounts returns a null value array (RPC capability gap)', async () => {
+    // regression: a spec-violating 200 OK with `value: null` (a rate-limited
+    // or malfunctioning node) must degrade like any other transport failure,
+    // not silently become an empty array that starves preAccountInfos and
+    // fails closed as SIM_RESULT_UNPARSEABLE (blocking a legitimate trade).
+    const wallet = generateSolanaWallet().address;
+    const txBase64 = buildLegacyTx({ wallet });
+
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async (url, opts) => {
+      const body = JSON.parse(opts.body);
+      if (body.method === 'getMultipleAccounts') return jsonRpcResponse({ value: null });
+      throw new Error(`solana-simulation.test.js: unexpected RPC method ${body.method}`);
+    }));
+
+    await expect(simulateSolanaAssetChanges('solana', txBase64, { walletAddress: wallet }))
+      .rejects.toMatchObject({ code: 'SIM_RPC_ERROR' });
+  });
+
   it('always sends replaceRecentBlockhash:true (the quote blockhash is stale by execute)', async () => {
     const wallet = generateSolanaWallet().address;
     const txBase64 = buildLegacyTx({ wallet });

--- a/src/__tests__/solana-simulation.test.js
+++ b/src/__tests__/solana-simulation.test.js
@@ -324,6 +324,23 @@ describe('solana-simulation', () => {
       .rejects.toMatchObject({ code: 'SIM_RPC_ERROR' });
   });
 
+  it('degrades as SIM_RPC_ERROR when a 200 OK sim omits the accounts array (RPC capability gap, not a corrupt result)', async () => {
+    // regression: a node that accepts `accounts` but doesn't honor it returns
+    // err: null with no accounts data — this must degrade (warn + proceed),
+    // not fail closed as SIM_RESULT_UNPARSEABLE, since SIMULATION_RPCS.solana
+    // defaults to a public endpoint that can behave this way under load.
+    const wallet = generateSolanaWallet().address;
+    const txBase64 = buildLegacyTx({ wallet });
+
+    vi.stubGlobal('fetch', mockSolanaRpc({
+      trackedAccounts: { [wallet]: nativeAccountInfo(1_000_000_000) },
+      simValue: () => ({ value: { err: null, accounts: null } }),
+    }));
+
+    await expect(simulateSolanaAssetChanges('solana', txBase64, { walletAddress: wallet }))
+      .rejects.toMatchObject({ code: 'SIM_RPC_ERROR' });
+  });
+
   it('always sends replaceRecentBlockhash:true (the quote blockhash is stale by execute)', async () => {
     const wallet = generateSolanaWallet().address;
     const txBase64 = buildLegacyTx({ wallet });

--- a/src/__tests__/solana-simulation.test.js
+++ b/src/__tests__/solana-simulation.test.js
@@ -404,6 +404,28 @@ describe('solana-simulation', () => {
       .rejects.toMatchObject({ code: 'SIM_RPC_ERROR' });
   });
 
+  it('degrades as SIM_RPC_ERROR when getMultipleAccounts returns fewer accounts than requested (misaligned response)', async () => {
+    // regression: a conforming RPC always returns value.length === the
+    // requested key count (null entries for missing accounts). A short array
+    // would silently shift every later account's pre-state by one slot against
+    // writableKeys, corrupting delta classification, rather than failing loudly.
+    const wallet = generateSolanaWallet().address;
+    const txBase64 = buildLegacyTx({ wallet, extraWritableKeys: [generateSolanaWallet().address] });
+
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async (url, opts) => {
+      const body = JSON.parse(opts.body);
+      if (body.method === 'getMultipleAccounts') {
+        const [pubkeys] = body.params;
+        // Return one fewer entry than requested.
+        return jsonRpcResponse({ value: pubkeys.slice(1).map(() => null) });
+      }
+      throw new Error(`solana-simulation.test.js: unexpected RPC method ${body.method}`);
+    }));
+
+    await expect(simulateSolanaAssetChanges('solana', txBase64, { walletAddress: wallet }))
+      .rejects.toMatchObject({ code: 'SIM_RPC_ERROR' });
+  });
+
   it('always sends replaceRecentBlockhash:true (the quote blockhash is stale by execute)', async () => {
     const wallet = generateSolanaWallet().address;
     const txBase64 = buildLegacyTx({ wallet });

--- a/src/__tests__/solana-simulation.test.js
+++ b/src/__tests__/solana-simulation.test.js
@@ -244,6 +244,63 @@ describe('solana-simulation', () => {
     expect(result.deltas[mint]).toBe(200n);
   });
 
+  it('first-time buy: tracks the output ATA the tx creates (no pre-state) and reports its delta', async () => {
+    // The output token account does not exist pre-swap (getMultipleAccounts
+    // returns null for it), so it has no ownership to read up front. It must
+    // still be snapshotted post-simulation and its whole post-balance counted
+    // as the delta — otherwise the output delta is 0 and every first buy blocks.
+    const wallet = generateSolanaWallet().address;
+    const newOutputAta = generateSolanaWallet().address;
+    const outputMint = generateSolanaWallet().address;
+    const txBase64 = buildLegacyTx({ wallet, extraWritableKeys: [newOutputAta] });
+
+    vi.stubGlobal('fetch', mockSolanaRpc({
+      trackedAccounts: {
+        [wallet]: nativeAccountInfo(10_000_000_000),
+        // newOutputAta intentionally absent → getMultipleAccounts returns null.
+      },
+      simValue: (params) => {
+        const addrs = params[1].accounts.addresses;
+        // The candidate ATA must be included in the snapshot request.
+        expect(addrs).toContain(newOutputAta);
+        const post = {
+          [wallet]: nativeAccountInfo(8_997_960_720), // paid 1 SOL + fee + ATA rent
+          [newOutputAta]: tokenAccountInfo({ mint: outputMint, owner: wallet, amount: 250_000_000 }),
+        };
+        return { value: { err: null, accounts: addrs.map((a) => post[a] ?? null) } };
+      },
+    }));
+
+    const result = await simulateSolanaAssetChanges('solana', txBase64, { walletAddress: wallet });
+    expect(result.deltas[outputMint]).toBe(250_000_000n); // full post-balance, pre = 0
+  });
+
+  it('ignores a newly-created account the tx does not assign to the wallet', async () => {
+    // A null pre-state account created for another party (e.g. a routing PDA)
+    // must not be counted toward the wallet's deltas.
+    const wallet = generateSolanaWallet().address;
+    const someoneElsesNewAta = generateSolanaWallet().address;
+    const otherOwner = generateSolanaWallet().address;
+    const otherMint = generateSolanaWallet().address;
+    const txBase64 = buildLegacyTx({ wallet, extraWritableKeys: [someoneElsesNewAta] });
+
+    vi.stubGlobal('fetch', mockSolanaRpc({
+      trackedAccounts: { [wallet]: nativeAccountInfo(1_000_000_000) },
+      simValue: (params) => {
+        const addrs = params[1].accounts.addresses;
+        const post = {
+          [wallet]: nativeAccountInfo(999_995_000),
+          [someoneElsesNewAta]: tokenAccountInfo({ mint: otherMint, owner: otherOwner, amount: 5_000_000 }),
+        };
+        return { value: { err: null, accounts: addrs.map((a) => post[a] ?? null) } };
+      },
+    }));
+
+    const result = await simulateSolanaAssetChanges('solana', txBase64, { walletAddress: wallet });
+    expect(result.deltas[otherMint]).toBeUndefined();
+    expect(result.deltas[SOL_SENTINEL]).toBe(-5_000n); // only the wallet's own fee delta
+  });
+
   it('throws SIM_REVERTED when the simulated transaction errors', async () => {
     const wallet = generateSolanaWallet().address;
     const txBase64 = buildLegacyTx({ wallet });

--- a/src/__tests__/solana-simulation.test.js
+++ b/src/__tests__/solana-simulation.test.js
@@ -244,6 +244,51 @@ describe('solana-simulation', () => {
     expect(result.deltas[mint]).toBe(200n);
   });
 
+  it('does not double-count a writable account referenced both as a static key and via an ALT (regression: no dedup summed its delta twice)', async () => {
+    const wallet = generateSolanaWallet().address;
+    const programId = generateSolanaWallet().address;
+    const recentBlockhash = generateSolanaWallet().address;
+    const altAddress = generateSolanaWallet().address;
+    const tokenAccount = generateSolanaWallet().address; // referenced BOTH ways below
+    const mint = generateSolanaWallet().address;
+
+    // ALT resolves the SAME tokenAccount already present as a static key.
+    const altAddresses = [generateSolanaWallet().address, generateSolanaWallet().address, generateSolanaWallet().address, tokenAccount];
+    const altTableData = Buffer.concat([Buffer.alloc(56), ...altAddresses.map((a) => base58Decode(a))]).toString('base64');
+
+    const messageBytes = buildMessageBytes({
+      versioned: true,
+      accountKeys: [wallet, tokenAccount, programId],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 1 },
+      recentBlockhash,
+      instructions: [{ programIdIndex: 2, accountIndexes: [0, 1], data: Buffer.from([0x01]) }],
+      addressTableLookups: [{ lookupTableAddress: altAddress, writableIndexes: [3], readonlyIndexes: [] }],
+    });
+    const txBase64 = wrapTransaction(messageBytes);
+
+    vi.stubGlobal('fetch', mockSolanaRpc({
+      altAccounts: { [altAddress]: { data: [altTableData, 'base64'], owner: 'AddressLookupTab1e1111111111111111111111', lamports: 1 } },
+      trackedAccounts: {
+        [wallet]: nativeAccountInfo(1_000_000_000),
+        [tokenAccount]: tokenAccountInfo({ mint, owner: wallet, amount: 500 }),
+      },
+      simValue: (params) => {
+        const addrs = params[1].accounts.addresses;
+        // Deduplicated: tokenAccount must appear only once in the snapshot request.
+        expect(addrs.filter((a) => a === tokenAccount)).toHaveLength(1);
+        const post = {
+          [wallet]: nativeAccountInfo(999_995_000),
+          [tokenAccount]: tokenAccountInfo({ mint, owner: wallet, amount: 700 }),
+        };
+        return { value: { err: null, accounts: addrs.map((a) => post[a]) } };
+      },
+    }));
+
+    const result = await simulateSolanaAssetChanges('solana', txBase64, { walletAddress: wallet });
+    // The real delta is 200 (500 -> 700); without dedup this would double to 400.
+    expect(result.deltas[mint]).toBe(200n);
+  });
+
   it('first-time buy: tracks the output ATA the tx creates (no pre-state) and reports its delta', async () => {
     // The output token account does not exist pre-swap (getMultipleAccounts
     // returns null for it), so it has no ownership to read up front. It must

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -1708,27 +1708,56 @@ describe('assertSolanaSwapOutcome', () => {
     expect(() => assertSolanaSwapOutcome(splInRequest, splInQuote, sim, {})).not.toThrow();
   });
 
-  it('rejects a native-SOL sibling drain beyond the dust tolerance', () => {
+  it('tolerates a legitimate near-cap priority fee as a native-SOL sibling on an SPL-in swap', () => {
+    // Regression: assertion 3's tolerance used to be NATIVE_SIBLING_DUST_LAMPORTS
+    // (3M) alone, with no priority-fee term — but assertSolanaInstructionsSafe
+    // legitimately allows a priority fee up to MAX_PRIORITY_FEE_LAMPORTS (10M),
+    // which also leaves the wallet as native SOL. A real swap paying close to
+    // that cap would false-block without the combined NATIVE_FEE_RENT_SLACK_LAMPORTS.
     const sim = { deltas: { [SOL_USDC]: -1000000n, [SOL_USDT]: 1000000n, [SOL_SENTINEL]: -10_000_000n } };
+    expect(() => assertSolanaSwapOutcome(splInRequest, splInQuote, sim, {})).not.toThrow();
+  });
+
+  it('rejects a native-SOL sibling drain beyond maxInputAmount + fee/rent slack', () => {
+    const sim = { deltas: { [SOL_USDC]: -1000000n, [SOL_USDT]: 1000000n, [SOL_SENTINEL]: -14_000_000n } };
     expect(() => assertSolanaSwapOutcome(splInRequest, splInQuote, sim, {}))
       .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*other than the one you are selling/i);
   });
 
   it('allows a custom siblingDustThreshold to override the native default', () => {
-    const sim = { deltas: { [SOL_USDC]: -1000000n, [SOL_USDT]: 1000000n, [SOL_SENTINEL]: -10_000_000n } };
+    const sim = { deltas: { [SOL_USDC]: -1000000n, [SOL_USDT]: 1000000n, [SOL_SENTINEL]: -14_000_000n } };
     expect(() => assertSolanaSwapOutcome(splInRequest, splInQuote, sim, { siblingDustThreshold: 20_000_000n })).not.toThrow();
   });
 
-  it('is metadata-bound (not tightly bounded) on native-SOL input, tolerating fee/rent noise', () => {
+  it('is slack-bounded (not tightly bounded) on native-SOL input, tolerating fee/rent noise', () => {
     const nativeInRequest = {
       chain: 'solana', walletAddress: 'Wallet1111111111111111111111111111111111',
       fromToken: SOL_SENTINEL, toToken: SOL_USDC, swapMode: 'exactIn', amount: '1000000000', maxInputAmount: '1000000000',
     };
     const nativeInQuote = { inputMint: SOL_SENTINEL, outputMint: SOL_USDC, inAmount: '1000000000', outAmount: '50000000' };
-    // Native delta is the input PLUS fee/rent noise — no tight ceiling applies.
+    // Native delta is the input plus ~5.1M lamports of fee/rent noise — within
+    // the fee/rent slack (MAX_PRIORITY_FEE_LAMPORTS + NATIVE_SIBLING_DUST_LAMPORTS),
+    // so the loosened bound still passes it.
     const sim = { deltas: { [SOL_SENTINEL]: -1_005_123n * 1000n, [SOL_USDC]: 50_000_000n } };
     expect(assertSolanaSwapOutcome(nativeInRequest, nativeInQuote, sim, { slippage: 0.03 }))
       .toEqual({ verified: true, inputAssertionSkipped: true });
+  });
+
+  it('rejects a native-SOL input drain beyond maxInputAmount + fee/rent slack (assertion 1, native input)', () => {
+    // Regression: assertion 1 used to be fully skipped for native-SOL input,
+    // and assertion 3 unconditionally exempts the input asset — so an extra,
+    // unaccounted native-SOL outflow (e.g. a plain System-Program transfer
+    // assertSolanaInstructionsSafe doesn't classify) could drain far beyond
+    // maxInputAmount as long as the declared output still arrived.
+    const nativeInRequest = {
+      chain: 'solana', walletAddress: 'Wallet1111111111111111111111111111111111',
+      fromToken: SOL_SENTINEL, toToken: SOL_USDC, swapMode: 'exactIn', amount: '1000000000', maxInputAmount: '1000000000',
+    };
+    const nativeInQuote = { inputMint: SOL_SENTINEL, outputMint: SOL_USDC, inAmount: '1000000000', outAmount: '50000000' };
+    // 1000 SOL drained instead of the declared 1 SOL — the output still lands.
+    const sim = { deltas: { [SOL_SENTINEL]: -1_000_000_000_000n, [SOL_USDC]: 50_000_000n } };
+    expect(() => assertSolanaSwapOutcome(nativeInRequest, nativeInQuote, sim, { slippage: 0.03 }))
+      .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*maximum input/i);
   });
 
   it('reports inputAssertionSkipped: false on an SPL-in swap, where assertion 1 does run', () => {
@@ -1766,16 +1795,30 @@ describe('assertSolanaSwapOutcome', () => {
   });
 
   it('still blocks native-SOL output that falls short beyond the fee/rent tolerance', () => {
-    // Same trade, but the delta is 990_000_000 — 9M under the floor, far past
-    // the ~3M dust tolerance, so a genuine shortfall is still caught.
+    // Same trade, but the delta is 980_000_000 — 19M under the floor, far past
+    // the ~13M combined fee/rent tolerance, so a genuine shortfall is still caught.
     const req = {
       chain: 'solana', walletAddress: 'Wallet1111111111111111111111111111111111',
       fromToken: SOL_USDC, toToken: SOL_SENTINEL, swapMode: 'exactIn', amount: '50000000', maxInputAmount: '50000000',
     };
     const quote = { inputMint: SOL_USDC, outputMint: SOL_SENTINEL, inAmount: '50000000', outAmount: '1000000000' };
-    const sim = { deltas: { [SOL_USDC]: -50_000_000n, [SOL_SENTINEL]: 990_000_000n } };
+    const sim = { deltas: { [SOL_USDC]: -50_000_000n, [SOL_SENTINEL]: 980_000_000n } };
     expect(() => assertSolanaSwapOutcome(req, quote, sim, { slippage: 0.001 }))
       .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*minimum acceptable output/i);
+  });
+
+  it('tolerates a legitimate near-cap priority fee reducing native-SOL output (SPL→SOL)', () => {
+    // Regression: assertion 2's floor slack used to be NATIVE_SIBLING_DUST_LAMPORTS
+    // (3M) alone, with no priority-fee term. A real swap paying close to the
+    // MAX_PRIORITY_FEE_LAMPORTS cap (10M) can land ~12M lamports under the raw
+    // floor and must still pass — the same combined slack assertions 1/3 use.
+    const req = {
+      chain: 'solana', walletAddress: 'Wallet1111111111111111111111111111111111',
+      fromToken: SOL_USDC, toToken: SOL_SENTINEL, swapMode: 'exactIn', amount: '50000000', maxInputAmount: '50000000',
+    };
+    const quote = { inputMint: SOL_USDC, outputMint: SOL_SENTINEL, inAmount: '50000000', outAmount: '1000000000' };
+    const sim = { deltas: { [SOL_USDC]: -50_000_000n, [SOL_SENTINEL]: 987_000_000n } };
+    expect(() => assertSolanaSwapOutcome(req, quote, sim, { slippage: 0.001 })).not.toThrow();
   });
 
   it('blocks a negative output delta even when the dust-quoted floor collapses below zero (regression: floor underflow admitted any non-negative delta)', () => {

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { validateQuoteInput, fetchNativeBalance, fetchTokenBalance, validateBalance, resolvePercentAmount, validateGasBalance, GASLESS_MIN_TRADE_USD, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertInputWithinMax, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, MAX_UINT256, needsAllowanceRevoke } from '../trade-validation.js';
+import { validateQuoteInput, fetchNativeBalance, fetchTokenBalance, validateBalance, resolvePercentAmount, validateGasBalance, GASLESS_MIN_TRADE_USD, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertInputWithinMax, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, assertSolanaSwapOutcome, MAX_UINT256, needsAllowanceRevoke } from '../trade-validation.js';
+import { SOL_SENTINEL } from '../solana-simulation.js';
 import { base58Decode, generateSolanaWallet } from '../wallet.js';
 
 describe('validateQuoteInput', () => {
@@ -1657,6 +1658,95 @@ describe('assertSwapOutcome', () => {
   it('fails closed on a corrupt (non-integer) simulated delta', () => {
     const sim = { deltas: { [USDC]: 'not-a-number' }, approvals: [] };
     expect(() => assertSwapOutcome(exactInRequest, exactInQuote, sim, {})).toThrow(/SWAP_OUTCOME_MISMATCH/i);
+  });
+});
+
+describe('assertSolanaSwapOutcome', () => {
+  const SOL_USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+  const SOL_USDT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB';
+
+  // exactIn: sell 1,000,000 SPL_A for SPL_B, quoted 1,000,000 out, 3% slippage.
+  const splInRequest = {
+    chain: 'solana', walletAddress: 'Wallet1111111111111111111111111111111111',
+    fromToken: SOL_USDC, toToken: SOL_USDT, swapMode: 'exactIn', amount: '1000000', maxInputAmount: '1000000',
+  };
+  const splInQuote = { inputMint: SOL_USDC, outputMint: SOL_USDT, inAmount: '1000000', outAmount: '1000000' };
+
+  it('passes a benign SPL-in swap within cap and above min output', () => {
+    const sim = { deltas: { [SOL_USDC]: -1000000n, [SOL_USDT]: 1000000n } };
+    expect(() => assertSolanaSwapOutcome(splInRequest, splInQuote, sim, { slippage: 0.03 })).not.toThrow();
+  });
+
+  it('rejects an SPL input outflow exceeding maxInputAmount (assertion 1)', () => {
+    const sim = { deltas: { [SOL_USDC]: -1000001n, [SOL_USDT]: 1000000n } };
+    expect(() => assertSolanaSwapOutcome(splInRequest, splInQuote, sim, {}))
+      .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*maximum input/i);
+  });
+
+  it('rejects an output below the minimum acceptable (assertion 2)', () => {
+    const sim = { deltas: { [SOL_USDC]: -1000000n, [SOL_USDT]: 900000n } }; // below 970,000 floor
+    expect(() => assertSolanaSwapOutcome(splInRequest, splInQuote, sim, { slippage: 0.03 }))
+      .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*minimum acceptable output/i);
+  });
+
+  it('rejects a non-positive output', () => {
+    const sim = { deltas: { [SOL_USDC]: -1000000n, [SOL_USDT]: 0n } };
+    expect(() => assertSolanaSwapOutcome(splInRequest, splInQuote, sim, {}))
+      .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*minimum acceptable output/i);
+  });
+
+  it('rejects a sibling SPL-token drain (assertion 3, zero tolerance)', () => {
+    const otherMint = 'Other11111111111111111111111111111111111';
+    const sim = { deltas: { [SOL_USDC]: -1000000n, [SOL_USDT]: 1000000n, [otherMint]: -1n } };
+    expect(() => assertSolanaSwapOutcome(splInRequest, splInQuote, sim, {}))
+      .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*other than the one you are selling/i);
+  });
+
+  it('tolerates native-SOL fee/rent dust as a sibling on an SPL-in swap', () => {
+    // Fee + one transient ATA's rent, well under NATIVE_SIBLING_DUST_LAMPORTS.
+    const sim = { deltas: { [SOL_USDC]: -1000000n, [SOL_USDT]: 1000000n, [SOL_SENTINEL]: -2_000_000n } };
+    expect(() => assertSolanaSwapOutcome(splInRequest, splInQuote, sim, {})).not.toThrow();
+  });
+
+  it('rejects a native-SOL sibling drain beyond the dust tolerance', () => {
+    const sim = { deltas: { [SOL_USDC]: -1000000n, [SOL_USDT]: 1000000n, [SOL_SENTINEL]: -10_000_000n } };
+    expect(() => assertSolanaSwapOutcome(splInRequest, splInQuote, sim, {}))
+      .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*other than the one you are selling/i);
+  });
+
+  it('allows a custom siblingDustThreshold to override the native default', () => {
+    const sim = { deltas: { [SOL_USDC]: -1000000n, [SOL_USDT]: 1000000n, [SOL_SENTINEL]: -10_000_000n } };
+    expect(() => assertSolanaSwapOutcome(splInRequest, splInQuote, sim, { siblingDustThreshold: 20_000_000n })).not.toThrow();
+  });
+
+  it('is metadata-bound (not tightly bounded) on native-SOL input, tolerating fee/rent noise', () => {
+    const nativeInRequest = {
+      chain: 'solana', walletAddress: 'Wallet1111111111111111111111111111111111',
+      fromToken: SOL_SENTINEL, toToken: SOL_USDC, swapMode: 'exactIn', amount: '1000000000', maxInputAmount: '1000000000',
+    };
+    const nativeInQuote = { inputMint: SOL_SENTINEL, outputMint: SOL_USDC, inAmount: '1000000000', outAmount: '50000000' };
+    // Native delta is the input PLUS fee/rent noise — no tight ceiling applies.
+    const sim = { deltas: { [SOL_SENTINEL]: -1_005_123n * 1000n, [SOL_USDC]: 50_000_000n } };
+    expect(() => assertSolanaSwapOutcome(nativeInRequest, nativeInQuote, sim, { slippage: 0.03 })).not.toThrow();
+  });
+
+  it('fails closed when input and output tokens are the same', () => {
+    const req = { ...splInRequest, toToken: SOL_USDC };
+    const quote = { inputMint: SOL_USDC, outputMint: SOL_USDC, inAmount: '1000000', outAmount: '1000000' };
+    const sim = { deltas: { [SOL_USDC]: -1000000n } };
+    expect(() => assertSolanaSwapOutcome(req, quote, sim, {}))
+      .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*input and output tokens are the same/i);
+  });
+
+  it('fails closed with no request intent', () => {
+    const sim = { deltas: { [SOL_USDC]: -1000000n, [SOL_USDT]: 1000000n } };
+    expect(() => assertSolanaSwapOutcome(null, splInQuote, sim, {}))
+      .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*no request intent/i);
+  });
+
+  it('fails closed on a corrupt (non-integer) simulated delta', () => {
+    const sim = { deltas: { [SOL_USDC]: 'not-a-number' } };
+    expect(() => assertSolanaSwapOutcome(splInRequest, splInQuote, sim, {})).toThrow(/SWAP_OUTCOME_MISMATCH/i);
   });
 });
 

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -1745,6 +1745,32 @@ describe('assertSolanaSwapOutcome', () => {
     expect(() => assertSolanaSwapOutcome(wsolInRequest, wsolInQuote, sim, { slippage: 0.03 })).not.toThrow();
   });
 
+  it('tolerates fee/rent noise on native-SOL output (SPL→SOL) at tight slippage', () => {
+    // USDC → 1 SOL, 0.1% slippage → minOut = 999_000_000. The native delta nets
+    // out a priority fee + base fee (~2M lamports), landing at 998_000_000 —
+    // below the raw floor but within the fee/rent tolerance, so it must pass.
+    const req = {
+      chain: 'solana', walletAddress: 'Wallet1111111111111111111111111111111111',
+      fromToken: SOL_USDC, toToken: SOL_SENTINEL, swapMode: 'exactIn', amount: '50000000', maxInputAmount: '50000000',
+    };
+    const quote = { inputMint: SOL_USDC, outputMint: SOL_SENTINEL, inAmount: '50000000', outAmount: '1000000000' };
+    const sim = { deltas: { [SOL_USDC]: -50_000_000n, [SOL_SENTINEL]: 998_000_000n } };
+    expect(() => assertSolanaSwapOutcome(req, quote, sim, { slippage: 0.001 })).not.toThrow();
+  });
+
+  it('still blocks native-SOL output that falls short beyond the fee/rent tolerance', () => {
+    // Same trade, but the delta is 990_000_000 — 9M under the floor, far past
+    // the ~3M dust tolerance, so a genuine shortfall is still caught.
+    const req = {
+      chain: 'solana', walletAddress: 'Wallet1111111111111111111111111111111111',
+      fromToken: SOL_USDC, toToken: SOL_SENTINEL, swapMode: 'exactIn', amount: '50000000', maxInputAmount: '50000000',
+    };
+    const quote = { inputMint: SOL_USDC, outputMint: SOL_SENTINEL, inAmount: '50000000', outAmount: '1000000000' };
+    const sim = { deltas: { [SOL_USDC]: -50_000_000n, [SOL_SENTINEL]: 990_000_000n } };
+    expect(() => assertSolanaSwapOutcome(req, quote, sim, { slippage: 0.001 }))
+      .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*minimum acceptable output/i);
+  });
+
   it('fails closed when input and output tokens are the same', () => {
     const req = { ...splInRequest, toToken: SOL_USDC };
     const quote = { inputMint: SOL_USDC, outputMint: SOL_USDC, inAmount: '1000000', outAmount: '1000000' };

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -1727,7 +1727,14 @@ describe('assertSolanaSwapOutcome', () => {
     const nativeInQuote = { inputMint: SOL_SENTINEL, outputMint: SOL_USDC, inAmount: '1000000000', outAmount: '50000000' };
     // Native delta is the input PLUS fee/rent noise — no tight ceiling applies.
     const sim = { deltas: { [SOL_SENTINEL]: -1_005_123n * 1000n, [SOL_USDC]: 50_000_000n } };
-    expect(() => assertSolanaSwapOutcome(nativeInRequest, nativeInQuote, sim, { slippage: 0.03 })).not.toThrow();
+    expect(assertSolanaSwapOutcome(nativeInRequest, nativeInQuote, sim, { slippage: 0.03 }))
+      .toEqual({ verified: true, inputAssertionSkipped: true });
+  });
+
+  it('reports inputAssertionSkipped: false on an SPL-in swap, where assertion 1 does run', () => {
+    const sim = { deltas: { [SOL_USDC]: -1000000n, [SOL_USDT]: 1000000n } };
+    expect(assertSolanaSwapOutcome(splInRequest, splInQuote, sim, { slippage: 0.03 }))
+      .toEqual({ verified: true, inputAssertionSkipped: false });
   });
 
   it('folds a WSOL-mint quote input to the native sentinel so the delta matches (regression: SOLANA_NATIVE_MINTS ReferenceError)', () => {

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -2144,4 +2144,42 @@ describe('assertSolanaInstructionsSafe', () => {
     });
     expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet })).not.toThrow();
   });
+
+  // Same layout as buildTransaction but as a v0 message (version-prefixed
+  // header, zero address-lookup-table entries) so a test can point an
+  // instruction's programIdIndex past the static account keys — simulating a
+  // program invoked only through an ALT entry.
+  function buildVersionedTransaction({ accountKeys, instructions }) {
+    const parts = [Buffer.from([0x80, 1, 0, accountKeys.length - 1])]; // v0, 1 signer, that signer is writable
+    parts.push(encodeCompactU16(accountKeys.length));
+    for (const k of accountKeys) parts.push(base58Decode(k));
+    parts.push(base58Decode(accountKeys[0])); // recentBlockhash placeholder — any 32 bytes
+    parts.push(encodeCompactU16(instructions.length));
+    for (const ix of instructions) {
+      parts.push(Buffer.from([ix.programIdIndex]));
+      parts.push(encodeCompactU16(ix.accountIndexes.length));
+      for (const idx of ix.accountIndexes) parts.push(Buffer.from([idx]));
+      parts.push(encodeCompactU16(ix.data.length));
+      parts.push(ix.data);
+    }
+    parts.push(encodeCompactU16(0)); // no address-lookup-table entries
+    const messageBytes = Buffer.concat(parts);
+    return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), messageBytes]).toString('base64');
+  }
+
+  it('fails closed on an instruction whose program ID is only ALT-resolvable', () => {
+    // programIdIndex 3 is past accountKeys.length (3 static keys, indexes
+    // 0-2), so it can only resolve via an address-lookup-table entry — the
+    // same gap an Approve/SetAuthority/CloseAccount instruction could hide
+    // behind if the SPL Token program itself were routed through an ALT.
+    const wallet = generateSolanaWallet().address;
+    const sourceAccount = generateSolanaWallet().address;
+    const delegate = generateSolanaWallet().address;
+    const tx = buildVersionedTransaction({
+      accountKeys: [wallet, sourceAccount, delegate],
+      instructions: [{ programIdIndex: 3, accountIndexes: [1, 2, 0], data: Buffer.from([4]) }],
+    });
+    expect(() => assertSolanaInstructionsSafe(tx, { walletAddress: wallet }))
+      .toThrow(/only resolvable via an address-lookup-table entry/);
+  });
 });

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -1771,6 +1771,22 @@ describe('assertSolanaSwapOutcome', () => {
       .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*minimum acceptable output/i);
   });
 
+  it('blocks a negative output delta even when the dust-quoted floor collapses below zero (regression: floor underflow admitted any non-negative delta)', () => {
+    // Quoted output (1,000,000 lamports) is below NATIVE_SIBLING_DUST_LAMPORTS
+    // (3,000,000n), so minOut - outputFloorSlack goes negative. The floor must
+    // clamp at 0 rather than admit any non-negative delta — otherwise a swap
+    // that actually lost SOL (fees exceeding the tiny quoted output) would
+    // wrongly pass.
+    const req = {
+      chain: 'solana', walletAddress: 'Wallet1111111111111111111111111111111111',
+      fromToken: SOL_USDC, toToken: SOL_SENTINEL, swapMode: 'exactIn', amount: '1000', maxInputAmount: '1000',
+    };
+    const quote = { inputMint: SOL_USDC, outputMint: SOL_SENTINEL, inAmount: '1000', outAmount: '1000000' };
+    const sim = { deltas: { [SOL_USDC]: -1000n, [SOL_SENTINEL]: -500000n } };
+    expect(() => assertSolanaSwapOutcome(req, quote, sim, { slippage: 0.03 }))
+      .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*minimum acceptable output/i);
+  });
+
   it('fails closed when input and output tokens are the same', () => {
     const req = { ...splInRequest, toToken: SOL_USDC };
     const quote = { inputMint: SOL_USDC, outputMint: SOL_USDC, inAmount: '1000000', outAmount: '1000000' };

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -1794,6 +1794,22 @@ describe('assertSolanaSwapOutcome', () => {
       .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*minimum acceptable output/i);
   });
 
+  it('blocks a zero output delta even when the dust-quoted floor collapses to zero (regression: a dust-adjusted floor of 0 admitted a fully-failed trade)', () => {
+    // Same dust-quoted setup as above (adjustedFloor clamps to 0n), but this
+    // time the swap delivers exactly nothing rather than a net loss. The EVM
+    // sibling (assertSwapOutcome) never has this gap because its minOut can
+    // never collapse to <= 0; the explicit outputDelta <= 0n check restores
+    // that same invariant here.
+    const req = {
+      chain: 'solana', walletAddress: 'Wallet1111111111111111111111111111111111',
+      fromToken: SOL_USDC, toToken: SOL_SENTINEL, swapMode: 'exactIn', amount: '1000', maxInputAmount: '1000',
+    };
+    const quote = { inputMint: SOL_USDC, outputMint: SOL_SENTINEL, inAmount: '1000', outAmount: '1000000' };
+    const sim = { deltas: { [SOL_USDC]: -1000n, [SOL_SENTINEL]: 0n } };
+    expect(() => assertSolanaSwapOutcome(req, quote, sim, { slippage: 0.03 }))
+      .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*minimum acceptable output/i);
+  });
+
   it('fails closed when input and output tokens are the same', () => {
     const req = { ...splInRequest, toToken: SOL_USDC };
     const quote = { inputMint: SOL_USDC, outputMint: SOL_USDC, inAmount: '1000000', outAmount: '1000000' };

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -1730,6 +1730,21 @@ describe('assertSolanaSwapOutcome', () => {
     expect(() => assertSolanaSwapOutcome(nativeInRequest, nativeInQuote, sim, { slippage: 0.03 })).not.toThrow();
   });
 
+  it('folds a WSOL-mint quote input to the native sentinel so the delta matches (regression: SOLANA_NATIVE_MINTS ReferenceError)', () => {
+    // A real Jupiter SOL→USDC quote carries the WSOL mint (So111…112) in
+    // inputMint, while the simulation reports the native delta under the
+    // system-program sentinel. foldNative must reconcile the two — the crash
+    // path when the alias set was undefined.
+    const WSOL = 'So11111111111111111111111111111111111111112';
+    const wsolInRequest = {
+      chain: 'solana', walletAddress: 'Wallet1111111111111111111111111111111111',
+      fromToken: WSOL, toToken: SOL_USDC, swapMode: 'exactIn', amount: '1000000000', maxInputAmount: '1000000000',
+    };
+    const wsolInQuote = { inputMint: WSOL, outputMint: SOL_USDC, inAmount: '1000000000', outAmount: '50000000' };
+    const sim = { deltas: { [SOL_SENTINEL]: -1_005_123n * 1000n, [SOL_USDC]: 50_000_000n } };
+    expect(() => assertSolanaSwapOutcome(wsolInRequest, wsolInQuote, sim, { slippage: 0.03 })).not.toThrow();
+  });
+
   it('fails closed when input and output tokens are the same', () => {
     const req = { ...splInRequest, toToken: SOL_USDC };
     const quote = { inputMint: SOL_USDC, outputMint: SOL_USDC, inAmount: '1000000', outAmount: '1000000' };

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -1408,15 +1408,22 @@ describe('WalletConnect execute support', () => {
 
 describe('Privy execute support', () => {
   let originalEnv;
+  let origSolanaSimRpc;
 
   beforeEach(() => {
     originalEnv = { ...process.env };
     process.env.PRIVY_APP_ID = 'test-app-id';
     process.env.PRIVY_APP_SECRET = 'test-secret';
+    // These tests use placeholder (non-parseable) transaction bytes and aren't
+    // testing swap-outcome verification, so disable it here rather than
+    // mocking a full Solana RPC round trip.
+    origSolanaSimRpc = SIMULATION_RPCS.solana;
+    SIMULATION_RPCS.solana = null;
   });
 
   afterEach(() => {
     process.env = originalEnv;
+    SIMULATION_RPCS.solana = origSolanaSimRpc;
     vi.unstubAllGlobals();
   });
 
@@ -4579,6 +4586,10 @@ describe('Relay aggregator: --aggregator override on bridge-status', () => {
 });
 
 describe('Relay aggregator: Solana non-gasless omits requestId', () => {
+  let origSolanaSimRpc;
+  beforeEach(() => { origSolanaSimRpc = SIMULATION_RPCS.solana; SIMULATION_RPCS.solana = null; });
+  afterEach(() => { SIMULATION_RPCS.solana = origSolanaSimRpc; });
+
   it('non-gasless Solana Relay execute does NOT send requestId (backend 502s otherwise)', async () => {
     createWallet('default', 'testpass');
     process.env.NANSEN_WALLET_PASSWORD = 'testpass';
@@ -5193,8 +5204,14 @@ describe('Solana intent binding (adversarial)', () => {
     return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null })) });
   });
   const noBroadcast = (calls) => expect(calls.some(c => c.includes('/execute'))).toBe(false);
+  let origSolanaSimRpc;
 
-  afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); delete process.env.NANSEN_WALLET_PASSWORD; delete process.env.PRIVY_APP_ID; delete process.env.PRIVY_APP_SECRET; });
+  beforeEach(() => { origSolanaSimRpc = SIMULATION_RPCS.solana; SIMULATION_RPCS.solana = null; });
+  afterEach(() => {
+    SIMULATION_RPCS.solana = origSolanaSimRpc;
+    vi.unstubAllGlobals(); vi.restoreAllMocks();
+    delete process.env.NANSEN_WALLET_PASSWORD; delete process.env.PRIVY_APP_ID; delete process.env.PRIVY_APP_SECRET;
+  });
 
   it('local wallet: refuses a quote with a tampered token pair', async () => {
     createWallet('default', 'testpass');

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -39,6 +39,7 @@ import {
   formatQuote,
   simulateEvmCall,
   verifySwapOutcome,
+  verifySolanaSwapOutcome,
   getBridgeStatus,
   pollBridgeStatus,
   saveTxRecord,
@@ -5446,6 +5447,368 @@ describe('Solana intent binding (adversarial)', () => {
     await cmds.execute([], null, {}, { quote: quoteId });
 
     expect(logs.some(l => l.includes('Transaction successful'))).toBe(true);
+  });
+});
+
+// Hand-rolled Solana tx builder, independent of solana-tx.js (see the same
+// convention in solana-tx.test.js / solana-simulation.test.js).
+function encodeSolanaCompactU16(value) {
+  if (value < 0x80) return Buffer.from([value]);
+  if (value < 0x4000) return Buffer.from([(value & 0x7f) | 0x80, (value >> 7) & 0x7f]);
+  return Buffer.from([(value & 0x7f) | 0x80, ((value >> 7) & 0x7f) | 0x80, (value >> 14) & 0x03]);
+}
+
+// A minimal legacy tx: [wallet (signer, writable), tokenAccountIn (writable),
+// tokenAccountOut (writable), programId (readonly)]. Contents of the single
+// instruction are irrelevant — simulation only reads the accounts snapshot.
+function buildSolanaSwapTx({ wallet, tokenAccountIn, tokenAccountOut }) {
+  const programId = generateSolanaWallet().address;
+  const recentBlockhash = generateSolanaWallet().address;
+  const accountKeys = [wallet, tokenAccountIn, tokenAccountOut, programId];
+  const parts = [Buffer.from([1, 0, 1])]; // 1 required sig, 0 readonly signed, 1 readonly unsigned (programId)
+  parts.push(encodeSolanaCompactU16(accountKeys.length));
+  for (const k of accountKeys) parts.push(base58Decode(k));
+  parts.push(base58Decode(recentBlockhash));
+  parts.push(encodeSolanaCompactU16(1));
+  parts.push(Buffer.from([3])); // programIdIndex
+  parts.push(encodeSolanaCompactU16(1));
+  parts.push(Buffer.from([0]));
+  parts.push(encodeSolanaCompactU16(1));
+  parts.push(Buffer.from([0x01]));
+  const messageBytes = Buffer.concat(parts);
+  return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), messageBytes]).toString('base64');
+}
+
+function solanaNativeAccountInfo(lamports) {
+  return { lamports, owner: '11111111111111111111111111111111', data: ['', 'base64'], executable: false, rentEpoch: 0 };
+}
+function solanaTokenAccountInfo({ mint, owner, amount }) {
+  return {
+    lamports: 2039280,
+    owner: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    data: { program: 'spl-token', parsed: { type: 'account', info: { mint, owner, tokenAmount: { amount: String(amount), decimals: 6 } } } },
+    executable: false,
+    rentEpoch: 0,
+  };
+}
+function solanaJsonRpcResponse(result) {
+  return { ok: true, status: 200, text: async () => JSON.stringify({ jsonrpc: '2.0', id: 1, result }) };
+}
+// pre/post are keyed by pubkey; `pre` classifies (and seeds) tracked accounts,
+// `post` supplies the simulated result in the order the caller requested.
+function mockSolanaSimRpc({ pre, post }) {
+  return vi.fn().mockImplementation(async (url, opts) => {
+    const body = JSON.parse(opts.body);
+    if (body.method === 'getMultipleAccounts') {
+      const [pubkeys] = body.params;
+      return solanaJsonRpcResponse({ value: pubkeys.map((pk) => pre[pk] ?? null) });
+    }
+    if (body.method === 'simulateTransaction') {
+      const addrs = body.params[1].accounts.addresses;
+      return solanaJsonRpcResponse({ value: { err: null, accounts: addrs.map((a) => post[a] ?? null) } });
+    }
+    throw new Error(`unhandled RPC method in test: ${body.method}`);
+  });
+}
+
+describe('verifySolanaSwapOutcome (execute-path wiring)', () => {
+  const wallet = generateSolanaWallet().address;
+  const tokenIn = generateSolanaWallet().address;
+  const tokenOut = generateSolanaWallet().address;
+  const mintIn = SOL_USDC;
+  const mintOut = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB'; // SOL_USDT
+
+  const quote = { inputMint: mintIn, outputMint: mintOut, inAmount: '1000000', outAmount: '1000000' };
+  const quoteData = {
+    chain: 'solana',
+    slippage: 0.03,
+    request: { chain: 'solana', walletAddress: wallet, fromToken: mintIn, toToken: mintOut, swapMode: 'exactIn', amount: '1000000', maxInputAmount: '1000000' },
+  };
+  const txBase64 = buildSolanaSwapTx({ wallet, tokenAccountIn: tokenIn, tokenAccountOut: tokenOut });
+
+  let origSolanaSimRpc;
+  beforeEach(() => { origSolanaSimRpc = SIMULATION_RPCS.solana; SIMULATION_RPCS.solana = 'http://sol-sim.test'; });
+  afterEach(() => { SIMULATION_RPCS.solana = origSolanaSimRpc; vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+  const pre = {
+    [wallet]: solanaNativeAccountInfo(1_000_000_000),
+    [tokenIn]: solanaTokenAccountInfo({ mint: mintIn, owner: wallet, amount: 1_000_000 }),
+    [tokenOut]: solanaTokenAccountInfo({ mint: mintOut, owner: wallet, amount: 0 }),
+  };
+
+  it('proceeds on a clean swap', async () => {
+    const post = {
+      [wallet]: solanaNativeAccountInfo(999_995_000),
+      [tokenIn]: solanaTokenAccountInfo({ mint: mintIn, owner: wallet, amount: 0 }),
+      [tokenOut]: solanaTokenAccountInfo({ mint: mintOut, owner: wallet, amount: 1_000_000 }),
+    };
+    vi.stubGlobal('fetch', mockSolanaSimRpc({ pre, post }));
+    const r = await verifySolanaSwapOutcome({ chain: 'solana', walletAddress: wallet, txBase64, quote, quoteData });
+    expect(r.proceed).toBe(true);
+  });
+
+  it('blocks (proceed=false) when a sibling token is drained', async () => {
+    const siblingPre = { ...pre, [tokenOut]: solanaTokenAccountInfo({ mint: 'SiblingMint111111111111111111111111111111', owner: wallet, amount: 500 }) };
+    const post = {
+      [wallet]: solanaNativeAccountInfo(999_995_000),
+      [tokenIn]: solanaTokenAccountInfo({ mint: mintIn, owner: wallet, amount: 0 }),
+      [tokenOut]: solanaTokenAccountInfo({ mint: 'SiblingMint111111111111111111111111111111', owner: wallet, amount: 0 }), // drained, not the swap's output
+    };
+    vi.stubGlobal('fetch', mockSolanaSimRpc({ pre: siblingPre, post }));
+    const r = await verifySolanaSwapOutcome({ chain: 'solana', walletAddress: wallet, txBase64, quote, quoteData });
+    expect(r.proceed).toBe(false);
+    expect(r.reason).toMatch(/SWAP_OUTCOME_MISMATCH/i);
+  });
+
+  it('blocks when the output falls short', async () => {
+    const post = {
+      [wallet]: solanaNativeAccountInfo(999_995_000),
+      [tokenIn]: solanaTokenAccountInfo({ mint: mintIn, owner: wallet, amount: 0 }),
+      [tokenOut]: solanaTokenAccountInfo({ mint: mintOut, owner: wallet, amount: 900_000 }), // below 970,000 floor
+    };
+    vi.stubGlobal('fetch', mockSolanaSimRpc({ pre, post }));
+    const r = await verifySolanaSwapOutcome({ chain: 'solana', walletAddress: wallet, txBase64, quote, quoteData });
+    expect(r.proceed).toBe(false);
+  });
+
+  it('blocks when the transaction reverts in simulation', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async (url, opts) => {
+      const body = JSON.parse(opts.body);
+      if (body.method === 'getMultipleAccounts') {
+        const [pubkeys] = body.params;
+        return solanaJsonRpcResponse({ value: pubkeys.map((pk) => pre[pk] ?? null) });
+      }
+      return solanaJsonRpcResponse({ value: { err: { InstructionError: [0, 'Custom'] }, accounts: null } });
+    }));
+    const r = await verifySolanaSwapOutcome({ chain: 'solana', walletAddress: wallet, txBase64, quote, quoteData });
+    expect(r.proceed).toBe(false);
+  });
+
+  it('degrades (proceed=true) when no simulation endpoint is configured', async () => {
+    SIMULATION_RPCS.solana = null;
+    const logs = [];
+    const r = await verifySolanaSwapOutcome({ chain: 'solana', walletAddress: wallet, txBase64, quote, quoteData, log: (m) => logs.push(m) });
+    expect(r.proceed).toBe(true);
+    expect(logs.some((l) => /unavailable|proceeding without/i.test(l))).toBe(true);
+  });
+
+  it('degrades (proceed=true) on an RPC transport failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+    const logs = [];
+    const r = await verifySolanaSwapOutcome({ chain: 'solana', walletAddress: wallet, txBase64, quote, quoteData, log: (m) => logs.push(m) });
+    expect(r.proceed).toBe(true);
+    expect(logs.some((l) => /could not run|proceeding without/i.test(l))).toBe(true);
+  });
+
+  it('skips non-Solana chains', async () => {
+    vi.stubGlobal('fetch', vi.fn()); // must not be called
+    const r = await verifySolanaSwapOutcome({ chain: 'base', walletAddress: wallet, txBase64, quote, quoteData });
+    expect(r.proceed).toBe(true);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('skips cross-chain bridge quotes', async () => {
+    vi.stubGlobal('fetch', vi.fn()); // must not be called
+    const crossChainData = { ...quoteData, chain: 'solana', toChain: 'base' };
+    const r = await verifySolanaSwapOutcome({ chain: 'solana', walletAddress: wallet, txBase64, quote, quoteData: crossChainData });
+    expect(r.proceed).toBe(true);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('degrades (proceed=true) for a pre-intent quote with no request recorded', async () => {
+    vi.stubGlobal('fetch', vi.fn()); // must not be called
+    const logs = [];
+    const r = await verifySolanaSwapOutcome({ chain: 'solana', walletAddress: wallet, txBase64, quote, quoteData: { chain: 'solana' }, log: (m) => logs.push(m) });
+    expect(r.proceed).toBe(true);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(logs.some((l) => /no request intent/i.test(l))).toBe(true);
+  });
+
+  it('tolerates native-SOL fee/rent dust without false-blocking', async () => {
+    const post = {
+      [wallet]: solanaNativeAccountInfo(999_998_000), // ~2000 lamports of fee/rent noise
+      [tokenIn]: solanaTokenAccountInfo({ mint: mintIn, owner: wallet, amount: 0 }),
+      [tokenOut]: solanaTokenAccountInfo({ mint: mintOut, owner: wallet, amount: 1_000_000 }),
+    };
+    vi.stubGlobal('fetch', mockSolanaSimRpc({ pre, post }));
+    const r = await verifySolanaSwapOutcome({ chain: 'solana', walletAddress: wallet, txBase64, quote, quoteData });
+    expect(r.proceed).toBe(true);
+  });
+});
+
+describe('Solana execute: swap-outcome verification blocks signing (adversarial)', () => {
+  const mintOut = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB'; // SOL_USDT
+  afterEach(() => {
+    delete process.env.NANSEN_WALLET_PASSWORD;
+    delete process.env.PRIVY_APP_ID;
+    delete process.env.PRIVY_APP_SECRET;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('local wallet: a sibling-drain outcome blocks before signing (no broadcast)', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const wallet = showWallet('default').solana;
+    const tokenIn = generateSolanaWallet().address;
+    const tokenOut = generateSolanaWallet().address; // will report a sibling mint, not mintOut
+    const txBase64 = buildSolanaSwapTx({ wallet, tokenAccountIn: tokenIn, tokenAccountOut: tokenOut });
+
+    const pre = {
+      [wallet]: solanaNativeAccountInfo(1_000_000_000),
+      [tokenIn]: solanaTokenAccountInfo({ mint: SOL_USDC, owner: wallet, amount: 1_000_000 }),
+      [tokenOut]: solanaTokenAccountInfo({ mint: 'SiblingMint111111111111111111111111111111', owner: wallet, amount: 500 }),
+    };
+    const post = {
+      [wallet]: solanaNativeAccountInfo(999_995_000),
+      [tokenIn]: solanaTokenAccountInfo({ mint: SOL_USDC, owner: wallet, amount: 0 }),
+      [tokenOut]: solanaTokenAccountInfo({ mint: 'SiblingMint111111111111111111111111111111', owner: wallet, amount: 0 }),
+    };
+    const calls = [];
+    const rpcMock = mockSolanaSimRpc({ pre, post });
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      calls.push(typeof url === 'string' ? url : url.toString());
+      return rpcMock(url, opts);
+    }));
+    SIMULATION_RPCS.solana = 'http://sol-sim.test';
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{ aggregator: 'jupiter', inputMint: SOL_USDC, outputMint: mintOut, inAmount: '1000000', outAmount: '1000000', transaction: txBase64 }],
+    }, 'solana', 'local', null, null, {
+      swapMode: 'exactIn',
+      request: solanaIntent({ walletAddress: wallet, fromToken: SOL_USDC, toToken: mintOut, amount: '1000000', maxInputAmount: '1000000' }),
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    await expect(cmds.execute([], null, {}, { quote: quoteId })).rejects.toThrow(/outcome verification failed/i);
+    expect(calls.some((c) => c.includes('/execute'))).toBe(false);
+  });
+
+  it('Privy: a short-output outcome blocks before signing (never reaches signSolanaTransaction)', async () => {
+    process.env.PRIVY_APP_ID = 'test-app-id';
+    process.env.PRIVY_APP_SECRET = 'test-secret';
+    const wallet = generateSolanaWallet().address;
+    const tokenIn = generateSolanaWallet().address;
+    const tokenOut = generateSolanaWallet().address;
+    const txBase64 = buildSolanaSwapTx({ wallet, tokenAccountIn: tokenIn, tokenAccountOut: tokenOut });
+
+    const pre = {
+      [wallet]: solanaNativeAccountInfo(1_000_000_000),
+      [tokenIn]: solanaTokenAccountInfo({ mint: SOL_USDC, owner: wallet, amount: 1_000_000 }),
+      [tokenOut]: solanaTokenAccountInfo({ mint: mintOut, owner: wallet, amount: 0 }),
+    };
+    const post = {
+      [wallet]: solanaNativeAccountInfo(999_995_000),
+      [tokenIn]: solanaTokenAccountInfo({ mint: SOL_USDC, owner: wallet, amount: 0 }),
+      [tokenOut]: solanaTokenAccountInfo({ mint: mintOut, owner: wallet, amount: 900_000 }), // short
+    };
+    const rpcMock = mockSolanaSimRpc({ pre, post });
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      calls.push({ url: urlStr, method: opts?.method });
+      if (urlStr.includes('privy.io') && opts?.method === 'GET') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 'wl_sol_1', address: wallet, chain_type: 'solana' }) });
+      }
+      if (urlStr.includes('privy.io')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: { signed_transaction: 'c2lnbmVkVHg=' } }) });
+      }
+      return rpcMock(url, opts);
+    }));
+    SIMULATION_RPCS.solana = 'http://sol-sim.test';
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{ aggregator: 'jupiter', inputMint: SOL_USDC, outputMint: mintOut, inAmount: '1000000', outAmount: '1000000', transaction: txBase64 }],
+    }, 'solana', 'privy', { evm: 'wl_evm_1', solana: 'wl_sol_1' }, null, {
+      swapMode: 'exactIn',
+      request: solanaIntent({ walletAddress: wallet, fromToken: SOL_USDC, toToken: mintOut, amount: '1000000', maxInputAmount: '1000000' }),
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    await expect(cmds.execute([], null, {}, { quote: quoteId })).rejects.toThrow(/outcome verification failed/i);
+    expect(calls.some((c) => c.url.includes('privy.io') && c.method === 'POST')).toBe(false);
+    expect(calls.some((c) => c.url.includes('/execute'))).toBe(false);
+  });
+
+  it('WalletConnect: a blocked outcome never reaches sendSolanaTransactionViaWalletConnect', async () => {
+    const wallet = generateSolanaWallet().address;
+    vi.spyOn(wcTrading, 'getWalletConnectAddress').mockResolvedValue(wallet);
+    const sendSpy = vi.spyOn(wcTrading, 'sendSolanaTransactionViaWalletConnect').mockResolvedValue({ signedTransaction: '5K4Ld...' });
+
+    const tokenIn = generateSolanaWallet().address;
+    const tokenOut = generateSolanaWallet().address;
+    const txBase64 = buildSolanaSwapTx({ wallet, tokenAccountIn: tokenIn, tokenAccountOut: tokenOut });
+
+    const pre = {
+      [wallet]: solanaNativeAccountInfo(1_000_000_000),
+      [tokenIn]: solanaTokenAccountInfo({ mint: SOL_USDC, owner: wallet, amount: 1_000_000 }),
+      [tokenOut]: solanaTokenAccountInfo({ mint: mintOut, owner: wallet, amount: 0 }),
+    };
+    const post = {
+      [wallet]: solanaNativeAccountInfo(999_995_000),
+      [tokenIn]: solanaTokenAccountInfo({ mint: SOL_USDC, owner: wallet, amount: 0 }),
+      [tokenOut]: solanaTokenAccountInfo({ mint: mintOut, owner: wallet, amount: 900_000 }), // short
+    };
+    vi.stubGlobal('fetch', mockSolanaSimRpc({ pre, post }));
+    SIMULATION_RPCS.solana = 'http://sol-sim.test';
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{ aggregator: 'jupiter', inputMint: SOL_USDC, outputMint: mintOut, inAmount: '1000000', outAmount: '1000000', transaction: txBase64 }],
+    }, 'solana', 'walletconnect', null, null, {
+      swapMode: 'exactIn',
+      request: solanaIntent({ walletAddress: wallet, fromToken: SOL_USDC, toToken: mintOut, amount: '1000000', maxInputAmount: '1000000' }),
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    await expect(cmds.execute([], null, {}, { quote: quoteId })).rejects.toThrow(/outcome verification failed/i);
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it('regression: a benign Solana quote passes real outcome verification and still signs', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const wallet = showWallet('default').solana;
+    const tokenIn = generateSolanaWallet().address;
+    const tokenOut = generateSolanaWallet().address;
+    const txBase64 = buildSolanaSwapTx({ wallet, tokenAccountIn: tokenIn, tokenAccountOut: tokenOut });
+
+    const pre = {
+      [wallet]: solanaNativeAccountInfo(1_000_000_000),
+      [tokenIn]: solanaTokenAccountInfo({ mint: SOL_USDC, owner: wallet, amount: 1_000_000 }),
+      [tokenOut]: solanaTokenAccountInfo({ mint: mintOut, owner: wallet, amount: 0 }),
+    };
+    const post = {
+      [wallet]: solanaNativeAccountInfo(999_995_000),
+      [tokenIn]: solanaTokenAccountInfo({ mint: SOL_USDC, owner: wallet, amount: 0 }),
+      [tokenOut]: solanaTokenAccountInfo({ mint: mintOut, owner: wallet, amount: 1_000_000 }),
+    };
+    const rpcMock = mockSolanaSimRpc({ pre, post });
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ status: 'Success', signature: 'SolSig', chainType: 'solana', broadcaster: 'jupiter' })) });
+      }
+      return rpcMock(url, opts);
+    }));
+    SIMULATION_RPCS.solana = 'http://sol-sim.test';
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{ aggregator: 'jupiter', inputMint: SOL_USDC, outputMint: mintOut, inAmount: '1000000', outAmount: '1000000', transaction: txBase64 }],
+    }, 'solana', 'local', null, null, {
+      swapMode: 'exactIn',
+      request: solanaIntent({ walletAddress: wallet, fromToken: SOL_USDC, toToken: mintOut, amount: '1000000', maxInputAmount: '1000000' }),
+    });
+
+    const logs = [];
+    const cmds = buildTradingCommands({ log: (m) => logs.push(m), exit: () => {} });
+    await cmds.execute([], null, {}, { quote: quoteId });
+
+    expect(logs.some((l) => l.includes('Swap outcome verified'))).toBe(true);
+    expect(logs.some((l) => l.includes('Transaction successful'))).toBe(true);
   });
 });
 

--- a/src/rpc-urls.js
+++ b/src/rpc-urls.js
@@ -12,6 +12,7 @@
  *   NANSEN_XLAYER_RPC     Custom X Layer RPC
  *   NANSEN_SOLANA_RPC     Custom Solana RPC
  *   NANSEN_BASE_SIM_RPC   Custom Base simulation RPC (see SIMULATION_RPCS below)
+ *   NANSEN_SOLANA_SIM_RPC Custom Solana simulation RPC (see SIMULATION_RPCS below)
  *
  * Simulation RPCs (SIMULATION_RPCS) are a SEPARATE registry from the cheap
  * defaults above. Swap-outcome verification (src/swap-simulation.js) needs an
@@ -76,8 +77,16 @@ const DEFAULT_BASE_SIM_RPC = 'https://api.nansen.ai/api/v1/trade/simulate-swap';
 // Intentionally a mutable export: unit tests override an entry in-place (e.g.
 // `SIMULATION_RPCS.base = ...`) to point at a mock or to null out the endpoint,
 // restoring it in afterEach. Runtime code only ever reads it.
+//
+// Solana's `simulateTransaction` (with `accounts` + `replaceRecentBlockhash`) is
+// a standard public-RPC method, unlike the EVM entry above — no trace RPC or
+// Nansen-hosted proxy is needed, so this defaults to the same public endpoint as
+// CHAIN_RPCS.solana. It is called anonymously (see isNansenHostedUrl); a public
+// node may throttle simulation-with-accounts, in which case the check degrades
+// (warns and proceeds) rather than blocking a trade.
 export const SIMULATION_RPCS = {
   base: process.env.NANSEN_BASE_SIM_RPC || DEFAULT_BASE_SIM_RPC,
+  solana: process.env.NANSEN_SOLANA_SIM_RPC || CHAIN_RPCS.solana,
 };
 
 // Nansen hosts the API key may be forwarded to. Kept to an explicit allowlist

--- a/src/schema.json
+++ b/src/schema.json
@@ -1624,7 +1624,7 @@
             },
             "no-verify-outcome": {
               "type": "boolean",
-              "description": "Skip EVM swap-outcome verification. That check simulates the swap and confirms the wallet's balance changes match the quote (input spent within your max, expected output received, no other token moved) before broadcasting; it needs a simulation-capable endpoint (NANSEN_BASE_SIM_RPC) and degrades with a warning when none is available. No effect on Solana."
+              "description": "Skip swap-outcome verification. That check simulates the swap and confirms the wallet's balance changes match the quote (input spent within your max, expected output received, no other asset moved) before broadcasting; it needs a simulation-capable endpoint (NANSEN_BASE_SIM_RPC on EVM, NANSEN_SOLANA_SIM_RPC on Solana) and degrades with a warning when none is available."
             },
             "no-revoke-excessive-allowance": {
               "type": "boolean",

--- a/src/solana-simulation.js
+++ b/src/solana-simulation.js
@@ -109,7 +109,7 @@ async function getMultipleAccountsChunked(rpcUrl, pubkeys, encoding, timeoutMs) 
   const out = [];
   for (let i = 0; i < pubkeys.length; i += MAX_ACCOUNTS_PER_CALL) {
     const chunk = pubkeys.slice(i, i + MAX_ACCOUNTS_PER_CALL);
-    const result = await rpcCall(rpcUrl, 'getMultipleAccounts', [chunk, { encoding }], timeoutMs);
+    const result = await rpcCall(rpcUrl, 'getMultipleAccounts', [chunk, { encoding, commitment: 'confirmed' }], timeoutMs);
     if (!Array.isArray(result?.value)) {
       throw new SolanaSimulationError(
         'SIM_RPC_ERROR',

--- a/src/solana-simulation.js
+++ b/src/solana-simulation.js
@@ -208,23 +208,39 @@ export async function simulateSolanaAssetChanges(chain, txBase64, { walletAddres
 
   const preAccountInfos = await getMultipleAccountsChunked(rpcUrl, writableKeys, 'jsonParsed', timeoutMs);
 
-  // Track only the wallet's own accounts among the writable set — that's the
+  // Track the wallet's own accounts among the writable set — that's the
   // complete drain surface assertSolanaSwapOutcome needs (input/output/sibling).
-  const tracked = []; // { kind: 'native'|'token', pubkey, mint?, preInfo }
+  // Accounts that don't exist pre-swap are tracked as *candidates*: a first-ever
+  // purchase of the output token has the tx create its ATA, so it has no
+  // pre-state to read ownership from. We snapshot it post-simulation anyway and
+  // classify it from the created account's owner (below); a zero pre-balance
+  // makes its whole post-balance the delta. Skipping these would report a 0n
+  // output delta and false-block every first-time buy.
+  const tracked = []; // { pubkey, preInfo, classified, kind?, mint? }
+  let sawWalletAccount = false;
   writableKeys.forEach((pubkey, i) => {
     const info = preAccountInfos[i];
-    if (!info) return; // doesn't exist yet (e.g. an ATA the tx itself creates)
+    if (!info) {
+      tracked.push({ pubkey, preInfo: null, classified: false });
+      return;
+    }
     if (pubkey === walletAddress) {
-      tracked.push({ kind: 'native', pubkey, preInfo: info });
+      tracked.push({ pubkey, preInfo: info, classified: true, kind: 'native' });
+      sawWalletAccount = true;
       return;
     }
     const parsedInfo = info.data?.parsed;
     if (parsedInfo?.type === 'account' && parsedInfo.info?.owner === walletAddress) {
-      tracked.push({ kind: 'token', pubkey, mint: parsedInfo.info.mint, preInfo: info });
+      tracked.push({ pubkey, preInfo: info, classified: true, kind: 'token', mint: parsedInfo.info.mint });
+      sawWalletAccount = true;
     }
   });
 
-  if (!tracked.length) {
+  // The wallet's native account is the fee payer, so it always pre-exists and is
+  // writable; not seeing it means we couldn't locate the signer's own accounts
+  // and can't meaningfully verify the outcome. (Unclassified candidates alone
+  // don't count — they may all belong to other parties.)
+  if (!sawWalletAccount) {
     throw new SolanaSimulationError(
       'SIM_RESULT_UNPARSEABLE',
       'Could not resolve the signer wallet as a writable account in this transaction; cannot verify the outcome.',
@@ -257,11 +273,26 @@ export async function simulateSolanaAssetChanges(chain, txBase64, { walletAddres
 
   const deltas = {};
   tracked.forEach((t, i) => {
-    const pre = extractBalance(t.kind, t.preInfo);
-    const post = extractBalance(t.kind, postAccountInfos[i]);
+    const postInfo = postAccountInfos[i];
+    let { kind, mint } = t;
+    if (!t.classified) {
+      // Newly-created account: classify from its post-simulation state and
+      // count it only if the tx created it as one of the wallet's own accounts
+      // (e.g. the output-token ATA). Anything else is another party's account.
+      if (!postInfo) return;
+      const parsedInfo = postInfo.data?.parsed;
+      if (parsedInfo?.type === 'account' && parsedInfo.info?.owner === walletAddress) {
+        kind = 'token';
+        mint = parsedInfo.info.mint;
+      } else {
+        return;
+      }
+    }
+    const pre = extractBalance(kind, t.preInfo); // null preInfo (new account) → 0n
+    const post = extractBalance(kind, postInfo);
     const delta = post - pre;
     if (delta === 0n) return;
-    const key = t.kind === 'native' ? SOL_SENTINEL : (isSolanaNativeMint(t.mint) ? SOL_SENTINEL : t.mint);
+    const key = kind === 'native' ? SOL_SENTINEL : (isSolanaNativeMint(mint) ? SOL_SENTINEL : mint);
     deltas[key] = (deltas[key] || 0n) + delta;
   });
   for (const k of Object.keys(deltas)) {

--- a/src/solana-simulation.js
+++ b/src/solana-simulation.js
@@ -110,7 +110,13 @@ async function getMultipleAccountsChunked(rpcUrl, pubkeys, encoding, timeoutMs) 
   for (let i = 0; i < pubkeys.length; i += MAX_ACCOUNTS_PER_CALL) {
     const chunk = pubkeys.slice(i, i + MAX_ACCOUNTS_PER_CALL);
     const result = await rpcCall(rpcUrl, 'getMultipleAccounts', [chunk, { encoding }], timeoutMs);
-    out.push(...(result?.value ?? []));
+    if (!Array.isArray(result?.value)) {
+      throw new SolanaSimulationError(
+        'SIM_RPC_ERROR',
+        `getMultipleAccounts returned no account array (value: ${JSON.stringify(result?.value)}); RPC may be rate-limiting or malfunctioning.`,
+      );
+    }
+    out.push(...result.value);
   }
   return out;
 }

--- a/src/solana-simulation.js
+++ b/src/solana-simulation.js
@@ -39,10 +39,14 @@ const MAX_ACCOUNTS_PER_CALL = 100;
  * A simulation error the caller can distinguish from a genuine outcome mismatch.
  * `code` is one of:
  *   NO_SIM_RPC             - no simulation endpoint configured for the chain
- *   SIM_RPC_ERROR           - transport/parse failure talking to the endpoint
+ *   SIM_RPC_ERROR           - transport/parse failure talking to the endpoint,
+ *                             OR a 200 OK sim that omitted the `accounts`
+ *                             result we asked for (an RPC capability gap, not
+ *                             a corrupt result — see the throw site below)
  *   SIM_REVERTED            - the transaction itself reverted in simulation
- *   SIM_RESULT_UNPARSEABLE  - the sim ran, but a tracked balance or lookup
- *                             table couldn't be resolved/parsed
+ *   SIM_RESULT_UNPARSEABLE  - the sim ran AND returned the accounts we asked
+ *                             for, but a tracked balance or lookup table
+ *                             couldn't be resolved/parsed
  * NO_SIM_RPC and SIM_RPC_ERROR are degrade conditions (warn, proceed per
  * policy); the caller decides. SIM_REVERTED and SIM_RESULT_UNPARSEABLE are
  * outcome/parse problems and must not be silently ignored — fail closed.
@@ -268,7 +272,14 @@ export async function simulateSolanaAssetChanges(chain, txBase64, { walletAddres
   }
   const postAccountInfos = simResult?.value?.accounts;
   if (!Array.isArray(postAccountInfos) || postAccountInfos.length !== tracked.length) {
-    throw new SolanaSimulationError('SIM_RESULT_UNPARSEABLE', 'Simulation did not return balance data for the tracked accounts.');
+    // A 200 OK with `err: null` but no (or short) `accounts` array means the
+    // node accepted the request without honoring the `accounts` param — the
+    // same "public node doesn't fully support this" gap rpc-urls.js documents
+    // as a degrade condition, not a corrupt result. SIM_RPC_ERROR here (rather
+    // than SIM_RESULT_UNPARSEABLE) keeps this in verifySolanaSwapOutcome's
+    // degrade allow-list so a capability gap on the default public RPC warns
+    // and proceeds instead of blocking every trade.
+    throw new SolanaSimulationError('SIM_RPC_ERROR', 'Simulation did not return balance data for the tracked accounts (RPC may not support the `accounts` parameter).');
   }
 
   const deltas = {};

--- a/src/solana-simulation.js
+++ b/src/solana-simulation.js
@@ -204,11 +204,25 @@ export async function simulateSolanaAssetChanges(chain, txBase64, { walletAddres
 
   const parsed = parseTransactionMessage(txBase64);
 
+  // Deduplicated: the same pubkey could in principle appear more than once
+  // across the static keys and ALT-resolved writable indexes (or across two
+  // different lookup tables). Without dedup, tracking + summing its delta
+  // twice would double (or further inflate) a real balance change, letting
+  // assertSolanaSwapOutcome's minimum-output check pass on an inflated delta
+  // that doesn't reflect what the wallet actually received.
   const writableKeys = [];
+  const seenWritableKeys = new Set();
+  const pushWritable = (key) => {
+    if (seenWritableKeys.has(key)) return;
+    seenWritableKeys.add(key);
+    writableKeys.push(key);
+  };
   for (let i = 0; i < parsed.staticAccountKeys.length; i++) {
-    if (isStaticWritable(parsed, i)) writableKeys.push(parsed.staticAccountKeys[i]);
+    if (isStaticWritable(parsed, i)) pushWritable(parsed.staticAccountKeys[i]);
   }
-  writableKeys.push(...(await resolveAltWritableAccounts(rpcUrl, parsed, timeoutMs)));
+  for (const key of await resolveAltWritableAccounts(rpcUrl, parsed, timeoutMs)) {
+    pushWritable(key);
+  }
 
   const preAccountInfos = await getMultipleAccountsChunked(rpcUrl, writableKeys, 'jsonParsed', timeoutMs);
 

--- a/src/solana-simulation.js
+++ b/src/solana-simulation.js
@@ -21,7 +21,7 @@ import { SIMULATION_RPCS } from './rpc-urls.js';
 import { parseTransactionMessage } from './solana-tx.js';
 import { base58Encode } from './wallet.js';
 
-// Mirrors NATIVE_SOL_SYSTEM_MINT in trading.js / SOLANA_NATIVE_MINTS in
+// Mirrors NATIVE_SOL_SYSTEM_MINT in trading.js / SOLANA_NATIVE_SOL_ALIASES in
 // trade-validation.js (duplicated, not imported, to avoid a circular import —
 // both of those modules will import from this one).
 const WSOL_MINT = 'So11111111111111111111111111111111111111112';

--- a/src/solana-simulation.js
+++ b/src/solana-simulation.js
@@ -116,6 +116,17 @@ async function getMultipleAccountsChunked(rpcUrl, pubkeys, encoding, timeoutMs) 
         `getMultipleAccounts returned no account array (value: ${JSON.stringify(result?.value)}); RPC may be rate-limiting or malfunctioning.`,
       );
     }
+    // The RPC spec guarantees value.length === chunk.length (null entries for
+    // missing accounts), and every downstream read indexes into this array
+    // positionally against writableKeys. A short array would silently shift
+    // every later account's pre-state by one slot rather than fail loudly —
+    // treat a non-conforming length the same as a malformed response.
+    if (result.value.length !== chunk.length) {
+      throw new SolanaSimulationError(
+        'SIM_RPC_ERROR',
+        `getMultipleAccounts returned ${result.value.length} accounts for a ${chunk.length}-key request; RPC may be rate-limiting or malfunctioning.`,
+      );
+    }
     out.push(...result.value);
   }
   return out;

--- a/src/solana-simulation.js
+++ b/src/solana-simulation.js
@@ -1,0 +1,272 @@
+/**
+ * Solana swap-outcome simulation: run a swap transaction through
+ * `simulateTransaction` and report the resulting balance changes to the
+ * signer's wallet.
+ *
+ * This is the Solana sibling of swap-simulation.js. Solana signs the
+ * aggregator's serialized transaction verbatim, so this is the only check that
+ * confirms the wallet actually comes out the way the quote promised — the
+ * static checks in trade-validation.js inspect the instructions themselves,
+ * not their effect. All delta math runs here, client-side, from the raw
+ * `accounts` snapshot the RPC returns, so the verification stays independent
+ * of the service that built the quote.
+ *
+ * Unlike the EVM simulation endpoint, `simulateTransaction` (with `accounts` +
+ * `replaceRecentBlockhash`) is a standard public-RPC method — no trace RPC, no
+ * Nansen-hosted proxy. It is always called anonymously (see SIMULATION_RPCS.solana
+ * in rpc-urls.js); the Nansen API key is never attached here.
+ */
+
+import { SIMULATION_RPCS } from './rpc-urls.js';
+import { parseTransactionMessage } from './solana-tx.js';
+import { base58Encode } from './wallet.js';
+
+// Mirrors NATIVE_SOL_SYSTEM_MINT in trading.js / SOLANA_NATIVE_MINTS in
+// trade-validation.js (duplicated, not imported, to avoid a circular import —
+// both of those modules will import from this one).
+const WSOL_MINT = 'So11111111111111111111111111111111111111112';
+export const SOL_SENTINEL = '11111111111111111111111111111111';
+
+function isSolanaNativeMint(mint) {
+  return mint === WSOL_MINT || mint === SOL_SENTINEL;
+}
+
+// getMultipleAccounts caps at 100 keys per call; batch defensively even though
+// a real swap's writable-account set is well under this.
+const MAX_ACCOUNTS_PER_CALL = 100;
+
+/**
+ * A simulation error the caller can distinguish from a genuine outcome mismatch.
+ * `code` is one of:
+ *   NO_SIM_RPC             - no simulation endpoint configured for the chain
+ *   SIM_RPC_ERROR           - transport/parse failure talking to the endpoint
+ *   SIM_REVERTED            - the transaction itself reverted in simulation
+ *   SIM_RESULT_UNPARSEABLE  - the sim ran, but a tracked balance or lookup
+ *                             table couldn't be resolved/parsed
+ * NO_SIM_RPC and SIM_RPC_ERROR are degrade conditions (warn, proceed per
+ * policy); the caller decides. SIM_REVERTED and SIM_RESULT_UNPARSEABLE are
+ * outcome/parse problems and must not be silently ignored — fail closed.
+ */
+export class SolanaSimulationError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'SolanaSimulationError';
+    this.code = code;
+  }
+}
+
+/** Whether a sim-capable endpoint is configured for this chain. */
+export function hasSolanaSimulationRpc(chain) {
+  return chain === 'solana' && Boolean(SIMULATION_RPCS.solana);
+}
+
+async function rpcCall(rpcUrl, method, params, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+      signal: controller.signal,
+    });
+    const text = await res.text();
+    let body;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      throw new SolanaSimulationError(
+        'SIM_RPC_ERROR',
+        `Simulation RPC returned non-JSON (HTTP ${res.status}) for ${method}: ${text.slice(0, 120)}`,
+      );
+    }
+    const ok = res.ok ?? (res.status >= 200 && res.status < 300);
+    if (!ok) {
+      const detail = body?.error?.message || text.slice(0, 120);
+      throw new SolanaSimulationError('SIM_RPC_ERROR', `Simulation RPC HTTP ${res.status} for ${method}: ${detail}`);
+    }
+    if (body.error) {
+      throw new SolanaSimulationError('SIM_RPC_ERROR', `${method} error: ${body.error.message || JSON.stringify(body.error)}`);
+    }
+    return body.result;
+  } catch (e) {
+    if (e instanceof SolanaSimulationError) throw e;
+    if (e.name === 'AbortError') {
+      throw new SolanaSimulationError('SIM_RPC_ERROR', `Simulation RPC timed out after ${timeoutMs}ms (${method})`);
+    }
+    throw new SolanaSimulationError('SIM_RPC_ERROR', `Simulation RPC request failed (${method}): ${e.message}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function getMultipleAccountsChunked(rpcUrl, pubkeys, encoding, timeoutMs) {
+  if (!pubkeys.length) return [];
+  const out = [];
+  for (let i = 0; i < pubkeys.length; i += MAX_ACCOUNTS_PER_CALL) {
+    const chunk = pubkeys.slice(i, i + MAX_ACCOUNTS_PER_CALL);
+    const result = await rpcCall(rpcUrl, 'getMultipleAccounts', [chunk, { encoding }], timeoutMs);
+    out.push(...(result?.value ?? []));
+  }
+  return out;
+}
+
+/**
+ * A static account index is writable unless it's a readonly signer or one of
+ * the trailing readonly non-signers. Mirrors the header layout parsed by
+ * parseTransactionMessage (solana-tx.js).
+ */
+function isStaticWritable(parsed, index) {
+  const { numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts } = parsed.header;
+  const numStatic = parsed.staticAccountKeys.length;
+  if (index < numRequiredSignatures) {
+    return index < numRequiredSignatures - numReadonlySignedAccounts;
+  }
+  return index < numStatic - numReadonlyUnsignedAccounts;
+}
+
+/**
+ * Resolve only the WRITABLE accounts a v0 transaction references through
+ * address-lookup-tables. A readonly ALT account can never change balance, so
+ * it's irrelevant to the drain-surface check below — resolving only the
+ * writable indexes saves decoding entries this check will never use.
+ */
+async function resolveAltWritableAccounts(rpcUrl, parsed, timeoutMs) {
+  if (!parsed.addressTableLookups.length) return [];
+  const tableAddresses = parsed.addressTableLookups.map((l) => l.lookupTableAddress);
+  const tableInfos = await getMultipleAccountsChunked(rpcUrl, tableAddresses, 'base64', timeoutMs);
+
+  const resolved = [];
+  parsed.addressTableLookups.forEach((lookup, i) => {
+    const info = tableInfos[i];
+    if (!info) {
+      throw new SolanaSimulationError(
+        'SIM_RESULT_UNPARSEABLE',
+        `Address lookup table ${lookup.lookupTableAddress} not found; cannot resolve its accounts.`,
+      );
+    }
+    // LookupTableMeta: typeIndex u32, deactivationSlot u64, lastExtendedSlot u64,
+    // lastExtendedSlotStartIndex u8, authority Option<Pubkey>, padding — 32-byte
+    // pubkeys begin at byte offset 56.
+    const raw = Array.isArray(info.data) ? info.data[0] : info.data;
+    const buf = Buffer.from(raw, 'base64');
+    for (const idx of lookup.writableIndexes) {
+      const offset = 56 + idx * 32;
+      if (offset + 32 > buf.length) {
+        throw new SolanaSimulationError(
+          'SIM_RESULT_UNPARSEABLE',
+          `Address lookup table ${lookup.lookupTableAddress} has no entry at index ${idx}.`,
+        );
+      }
+      resolved.push(base58Encode(buf.subarray(offset, offset + 32)));
+    }
+  });
+  return resolved;
+}
+
+/** Lamports (native) or SPL token base-unit balance from a jsonParsed account. */
+function extractBalance(kind, info) {
+  if (!info) return 0n;
+  try {
+    if (kind === 'native') return BigInt(info.lamports ?? 0);
+    const amt = info.data?.parsed?.info?.tokenAmount?.amount;
+    return amt != null ? BigInt(amt) : 0n;
+  } catch {
+    throw new SolanaSimulationError('SIM_RESULT_UNPARSEABLE', `Could not parse a simulated ${kind} balance.`);
+  }
+}
+
+/**
+ * Simulate a Solana swap transaction and return the normalised asset changes
+ * it causes to `walletAddress`'s wallet.
+ *
+ * @param {string} chain - chain key (only 'solana' is wired today)
+ * @param {string} txBase64 - the serialized transaction to simulate, unsigned
+ * @param {{ walletAddress: string, timeoutMs?: number }} opts
+ * @returns {Promise<{ deltas: Record<string, bigint>, method: string }>}
+ *   deltas is keyed by mint address, with native SOL (and any WSOL leg of the
+ *   same swap) folded under SOL_SENTINEL.
+ * @throws {SolanaSimulationError} on any degrade condition, an in-sim revert,
+ *   or an unparseable result.
+ */
+export async function simulateSolanaAssetChanges(chain, txBase64, { walletAddress, timeoutMs = 20000 } = {}) {
+  const rpcUrl = SIMULATION_RPCS[chain];
+  if (!rpcUrl) {
+    throw new SolanaSimulationError('NO_SIM_RPC', `No simulation RPC configured for chain '${chain}'.`);
+  }
+  if (!walletAddress) {
+    throw new SolanaSimulationError('SIM_RPC_ERROR', 'simulateSolanaAssetChanges requires a `walletAddress`.');
+  }
+
+  const parsed = parseTransactionMessage(txBase64);
+
+  const writableKeys = [];
+  for (let i = 0; i < parsed.staticAccountKeys.length; i++) {
+    if (isStaticWritable(parsed, i)) writableKeys.push(parsed.staticAccountKeys[i]);
+  }
+  writableKeys.push(...(await resolveAltWritableAccounts(rpcUrl, parsed, timeoutMs)));
+
+  const preAccountInfos = await getMultipleAccountsChunked(rpcUrl, writableKeys, 'jsonParsed', timeoutMs);
+
+  // Track only the wallet's own accounts among the writable set — that's the
+  // complete drain surface assertSolanaSwapOutcome needs (input/output/sibling).
+  const tracked = []; // { kind: 'native'|'token', pubkey, mint?, preInfo }
+  writableKeys.forEach((pubkey, i) => {
+    const info = preAccountInfos[i];
+    if (!info) return; // doesn't exist yet (e.g. an ATA the tx itself creates)
+    if (pubkey === walletAddress) {
+      tracked.push({ kind: 'native', pubkey, preInfo: info });
+      return;
+    }
+    const parsedInfo = info.data?.parsed;
+    if (parsedInfo?.type === 'account' && parsedInfo.info?.owner === walletAddress) {
+      tracked.push({ kind: 'token', pubkey, mint: parsedInfo.info.mint, preInfo: info });
+    }
+  });
+
+  if (!tracked.length) {
+    throw new SolanaSimulationError(
+      'SIM_RESULT_UNPARSEABLE',
+      'Could not resolve the signer wallet as a writable account in this transaction; cannot verify the outcome.',
+    );
+  }
+
+  const simResult = await rpcCall(
+    rpcUrl,
+    'simulateTransaction',
+    [
+      txBase64,
+      {
+        sigVerify: false,
+        replaceRecentBlockhash: true,
+        commitment: 'confirmed',
+        encoding: 'base64',
+        accounts: { addresses: tracked.map((t) => t.pubkey), encoding: 'jsonParsed' },
+      },
+    ],
+    timeoutMs,
+  );
+
+  if (simResult?.value?.err != null) {
+    throw new SolanaSimulationError('SIM_REVERTED', `Swap reverts in simulation: ${JSON.stringify(simResult.value.err)}`);
+  }
+  const postAccountInfos = simResult?.value?.accounts;
+  if (!Array.isArray(postAccountInfos) || postAccountInfos.length !== tracked.length) {
+    throw new SolanaSimulationError('SIM_RESULT_UNPARSEABLE', 'Simulation did not return balance data for the tracked accounts.');
+  }
+
+  const deltas = {};
+  tracked.forEach((t, i) => {
+    const pre = extractBalance(t.kind, t.preInfo);
+    const post = extractBalance(t.kind, postAccountInfos[i]);
+    const delta = post - pre;
+    if (delta === 0n) return;
+    const key = t.kind === 'native' ? SOL_SENTINEL : (isSolanaNativeMint(t.mint) ? SOL_SENTINEL : t.mint);
+    deltas[key] = (deltas[key] || 0n) + delta;
+  });
+  for (const k of Object.keys(deltas)) {
+    if (deltas[k] === 0n) delete deltas[k];
+  }
+
+  return { deltas, method: 'simulateTransaction' };
+}

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1336,7 +1336,10 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
  * Address-lookup-table-resolved accounts can never be signers, so those
  * positions are always statically resolvable; only CloseAccount's destination
  * can legitimately be ALT-resolved, and an unresolvable destination is treated
- * the same as a stranger (fail closed).
+ * the same as a stranger (fail closed). The instruction's own program ID must
+ * also be statically resolvable — an ALT-resolved program ID can't be checked
+ * against SPL_TOKEN_PROGRAMS/COMPUTE_BUDGET_PROGRAM, so it's rejected outright
+ * rather than silently skipped.
  *
  * Throws on any of those patterns. Returns the parsed transaction otherwise.
  */
@@ -1373,7 +1376,18 @@ export function assertSolanaInstructionsSafe(txBase64, { walletAddress } = {}) {
 
   for (const ix of parsed.instructions) {
     const programId = resolveStaticAccount(parsed, ix.programIdIndex);
-    if (!programId) continue; // program invoked via an ALT entry — not a pattern we classify
+    // A program ID that's only ALT-resolvable can't be checked against
+    // SPL_TOKEN_PROGRAMS/COMPUTE_BUDGET_PROGRAM without an RPC call this
+    // static check intentionally doesn't make — and skipping it here would
+    // let an Approve/SetAuthority/CloseAccount instruction bypass the drain
+    // protection above just by routing the program ID through an ALT entry.
+    // Real swap/vault transactions reference these well-known programs as
+    // static keys, so fail closed rather than silently skip classification.
+    if (!programId) {
+      throw new Error(
+        'Solana transaction invokes a program only resolvable via an address-lookup-table entry, which cannot be safety-classified. Refusing to sign.',
+      );
+    }
 
     if (SPL_TOKEN_PROGRAMS.has(programId)) {
       // No discriminator byte — not a valid SPL Token instruction (the runtime

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1127,30 +1127,57 @@ export function assertSwapOutcome(request, quote, sim, { slippage, expectedSpend
 // and rent rather than the swap itself.
 const NATIVE_SIBLING_DUST_LAMPORTS = 3_000_000n; // ~0.003 SOL
 
+// Full native-SOL fee/rent noise budget: the dust above PLUS the priority fee
+// a transaction may legitimately pay, up to the ceiling assertSolanaInstructionsSafe
+// enforces. NATIVE_SIBLING_DUST_LAMPORTS alone only covers the base fee + rent —
+// a real, legal priority fee (anywhere up to MAX_PRIORITY_FEE_LAMPORTS) also
+// leaves the wallet as native SOL regardless of whether SOL is the input,
+// output, or an uninvolved sibling of the swap, so all three assertions below
+// need the same combined slack or a legitimate high-priority-fee trade false-blocks.
+const NATIVE_FEE_RENT_SLACK_LAMPORTS = MAX_PRIORITY_FEE_LAMPORTS + NATIVE_SIBLING_DUST_LAMPORTS;
+
 /**
  * The Solana sibling of assertSwapOutcome. Solana signs the aggregator's
  * serialized transaction verbatim and has no approval/calldata split to
  * validate, so this verifies the balance-delta simulation result (see
  * solana-simulation.js) against the persisted request intent directly.
  *
- * Three assertions (no assertion 4 sibling — an unexpected authority grant is
- * already rejected statically, RPC-free, by assertSolanaInstructionsSafe
- * before this ever runs):
+ * REQUIRES assertSolanaInstructionsSafe to have already run, RPC-free, on the
+ * same transaction (both current signing paths in trading.js call it first):
+ * an unexpected authority grant is rejected there (no assertion 4 sibling
+ * needed here), and assertion 1's native-input slack below is only a safe
+ * bound because that check has already enforced the priority-fee ceiling —
+ * skip it on any future signing path and native-input drains widen from a
+ * fixed slack to an unbounded priority fee.
+ *
+ * Three assertions:
  *   1. the input token leaves the wallet by no more than maxInputAmount.
- *      Native-SOL input is intentionally metadata-bound only: the lamport
- *      delta also carries the base fee, priority fee, and net ATA rent
- *      (opened minus reclaimed), which is too noisy to bound tightly from a
- *      raw balance delta. Tightness instead comes from assertQuoteMatchesRequest
- *      (binds exactIn input == request.amount) plus assertSolanaInstructionsSafe's
- *      fee-payer/fee-cap checks and assertions 2/3 below. A precise fee/rent
- *      model is explicitly deferred.
+ *      Native-SOL input can't be bound at the exact cap the way an SPL input
+ *      can: its lamport delta also carries the base fee, priority fee, and net
+ *      ATA rent (opened minus reclaimed), which is too noisy for a tight
+ *      bound. It is still bounded, not skipped — the cap is relaxed by a
+ *      fee/rent slack (the priority-fee ceiling assertSolanaInstructionsSafe
+ *      enforces, plus one transient ATA's rent) so a real outflow beyond any
+ *      realistic transaction cost is still caught. Without this, a
+ *      transaction with an extra unaccounted native-SOL outflow (e.g. a plain
+ *      System-Program transfer, which assertSolanaInstructionsSafe does not
+ *      classify) would sail through as long as the declared output arrived —
+ *      neither assertQuoteMatchesRequest (checks the quote's declared
+ *      metadata, not the transaction's real effects) nor assertion 3 (which
+ *      exempts the input asset, assuming assertion 1 already bounded it)
+ *      would catch it.
  *   2. the output token arrives by at least the minimum acceptable amount.
- *      Native-SOL output relaxes this floor by NATIVE_SIBLING_DUST_LAMPORTS
- *      because its lamport delta also nets out the base/priority fee and ATA
- *      rent (same noise as native input); SPL output keeps the exact floor.
+ *      Native-SOL output relaxes this floor by NATIVE_FEE_RENT_SLACK_LAMPORTS
+ *      because its lamport delta also nets out the base fee, priority fee, and
+ *      ATA rent (same noise as native input); SPL output keeps the exact floor.
  *   3. no OTHER tracked asset leaves the wallet. SPL-token siblings get zero
  *      tolerance; native SOL, when it's a sibling (not the input), tolerates
- *      NATIVE_SIBLING_DUST_LAMPORTS of fee/rent dust.
+ *      NATIVE_FEE_RENT_SLACK_LAMPORTS of fee/rent dust. All three assertions
+ *      share this one slack value — splitting it (e.g. a smaller tolerance for
+ *      assertion 2/3 than assertion 1) would false-block a legitimate trade
+ *      paying close to the priority-fee ceiling on whichever assertion has the
+ *      smaller number, since the same fee leaves the wallet as native SOL
+ *      regardless of SOL's role in that particular swap.
  *
  * @param {object} request - persisted intent (quoteData.request); required
  * @param {object} quote - the quote being executed
@@ -1158,10 +1185,11 @@ const NATIVE_SIBLING_DUST_LAMPORTS = 3_000_000n; // ~0.003 SOL
  *   result from simulateSolanaAssetChanges()
  * @param {object} [ctx]
  * @param {number} [ctx.slippage] - slippage fraction in effect; defaults to 3%
- * @param {bigint} [ctx.siblingDustThreshold] - overrides NATIVE_SIBLING_DUST_LAMPORTS
+ * @param {bigint} [ctx.siblingDustThreshold] - overrides NATIVE_FEE_RENT_SLACK_LAMPORTS
  * @returns {{verified: true, inputAssertionSkipped: boolean}} inputAssertionSkipped
- *   is true when the input was native SOL, meaning assertion 1 did not run
- *   (see assertion 1's rationale above) — the caller should surface this.
+ *   is true when the input was native SOL, meaning assertion 1 ran with the
+ *   fee/rent slack applied instead of an exact bound (see assertion 1's
+ *   rationale above) — the caller should surface this.
  * @throws {Error} with `code = 'SWAP_OUTCOME_MISMATCH'` on any failed assertion.
  */
 export function assertSolanaSwapOutcome(request, quote, sim, { slippage, siblingDustThreshold } = {}) {
@@ -1199,22 +1227,30 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
 
   const inputIsNative = inputAsset === SOL_SENTINEL;
 
-  // --- Assertion 1: input outflow within the spend ceiling (SPL input only) ---
-  if (!inputIsNative) {
-    if (request.maxInputAmount == null) {
-      throw fail('request has no maximum input to bound the outflow against.');
-    }
-    let cap;
-    try {
-      cap = BigInt(request.maxInputAmount);
-    } catch {
-      throw fail(`maximum input (${request.maxInputAmount}) is not an integer.`);
-    }
-    const inputDelta = deltas[inputAsset] || 0n;
-    const outflow = inputDelta < 0n ? -inputDelta : 0n;
-    if (outflow > cap) {
-      throw fail(`the input token (${inputAsset}) left the wallet by ${outflow}, exceeding your maximum input (${cap}).`);
-    }
+  // --- Assertion 1: input outflow within the spend ceiling ---
+  if (request.maxInputAmount == null) {
+    throw fail('request has no maximum input to bound the outflow against.');
+  }
+  let cap;
+  try {
+    cap = BigInt(request.maxInputAmount);
+  } catch {
+    throw fail(`maximum input (${request.maxInputAmount}) is not an integer.`);
+  }
+  // Native-SOL input's lamport delta also carries the base fee, priority fee,
+  // and net ATA rent (opened minus reclaimed), so it can't be bound at the
+  // exact cap the way an SPL input can — but it must still be BOUNDED, not
+  // skipped: without this, a transaction with an extra unaccounted native-SOL
+  // outflow (e.g. a plain System-Program transfer, which assertSolanaInstructionsSafe
+  // does not classify) sails through as long as the declared output still
+  // arrives. The slack allows the worst realistic fee/rent noise — the same
+  // priority-fee ceiling assertSolanaInstructionsSafe enforces, plus one
+  // transient ATA's rent — without opening the cap back up to an unbounded drain.
+  const effectiveCap = inputIsNative ? cap + NATIVE_FEE_RENT_SLACK_LAMPORTS : cap;
+  const inputDelta = deltas[inputAsset] || 0n;
+  const outflow = inputDelta < 0n ? -inputDelta : 0n;
+  if (outflow > effectiveCap) {
+    throw fail(`the input token (${inputAsset}) left the wallet by ${outflow}, exceeding your maximum input (${cap}${inputIsNative ? ` plus fee/rent slack` : ''}).`);
   }
 
   // --- Assertion 2: output arrives at or above the minimum acceptable ---
@@ -1258,11 +1294,12 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
   // lamport delta is (SOL received − base/priority fee − net ATA rent), so a
   // legitimate trade can land a few million lamports under the quoted amount at
   // tight slippage or on a congested-network priority fee. Relax the floor by
-  // the same dust tolerance used for native siblings (assertion 3) so fee noise
-  // never false-blocks; the slippage floor still bounds any real shortfall. SPL
-  // output has no such noise and keeps the exact floor.
+  // the same combined fee/rent slack used for native siblings (assertion 3) and
+  // native input (assertion 1) so fee noise never false-blocks; the slippage
+  // floor still bounds any real shortfall. SPL output has no such noise and
+  // keeps the exact floor.
   const outputFloorSlack = outputIsNative
-    ? (siblingDustThreshold != null ? siblingDustThreshold : NATIVE_SIBLING_DUST_LAMPORTS)
+    ? (siblingDustThreshold != null ? siblingDustThreshold : NATIVE_FEE_RENT_SLACK_LAMPORTS)
     : 0n;
   // minOut can be smaller than the dust tolerance for a dust-quoted swap; clamp
   // the floor at 0 so the subtraction never goes negative and silently admits
@@ -1276,9 +1313,9 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
   }
 
   // --- Assertion 3: no other tracked asset leaves the wallet ---
-  const nativeDust = siblingDustThreshold != null ? siblingDustThreshold : NATIVE_SIBLING_DUST_LAMPORTS;
+  const nativeDust = siblingDustThreshold != null ? siblingDustThreshold : NATIVE_FEE_RENT_SLACK_LAMPORTS;
   for (const [token, delta] of Object.entries(deltas)) {
-    if (token === inputAsset) continue; // bounded by assertion 1 (or metadata-bound, for native input)
+    if (token === inputAsset) continue; // bounded by assertion 1 (with fee/rent slack, for native input)
     if (delta >= 0n) continue;
     const dust = token === SOL_SENTINEL ? nativeDust : 0n;
     if (-delta > dust) {
@@ -1286,9 +1323,9 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
     }
   }
 
-  // inputAssertionSkipped tells the caller assertion 1 didn't run (native-SOL
-  // input, per the JSDoc above), so it can surface that instead of implying
-  // the input spend was delta-verified.
+  // inputAssertionSkipped tells the caller assertion 1 ran with the fee/rent
+  // slack applied (native-SOL input, per the JSDoc above), so it can surface
+  // that instead of implying the input spend was tightly delta-verified.
   return { verified: true, inputAssertionSkipped: inputIsNative };
 }
 

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1181,7 +1181,7 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
     deltas[k] = amt;
   }
 
-  const foldNative = (mint) => (mint && SOLANA_NATIVE_MINTS.has(mint) ? SOL_SENTINEL : mint);
+  const foldNative = (mint) => (mint && SOLANA_NATIVE_SOL_ALIASES.has(mint) ? SOL_SENTINEL : mint);
   const inputAsset = quote?.inputMint ? foldNative(quote.inputMint) : null;
   const outputAsset = quote?.outputMint ? foldNative(quote.outputMint) : null;
   if (!inputAsset || !outputAsset) {
@@ -1279,21 +1279,19 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
  * (paired with the intent-binding metadata check), not a complete
  * authorization audit of the transaction.
  *
- * IMPORTANT — no outcome simulation backs this on Solana. Unlike the EVM path,
- * which pairs its static calldata checks with a balance-delta simulation
- * (verifySwapOutcome), there is no Solana simulation RPC (SIMULATION_RPCS is
- * Base-only), so this static check plus the metadata binding are the ONLY
- * transaction-level guards on the Solana signing path. In particular this
- * check does NOT classify SPL Transfer/TransferChecked: a legitimate swap or
- * vault deposit moves the input token (and WSOL) with exactly those
- * instructions, so they can't be blanket-rejected, and without a balance-delta
- * simulation there's nothing here to bound their destination or amount. The
- * consequence is a residual gap: a transaction that also transfers an
- * unrelated ("sibling") token the wallet holds, authorized by the wallet,
- * would pass. Closing it needs either a Solana outcome simulation or a positive
- * check that every wallet-authorized transfer moves only the declared input
- * mint (TransferChecked carries the mint; plain Transfer does not, so this
- * needs an RPC account lookup) — tracked as a follow-up, not covered here.
+ * IMPORTANT — this static check does NOT classify SPL Transfer/TransferChecked:
+ * a legitimate swap or vault deposit moves the input token (and WSOL) with
+ * exactly those instructions, so they can't be blanket-rejected, and there is
+ * nothing here to bound their destination or amount. On its own this leaves a
+ * residual gap: a transaction that also transfers an unrelated ("sibling")
+ * token the wallet holds, authorized by the wallet, would pass this check.
+ * That gap is now closed by outcome simulation — assertSolanaSwapOutcome, run
+ * via verifySolanaSwapOutcome immediately after this check on all Solana
+ * signing paths, simulates the transaction and rejects any balance delta on a
+ * token other than the declared input/output. That simulation degrades
+ * gracefully (warns and proceeds) when no simulation RPC endpoint is
+ * configured, so this static check plus the metadata binding remain the ONLY
+ * transaction-level guards whenever a sim RPC is unavailable.
  *
  * Within that scope, the SPL Token program requires the *authority* of
  * Approve/ApproveChecked/SetAuthority/CloseAccount to sign the transaction,

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1145,6 +1145,9 @@ const NATIVE_SIBLING_DUST_LAMPORTS = 3_000_000n; // ~0.003 SOL
  *      fee-payer/fee-cap checks and assertions 2/3 below. A precise fee/rent
  *      model is explicitly deferred.
  *   2. the output token arrives by at least the minimum acceptable amount.
+ *      Native-SOL output relaxes this floor by NATIVE_SIBLING_DUST_LAMPORTS
+ *      because its lamport delta also nets out the base/priority fee and ATA
+ *      rent (same noise as native input); SPL output keeps the exact floor.
  *   3. no OTHER tracked asset leaves the wallet. SPL-token siblings get zero
  *      tolerance; native SOL, when it's a sibling (not the input), tolerates
  *      NATIVE_SIBLING_DUST_LAMPORTS of fee/rent dust.
@@ -1213,6 +1216,7 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
 
   // --- Assertion 2: output arrives at or above the minimum acceptable ---
   const swapMode = request.swapMode ?? 'exactIn';
+  const outputIsNative = outputAsset === SOL_SENTINEL;
   const outputDelta = deltas[outputAsset] || 0n;
   let minOut;
   if (swapMode === 'exactOut') {
@@ -1247,7 +1251,17 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
     const bps = BigInt(Math.min(10000, Math.round(slip * 10000)));
     minOut = (quoted * (10000n - bps)) / 10000n;
   }
-  if (outputDelta < minOut) {
+  // Native-SOL output carries the same fee/rent noise as native input: the
+  // lamport delta is (SOL received − base/priority fee − net ATA rent), so a
+  // legitimate trade can land a few million lamports under the quoted amount at
+  // tight slippage or on a congested-network priority fee. Relax the floor by
+  // the same dust tolerance used for native siblings (assertion 3) so fee noise
+  // never false-blocks; the slippage floor still bounds any real shortfall. SPL
+  // output has no such noise and keeps the exact floor.
+  const outputFloorSlack = outputIsNative
+    ? (siblingDustThreshold != null ? siblingDustThreshold : NATIVE_SIBLING_DUST_LAMPORTS)
+    : 0n;
+  if (outputDelta < minOut - outputFloorSlack) {
     throw fail(`the output token (${outputAsset}) increased by only ${outputDelta}, below the minimum acceptable output (${minOut}).`);
   }
 

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1261,7 +1261,11 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
   const outputFloorSlack = outputIsNative
     ? (siblingDustThreshold != null ? siblingDustThreshold : NATIVE_SIBLING_DUST_LAMPORTS)
     : 0n;
-  if (outputDelta < minOut - outputFloorSlack) {
+  // minOut can be smaller than the dust tolerance for a dust-quoted swap; clamp
+  // the floor at 0 so the subtraction never goes negative and silently admits
+  // any non-negative outputDelta (including zero).
+  const adjustedFloor = minOut > outputFloorSlack ? minOut - outputFloorSlack : 0n;
+  if (outputDelta < adjustedFloor) {
     throw fail(`the output token (${outputAsset}) increased by only ${outputDelta}, below the minimum acceptable output (${minOut}).`);
   }
 

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -7,6 +7,7 @@
 import { validateAddress } from './api.js';
 import { CHAIN_RPCS } from './rpc-urls.js';
 import { parseTransactionMessage, resolveStaticAccount } from './solana-tx.js';
+import { SOL_SENTINEL } from './solana-simulation.js';
 
 const SUPPORTED_CHAINS = ['solana', 'base'];
 
@@ -1113,6 +1114,151 @@ export function assertSwapOutcome(request, quote, sim, { slippage, expectedSpend
       throw fail(
         `the swap grants an approval to an unexpected spender (${spender}); a swap should only (re)approve ${allowed.size ? [...allowed].join(', ') : 'nothing'}.`,
       );
+    }
+  }
+
+  return { verified: true };
+}
+
+// Native-SOL dust tolerated on a non-input sibling in assertSolanaSwapOutcome —
+// covers the base tx fee plus one transient ATA's rent (e.g. a WSOL account
+// opened and closed within the swap). SPL-token siblings get no such tolerance
+// (dust threshold 0n); only native SOL legitimately moves as a byproduct of fees
+// and rent rather than the swap itself.
+const NATIVE_SIBLING_DUST_LAMPORTS = 3_000_000n; // ~0.003 SOL
+
+/**
+ * The Solana sibling of assertSwapOutcome. Solana signs the aggregator's
+ * serialized transaction verbatim and has no approval/calldata split to
+ * validate, so this verifies the balance-delta simulation result (see
+ * solana-simulation.js) against the persisted request intent directly.
+ *
+ * Three assertions (no assertion 4 sibling — an unexpected authority grant is
+ * already rejected statically, RPC-free, by assertSolanaInstructionsSafe
+ * before this ever runs):
+ *   1. the input token leaves the wallet by no more than maxInputAmount.
+ *      Native-SOL input is intentionally metadata-bound only: the lamport
+ *      delta also carries the base fee, priority fee, and net ATA rent
+ *      (opened minus reclaimed), which is too noisy to bound tightly from a
+ *      raw balance delta. Tightness instead comes from assertQuoteMatchesRequest
+ *      (binds exactIn input == request.amount) plus assertSolanaInstructionsSafe's
+ *      fee-payer/fee-cap checks and assertions 2/3 below. A precise fee/rent
+ *      model is explicitly deferred.
+ *   2. the output token arrives by at least the minimum acceptable amount.
+ *   3. no OTHER tracked asset leaves the wallet. SPL-token siblings get zero
+ *      tolerance; native SOL, when it's a sibling (not the input), tolerates
+ *      NATIVE_SIBLING_DUST_LAMPORTS of fee/rent dust.
+ *
+ * @param {object} request - persisted intent (quoteData.request); required
+ * @param {object} quote - the quote being executed
+ * @param {{deltas: Record<string, bigint|string|number>}} sim - the normalised
+ *   result from simulateSolanaAssetChanges()
+ * @param {object} [ctx]
+ * @param {number} [ctx.slippage] - slippage fraction in effect; defaults to 3%
+ * @param {bigint} [ctx.siblingDustThreshold] - overrides NATIVE_SIBLING_DUST_LAMPORTS
+ * @throws {Error} with `code = 'SWAP_OUTCOME_MISMATCH'` on any failed assertion.
+ */
+export function assertSolanaSwapOutcome(request, quote, sim, { slippage, siblingDustThreshold } = {}) {
+  const fail = (detail) => {
+    const e = new Error(`Swap outcome mismatch (SWAP_OUTCOME_MISMATCH): ${detail} Refusing to sign.`);
+    e.code = 'SWAP_OUTCOME_MISMATCH';
+    return e;
+  };
+
+  if (!request) throw fail('no request intent to verify the outcome against.');
+  if (!sim || typeof sim !== 'object' || sim.deltas == null) {
+    throw fail('simulation returned no asset changes to verify.');
+  }
+
+  const deltas = {};
+  for (const [k, v] of Object.entries(sim.deltas)) {
+    let amt;
+    try {
+      amt = typeof v === 'bigint' ? v : BigInt(v);
+    } catch {
+      throw fail(`simulated delta for ${k} (${v}) is not an integer.`);
+    }
+    deltas[k] = amt;
+  }
+
+  const foldNative = (mint) => (mint && SOLANA_NATIVE_MINTS.has(mint) ? SOL_SENTINEL : mint);
+  const inputAsset = quote?.inputMint ? foldNative(quote.inputMint) : null;
+  const outputAsset = quote?.outputMint ? foldNative(quote.outputMint) : null;
+  if (!inputAsset || !outputAsset) {
+    throw fail('quote is missing the input or output token address.');
+  }
+  if (inputAsset === outputAsset) {
+    throw fail(`quote input and output tokens are the same (${inputAsset}); refusing to verify.`);
+  }
+
+  const inputIsNative = inputAsset === SOL_SENTINEL;
+
+  // --- Assertion 1: input outflow within the spend ceiling (SPL input only) ---
+  if (!inputIsNative) {
+    if (request.maxInputAmount == null) {
+      throw fail('request has no maximum input to bound the outflow against.');
+    }
+    let cap;
+    try {
+      cap = BigInt(request.maxInputAmount);
+    } catch {
+      throw fail(`maximum input (${request.maxInputAmount}) is not an integer.`);
+    }
+    const inputDelta = deltas[inputAsset] || 0n;
+    const outflow = inputDelta < 0n ? -inputDelta : 0n;
+    if (outflow > cap) {
+      throw fail(`the input token (${inputAsset}) left the wallet by ${outflow}, exceeding your maximum input (${cap}).`);
+    }
+  }
+
+  // --- Assertion 2: output arrives at or above the minimum acceptable ---
+  const swapMode = request.swapMode ?? 'exactIn';
+  const outputDelta = deltas[outputAsset] || 0n;
+  let minOut;
+  if (swapMode === 'exactOut') {
+    if (request.amount == null) throw fail('exactOut request is missing the requested output amount.');
+    try {
+      minOut = BigInt(request.amount);
+    } catch {
+      throw fail(`requested output amount (${request.amount}) is not an integer.`);
+    }
+    if (minOut <= 0n) {
+      throw fail(`exactOut request has a non-positive output amount (${minOut}); cannot compute a minimum acceptable output.`);
+    }
+  } else {
+    const quotedRaw = quote?.outAmount ?? quote?.outputAmount;
+    if (quotedRaw == null) {
+      throw fail('quote is missing the quoted output amount; cannot compute the minimum acceptable output.');
+    }
+    let quoted;
+    try {
+      quoted = BigInt(quotedRaw);
+    } catch {
+      throw fail(`quoted output amount (${quotedRaw}) is not an integer.`);
+    }
+    if (quoted <= 0n) {
+      throw fail(`quote has a non-positive output amount (${quoted}); cannot compute a minimum acceptable output.`);
+    }
+    // Floor of quoted × (1 − slippage), capped at 50% independent of what the
+    // user set (mirrors assertSwapOutcome's rationale: a defence-in-depth
+    // floor, not the user's execution tolerance).
+    const rawSlip = Number.isFinite(slippage) && slippage >= 0 ? slippage : 0.03;
+    const slip = Math.min(rawSlip, 0.5);
+    const bps = BigInt(Math.min(10000, Math.round(slip * 10000)));
+    minOut = (quoted * (10000n - bps)) / 10000n;
+  }
+  if (outputDelta < minOut) {
+    throw fail(`the output token (${outputAsset}) increased by only ${outputDelta}, below the minimum acceptable output (${minOut}).`);
+  }
+
+  // --- Assertion 3: no other tracked asset leaves the wallet ---
+  const nativeDust = siblingDustThreshold != null ? siblingDustThreshold : NATIVE_SIBLING_DUST_LAMPORTS;
+  for (const [token, delta] of Object.entries(deltas)) {
+    if (token === inputAsset) continue; // bounded by assertion 1 (or metadata-bound, for native input)
+    if (delta >= 0n) continue;
+    const dust = token === SOL_SENTINEL ? nativeDust : 0n;
+    if (-delta > dust) {
+      throw fail(`a token other than the one you are selling (${token}) left the wallet (delta ${delta}); a swap must not move any token except the input.`);
     }
   }
 

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1266,9 +1266,12 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
     : 0n;
   // minOut can be smaller than the dust tolerance for a dust-quoted swap; clamp
   // the floor at 0 so the subtraction never goes negative and silently admits
-  // any non-negative outputDelta (including zero).
+  // any non-negative outputDelta (including zero). The explicit outputDelta <= 0n
+  // check below then restores the invariant assertSwapOutcome (the EVM sibling)
+  // gets for free because its minOut can never collapse to <= 0: a swap must
+  // deliver SOME positive output, even when the dust-adjusted floor is 0.
   const adjustedFloor = minOut > outputFloorSlack ? minOut - outputFloorSlack : 0n;
-  if (outputDelta < adjustedFloor) {
+  if (outputDelta <= 0n || outputDelta < adjustedFloor) {
     throw fail(`the output token (${outputAsset}) increased by only ${outputDelta}, below the minimum acceptable output (${minOut}).`);
   }
 
@@ -1309,13 +1312,18 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
  * nothing here to bound their destination or amount. On its own this leaves a
  * residual gap: a transaction that also transfers an unrelated ("sibling")
  * token the wallet holds, authorized by the wallet, would pass this check.
- * That gap is now closed by outcome simulation — assertSolanaSwapOutcome, run
- * via verifySolanaSwapOutcome immediately after this check on all Solana
- * signing paths, simulates the transaction and rejects any balance delta on a
- * token other than the declared input/output. That simulation degrades
- * gracefully (warns and proceeds) when no simulation RPC endpoint is
- * configured, so this static check plus the metadata binding remain the ONLY
- * transaction-level guards whenever a sim RPC is unavailable.
+ * That gap is now closed, for swap execution, by outcome simulation —
+ * assertSolanaSwapOutcome, run via verifySolanaSwapOutcome immediately after
+ * this check on all Solana swap-execute signing paths (trading.js), simulates
+ * the transaction and rejects any balance delta on a token other than the
+ * declared input/output. That simulation degrades gracefully (warns and
+ * proceeds) when no simulation RPC endpoint is configured, so this static
+ * check plus the metadata binding remain the ONLY transaction-level guards
+ * whenever a sim RPC is unavailable. Limit-order vault deposit/cancel
+ * (limit-order.js) call only this static check, not verifySolanaSwapOutcome —
+ * they have no swap quote (no declared input/output pair) to bind an outcome
+ * check against, so the sibling-transfer gap described above is still open
+ * there; tracked as a follow-up, not covered here.
  *
  * Within that scope, the SPL Token program requires the *authority* of
  * Approve/ApproveChecked/SetAuthority/CloseAccount to sign the transaction,

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1159,6 +1159,9 @@ const NATIVE_SIBLING_DUST_LAMPORTS = 3_000_000n; // ~0.003 SOL
  * @param {object} [ctx]
  * @param {number} [ctx.slippage] - slippage fraction in effect; defaults to 3%
  * @param {bigint} [ctx.siblingDustThreshold] - overrides NATIVE_SIBLING_DUST_LAMPORTS
+ * @returns {{verified: true, inputAssertionSkipped: boolean}} inputAssertionSkipped
+ *   is true when the input was native SOL, meaning assertion 1 did not run
+ *   (see assertion 1's rationale above) — the caller should surface this.
  * @throws {Error} with `code = 'SWAP_OUTCOME_MISMATCH'` on any failed assertion.
  */
 export function assertSolanaSwapOutcome(request, quote, sim, { slippage, siblingDustThreshold } = {}) {
@@ -1280,7 +1283,10 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
     }
   }
 
-  return { verified: true };
+  // inputAssertionSkipped tells the caller assertion 1 didn't run (native-SOL
+  // input, per the JSDoc above), so it can surface that instead of implying
+  // the input spend was delta-verified.
+  return { verified: true, inputAssertionSkipped: inputIsNative };
 }
 
 /**

--- a/src/trading.js
+++ b/src/trading.js
@@ -813,7 +813,10 @@ export async function verifySolanaSwapOutcome({ chain, walletAddress, txBase64, 
   }
   try {
     const sim = await simulateSolanaAssetChanges(chain, txBase64, { walletAddress });
-    assertSolanaSwapOutcome(quoteData.request, quote, sim, { slippage: quoteData.slippage });
+    const outcome = assertSolanaSwapOutcome(quoteData.request, quote, sim, { slippage: quoteData.slippage });
+    if (outcome.inputAssertionSkipped) {
+      log('  ℹ Native-SOL input spend is metadata-bound, not delta-verified (fee/rent noise); output and sibling checks still ran.');
+    }
     log(`  ✓ Swap outcome verified (via ${sim.method}).`);
     return { proceed: true };
   } catch (e) {

--- a/src/trading.js
+++ b/src/trading.js
@@ -2208,10 +2208,9 @@ EXAMPLES:
               // Then statically inspect the serialized transaction's own
               // instructions ahead of signing — catches a delegate grant, authority
               // change, close-to-stranger, or excessive fee that the metadata check
-              // alone wouldn't see. Solana has no balance-delta simulation (that
-              // layer is Base-only), so this static check plus the metadata binding
-              // are the only transaction-level guards here — see
-              // assertSolanaInstructionsSafe for the residual sibling-transfer gap.
+              // alone wouldn't see. The residual sibling-transfer gap is closed by
+              // verifySolanaSwapOutcome below (degrades gracefully when no sim RPC
+              // is available, so this static check remains a guard when sim is off).
               assertSolanaInstructionsSafe(txBase64, { walletAddress });
 
               // Verify the swap's simulated on-chain outcome matches intent.
@@ -2530,10 +2529,9 @@ EXAMPLES:
               // Then statically inspect the serialized transaction's own
               // instructions ahead of signing — catches a delegate grant, authority
               // change, close-to-stranger, or excessive fee that the metadata check
-              // alone wouldn't see. Solana has no balance-delta simulation (that
-              // layer is Base-only), so this static check plus the metadata binding
-              // are the only transaction-level guards here — see
-              // assertSolanaInstructionsSafe for the residual sibling-transfer gap.
+              // alone wouldn't see. The residual sibling-transfer gap is closed by
+              // verifySolanaSwapOutcome below (degrades gracefully when no sim RPC
+              // is available, so this static check remains a guard when sim is off).
               assertSolanaInstructionsSafe(txBase64, { walletAddress: solanaWalletAddress });
 
               // Verify the swap's simulated on-chain outcome matches intent.

--- a/src/trading.js
+++ b/src/trading.js
@@ -815,7 +815,7 @@ export async function verifySolanaSwapOutcome({ chain, walletAddress, txBase64, 
     const sim = await simulateSolanaAssetChanges(chain, txBase64, { walletAddress });
     const outcome = assertSolanaSwapOutcome(quoteData.request, quote, sim, { slippage: quoteData.slippage });
     if (outcome.inputAssertionSkipped) {
-      log('  ℹ Native-SOL input spend is metadata-bound, not delta-verified (fee/rent noise); output and sibling checks still ran.');
+      log('  ℹ Native-SOL input spend is bounded with fee/rent slack, not exactly delta-verified; output and sibling checks still ran.');
     }
     log(`  ✓ Swap outcome verified (via ${sim.method}).`);
     return { proceed: true };

--- a/src/trading.js
+++ b/src/trading.js
@@ -13,11 +13,12 @@ import { base58Decode } from './transfer.js';
 import { keccak256, signSecp256k1, rlpEncode } from './crypto.js';
 import { getWalletConnectAddress, sendTransactionViaWalletConnect, sendSolanaTransactionViaWalletConnect, sendApprovalViaWalletConnect } from './walletconnect-trading.js';
 import { retrievePassword } from './keychain.js';
-import { validateQuoteInput, validateBalance, resolvePercentAmount, validateGasBalance, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, approvalAmountForSwap, needsAllowanceRevoke, OVERSIZED_ALLOWANCE_MULTIPLIER } from './trade-validation.js';
+import { validateQuoteInput, validateBalance, resolvePercentAmount, validateGasBalance, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, assertSolanaSwapOutcome, approvalAmountForSwap, needsAllowanceRevoke, OVERSIZED_ALLOWANCE_MULTIPLIER } from './trade-validation.js';
 import { readCompactU16 } from './solana-tx.js';
 export { readCompactU16 };
 import { CHAIN_RPCS } from './rpc-urls.js';
 import { simulateAssetChanges, SwapSimulationError, hasSimulationRpc } from './swap-simulation.js';
+import { simulateSolanaAssetChanges, SolanaSimulationError, hasSolanaSimulationRpc } from './solana-simulation.js';
 import { packageVersion, CommandError, telemetryHeaders, loadConfig } from './api.js';
 
 // ============= Constants =============
@@ -783,6 +784,40 @@ export async function verifySwapOutcome({ chain, from, quote, quoteData, apiKey 
     // (fall through to the next quote) when the outcome did not match or the
     // swap reverts in simulation.
     if (e instanceof SwapSimulationError && ['NO_SIM_RPC', 'NOT_SIM_CAPABLE', 'SIM_RPC_ERROR'].includes(e.code)) {
+      log(`  ⚠ Swap-outcome verification could not run (${e.message}); proceeding without it.`);
+      return { proceed: true };
+    }
+    return { proceed: false, reason: e.message };
+  }
+}
+
+/**
+ * The Solana sibling of verifySwapOutcome: simulates the swap transaction via
+ * simulateTransaction and checks the resulting balance deltas against the
+ * persisted request intent, degrading (warn + proceed) on any RPC/sim outage
+ * so an outage never blocks a trade — only a real outcome mismatch or an
+ * in-simulation revert blocks (falls through to the next quote).
+ */
+export async function verifySolanaSwapOutcome({ chain, walletAddress, txBase64, quote, quoteData, log = () => {} }) {
+  if (chain !== 'solana') return { proceed: true };
+  // Cross-chain: the output settles on the destination chain and can never
+  // appear in a source-chain simulation (mirrors the EVM bridge skip above).
+  if (quoteData?.toChain && quoteData.toChain !== quoteData.chain) return { proceed: true };
+  if (!quoteData?.request) {
+    log('  ⚠ Swap-outcome verification skipped (no request intent — re-quote to enable it).');
+    return { proceed: true };
+  }
+  if (!hasSolanaSimulationRpc(chain)) {
+    log(`  ⚠ Swap-outcome verification unavailable (no simulation endpoint for ${chain}); proceeding without it.`);
+    return { proceed: true };
+  }
+  try {
+    const sim = await simulateSolanaAssetChanges(chain, txBase64, { walletAddress });
+    assertSolanaSwapOutcome(quoteData.request, quote, sim, { slippage: quoteData.slippage });
+    log(`  ✓ Swap outcome verified (via ${sim.method}).`);
+    return { proceed: true };
+  } catch (e) {
+    if (e instanceof SolanaSimulationError && ['NO_SIM_RPC', 'SIM_RPC_ERROR'].includes(e.code)) {
       log(`  ⚠ Swap-outcome verification could not run (${e.message}); proceeding without it.`);
       return { proceed: true };
     }
@@ -2005,7 +2040,7 @@ OPTIONS:
   --quote <id>              Quote ID from 'nansen quote'
   --wallet <name>           Wallet name (default: default wallet)
   --no-simulate             Skip pre-broadcast simulation (the eth_call revert check)
-  --no-verify-outcome       Skip EVM swap-outcome verification (balance-delta check)
+  --no-verify-outcome       Skip swap-outcome verification (balance-delta check)
   --no-revoke-excessive-allowance
                             Skip auto-revoking an oversized/legacy allowance before re-approving
   --gasless                 Relay-only: have Relay's solver pay gas (no WalletConnect)
@@ -2178,6 +2213,18 @@ EXAMPLES:
               // are the only transaction-level guards here — see
               // assertSolanaInstructionsSafe for the residual sibling-transfer gap.
               assertSolanaInstructionsSafe(txBase64, { walletAddress });
+
+              // Verify the swap's simulated on-chain outcome matches intent.
+              // Degrades with a warning if no simulation endpoint is available.
+              if (!noVerifyOutcome) {
+                const outcome = await verifySolanaSwapOutcome({ chain, walletAddress, txBase64, quote: currentQuote, quoteData, log });
+                if (!outcome.proceed) {
+                  log(`  ❌ ${quoteName} failed swap-outcome verification: ${outcome.reason}`);
+                  if (qi + 1 < endIndex) log('  Trying next quote...');
+                  lastQuoteError = `${quoteName} outcome verification failed: ${outcome.reason}`;
+                  continue;
+                }
+              }
 
               log('  Signing Solana transaction via Privy...');
               const signResult = await privyClient.signSolanaTransaction(solWalletId, txBase64);
@@ -2488,6 +2535,18 @@ EXAMPLES:
               // are the only transaction-level guards here — see
               // assertSolanaInstructionsSafe for the residual sibling-transfer gap.
               assertSolanaInstructionsSafe(txBase64, { walletAddress: solanaWalletAddress });
+
+              // Verify the swap's simulated on-chain outcome matches intent.
+              // Degrades with a warning if no simulation endpoint is available.
+              if (!noVerifyOutcome) {
+                const outcome = await verifySolanaSwapOutcome({ chain, walletAddress: solanaWalletAddress, txBase64, quote: currentQuote, quoteData, log });
+                if (!outcome.proceed) {
+                  log(`  ❌ ${quoteName} failed swap-outcome verification: ${outcome.reason}`);
+                  if (qi + 1 < endIndex) log('  Trying next quote...');
+                  lastQuoteError = `${quoteName} outcome verification failed: ${outcome.reason}`;
+                  continue;
+                }
+              }
 
               if (isWalletConnect) {
                 // Solana via WalletConnect: convert base64 → base58 for WC protocol


### PR DESCRIPTION
## Summary

- Adds `src/solana-simulation.js`: runs a Solana swap transaction through `simulateTransaction` and reports balance deltas for the signing wallet
- Adds `assertSolanaSwapOutcome` to `trade-validation.js`: validates the simulated deltas against the persisted request intent (input within max, expected output received, no sibling token drained)
- Calls `verifySolanaSwapOutcome` in the execute path before signing — degrades gracefully (warn + proceed) on RPC/sim outage; blocks only on a real outcome mismatch or in-simulation revert
- Widens `--no-verify-outcome` and its schema description to cover both EVM and Solana

## Behaviour

| Condition | Result |
|-----------|--------|
| No simulation RPC configured | Warn + proceed |
| RPC error / outage | Warn + proceed |
| Clean sim, outcome matches quote | Verify ✓ + proceed |
| Sim revert | Block (next quote) |
| Sibling token drained or output below min | Block (next quote) |
| Cross-chain quote (output on destination chain) | Skip (can't sim cross-chain) |

## Test plan

- [ ] `npm test` passes (2209 tests)
- [ ] `solana-simulation.test.js` covers the delta-parsing and RPC error paths
- [ ] `trade-validation.test.js` covers `assertSolanaSwapOutcome` assertions (benign pass, input over cap, output below min, sibling drain, native dust tolerance)
- [ ] `trading.test.js` covers the end-to-end execute path with outcome verification enabled and disabled