### PR TITLE
fix: promote K to M after rounding at 1M boundary in formatValue

### DIFF
--- a/.changeset/fix-formatvalue-km-boundary.md
+++ b/.changeset/fix-formatvalue-km-boundary.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix `formatValue` displaying `1000.00K` instead of `1.00M` when a value like 999999.995 rounds up at the K/M boundary.

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -112,6 +112,12 @@ describe('formatValue', () => {
     expect(formatValue(5000)).toBe('5.00K');
     expect(formatValue(-1500)).toBe('-1.50K');
   });
+  it('should promote K to M at the rounding boundary', () => {
+    expect(formatValue(999999.994)).toBe('999.99K');
+    expect(formatValue(999999.995)).toBe('1.00M');
+    expect(formatValue(999999.999)).toBe('1.00M');
+    expect(formatValue(-999999.995)).toBe('-1.00M');
+  });
 
   it('should format integers without decimals', () => {
     expect(formatValue(42)).toBe('42');

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -113,7 +113,7 @@ describe('formatValue', () => {
     expect(formatValue(-1500)).toBe('-1.50K');
   });
   it('should promote K to M at the rounding boundary', () => {
-    expect(formatValue(999999.994)).toBe('999.99K');
+    expect(formatValue(999990)).toBe('999.99K');
     expect(formatValue(999999.995)).toBe('1.00M');
     expect(formatValue(999999.999)).toBe('1.00M');
     expect(formatValue(-999999.995)).toBe('-1.00M');

--- a/src/cli.js
+++ b/src/cli.js
@@ -231,7 +231,11 @@ export function formatValue(val) {
   if (val === null || val === undefined) return '';
   if (typeof val === 'number') {
     if (Math.abs(val) >= 1000000) return (val / 1000000).toFixed(2) + 'M';
-    if (Math.abs(val) >= 1000) return (val / 1000).toFixed(2) + 'K';
+    if (Math.abs(val) >= 1000) {
+      const formatted = (val / 1000).toFixed(2);
+      if (Math.abs(parseFloat(formatted)) >= 1000) return (val / 1000000).toFixed(2) + 'M';
+      return formatted + 'K';
+    }
     if (Number.isInteger(val)) return val.toString();
     return val.toFixed(2);
   }


### PR DESCRIPTION
## Summary

Fixes the K/M boundary rounding bug in `formatValue()`.

When a value like `999999.995` enters the K branch, `(val/1000).toFixed(2)` rounds to `1000.00`, producing `1000.00K` instead of `1.00M`.

## Fix

After formatting in the K branch, re-check if the result rounds up to >= 1000 and promote to M tier if so.

## Test Cases

```js
formatValue(999999.995);  // → "1.00M" ✓
formatValue(999999.999);  // → "1.00M" ✓
formatValue(-999999.995); // → "-1.00M" ✓
```

## Checklist
- [ ] Tests pass (`npm test`)
- [ ] `src/schema.json` updated if new commands or flags were added
- [ ] `README.md` updated if new top-level commands or categories were added
- [ ] Changeset added (`.changeset/`) only required for user-facing changes (new commands, flags, bug fixes, breaking changes)

Closes #525