### PR TITLE
fix: use BigInt for EVM balance in checkX402Balance to avoid precision loss on 18-decimal tokens

### DIFF
--- a/.changeset/fix-x402-bigint-balance.md
+++ b/.changeset/fix-x402-bigint-balance.md
@@ -2,4 +2,4 @@
 "nansen-cli": patch
 ---
 
-Use BigInt for EVM balance in `checkX402Balance` to avoid precision loss on 18-decimal tokens: `parseInt(hex, 16)` overflows `Number.MAX_SAFE_INTEGER` at ~9 tokens' worth of wei.
+Use BigInt for EVM balance in `checkX402Balance` to avoid precision loss on 18-decimal tokens (BSC stablecoins): `parseInt(hex, 16)` loses integer precision once the raw wei value exceeds `Number.MAX_SAFE_INTEGER` (~9.0e15 wei, i.e. ~0.009 tokens at 18 decimals), skewing the low-balance warning.

--- a/.changeset/fix-x402-bigint-balance.md
+++ b/.changeset/fix-x402-bigint-balance.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Use BigInt for EVM balance in `checkX402Balance` to avoid precision loss on 18-decimal tokens: `parseInt(hex, 16)` overflows `Number.MAX_SAFE_INTEGER` at ~9 tokens' worth of wei.

--- a/src/__tests__/x402-balance.test.js
+++ b/src/__tests__/x402-balance.test.js
@@ -48,7 +48,7 @@ describe('checkX402Balance BigInt precision (18 decimals)', () => {
   it('returns correct balance for wei values above MAX_SAFE_INTEGER', async () => {
     const { vi } = await import('vitest');
     vi.resetModules();
-    const mockHex = '0x00000000000000000000000000000000000000000000000057014a42e52a6a8000';
+    const mockHex = '0x00000000000000000000000000000000000000000000000572b7b98736c20000';
     const mockWallets = {
       defaultWallet: 'test',
       wallets: [{ name: 'test', evm: '0x' + '11'.repeat(20) }],

--- a/src/__tests__/x402-balance.test.js
+++ b/src/__tests__/x402-balance.test.js
@@ -43,3 +43,33 @@ describe('EVM_X402_TOKENS registry', () => {
     }
   });
 });
+
+describe('checkX402Balance BigInt precision (18 decimals)', () => {
+  it('returns correct balance for wei values above MAX_SAFE_INTEGER', async () => {
+    const { vi } = await import('vitest');
+    // 100.5 USDT on BSC = 100.5e18 wei = 0x57014A42E52A6A8000
+    // This exceeds Number.MAX_SAFE_INTEGER (2^53) and would lose precision with parseInt.
+    const mockHex = '0x00000000000000000000000000000000000000000000000057014a42e52a6a8000';
+    const mockWallets = {
+      defaultWallet: 'test',
+      wallets: [{ name: 'test', evm: '0x' + '11'.repeat(20) }],
+    };
+    vi.doMock('../wallet.js', () => ({
+      listWallets: () => mockWallets,
+      exportWallet: vi.fn(),
+    }));
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ jsonrpc: '2.0', id: 1, result: mockHex }),
+    });
+
+    const { checkX402Balance } = await import('../x402.js');
+    const result = await checkX402Balance('eip155:56', '0x55d398326f99059fF775485246999027B3197955');
+
+    expect(result).not.toBeNull();
+    expect(result.symbol).toBe('USDT');
+    expect(result.balance).toBeCloseTo(100.5, 1);
+
+    vi.doUnmock('../wallet.js');
+    delete global.fetch;
+  });
+});

--- a/src/__tests__/x402-balance.test.js
+++ b/src/__tests__/x402-balance.test.js
@@ -47,8 +47,7 @@ describe('EVM_X402_TOKENS registry', () => {
 describe('checkX402Balance BigInt precision (18 decimals)', () => {
   it('returns correct balance for wei values above MAX_SAFE_INTEGER', async () => {
     const { vi } = await import('vitest');
-    // 100.5 USDT on BSC = 100.5e18 wei = 0x57014A42E52A6A8000
-    // This exceeds Number.MAX_SAFE_INTEGER (2^53) and would lose precision with parseInt.
+    vi.resetModules();
     const mockHex = '0x00000000000000000000000000000000000000000000000057014a42e52a6a8000';
     const mockWallets = {
       defaultWallet: 'test',
@@ -68,6 +67,30 @@ describe('checkX402Balance BigInt precision (18 decimals)', () => {
     expect(result).not.toBeNull();
     expect(result.symbol).toBe('USDT');
     expect(result.balance).toBeCloseTo(100.5, 1);
+
+    vi.doUnmock('../wallet.js');
+    delete global.fetch;
+  });
+
+  it('returns zero balance when eth_call returns null', async () => {
+    const { vi } = await import('vitest');
+    vi.resetModules();
+    const mockWallets = {
+      defaultWallet: 'test',
+      wallets: [{ name: 'test', evm: '0x' + '11'.repeat(20) }],
+    };
+    vi.doMock('../wallet.js', () => ({
+      listWallets: () => mockWallets,
+      exportWallet: vi.fn(),
+    }));
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ jsonrpc: '2.0', id: 1, result: null }),
+    });
+
+    const { checkX402Balance } = await import('../x402.js');
+    const result = await checkX402Balance('eip155:56');
+
+    expect(result).toEqual({ balance: 0, symbol: 'U' });
 
     vi.doUnmock('../wallet.js');
     delete global.fetch;

--- a/src/x402.js
+++ b/src/x402.js
@@ -301,6 +301,7 @@ export async function checkX402Balance(network, asset = null) {
       // Use BigInt to avoid precision loss on 18-decimal tokens (BSC stablecoins).
       const raw = BigInt(data.result);
       const divisor = 10n ** BigInt(decimals);
+      // Fractional part is display-only (.toFixed(2)); sub-cent precision not guaranteed.
       return { balance: Number(raw / divisor) + Number(raw % divisor) / 10 ** decimals, symbol };
     }
 

--- a/src/x402.js
+++ b/src/x402.js
@@ -301,7 +301,7 @@ export async function checkX402Balance(network, asset = null) {
       // Use BigInt to avoid precision loss on 18-decimal tokens (BSC stablecoins).
       const raw = BigInt(data.result);
       const divisor = 10n ** BigInt(decimals);
-      return { balance: Number(raw / divisor) + Number(raw %% divisor) / 10 ** decimals, symbol };
+      return { balance: Number(raw / divisor) + Number(raw % divisor) / 10 ** decimals, symbol };
     }
 
     return null;

--- a/src/x402.js
+++ b/src/x402.js
@@ -298,7 +298,10 @@ export async function checkX402Balance(network, asset = null) {
         }),
       });
       const data = await resp.json();
-      return { balance: parseInt(data.result, 16) / 10 ** decimals, symbol };
+      // Use BigInt to avoid precision loss on 18-decimal tokens (BSC stablecoins).
+      const raw = BigInt(data.result);
+      const divisor = 10n ** BigInt(decimals);
+      return { balance: Number(raw / divisor) + Number(raw %% divisor) / 10 ** decimals, symbol };
     }
 
     return null;

--- a/src/x402.js
+++ b/src/x402.js
@@ -299,10 +299,13 @@ export async function checkX402Balance(network, asset = null) {
       });
       const data = await resp.json();
       // Use BigInt to avoid precision loss on 18-decimal tokens (BSC stablecoins).
+      if (!data.result || data.result === "0x") return { balance: 0, symbol };
       const raw = BigInt(data.result);
       const divisor = 10n ** BigInt(decimals);
       // Fractional part is display-only (.toFixed(2)); sub-cent precision not guaranteed.
-      return { balance: Number(raw / divisor) + Number(raw % divisor) / 10 ** decimals, symbol };
+      const whole = Number(raw / divisor);
+      const frac = Number((raw % divisor) * 10000n / divisor) / 10000;
+      return { balance: whole + frac, symbol };
     }
 
     return null;


### PR DESCRIPTION
Closes #523

## Problem

`checkX402Balance()` converts the raw `balanceOf` hex result with `parseInt(data.result, 16) / 10 ** decimals`. For 18-decimal tokens (all four BSC stablecoins), this loses precision once the raw wei value exceeds `Number.MAX_SAFE_INTEGER` (2^53).

The same file already uses `BigInt` correctly in `hasPermit2Allowance()` the balance check is the only inconsistent path.

## Fix

Replace `parseInt` + float division with `BigInt` division, matching the `formatWei` pattern in `trading.js` and `hasPermit2Allowance` in the same file.