### PR TITLE
Tolerate a bounded native-token fee on bridge swap-outcome checks

### DIFF
--- a/.changeset/bridge-native-fee-sibling-tolerance.md
+++ b/.changeset/bridge-native-fee-sibling-tolerance.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Trade safety: tolerate a bounded native-token fee on cross-chain bridge swaps. The pre-signing swap-outcome check rejected any non-input token leaving the wallet, which could reject a legitimate bridge that pays its network fee in the native token on a token-input route. The tolerance is capped and applies only to the native token on bridges; every other token, and all same-chain swaps, stay strict.

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -1640,13 +1640,20 @@ describe('assertSwapOutcome', () => {
       .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*non-positive output amount/i);
   });
 
-  it('tolerates a sub-threshold non-input outflow when a dust threshold is set', () => {
-    const sim = {
+  it('same-chain: a non-input outflow is strict-zero even when a dust threshold is passed', () => {
+    // The dust threshold only relaxes assertion 3 for a native sibling on a
+    // bridge; a same-chain swap keeps strict-zero for every non-input token,
+    // regardless of what the caller passes.
+    const erc20Sibling = {
       deltas: { [USDC]: -1000000n, [DAI]: 1000000n, '0xaaaa000000000000000000000000000000000001': -3n },
       approvals: [],
     };
-    expect(() => assertSwapOutcome(exactInRequest, exactInQuote, sim, { siblingDustThreshold: 5n })).not.toThrow();
-    expect(() => assertSwapOutcome(exactInRequest, exactInQuote, sim, { siblingDustThreshold: 2n })).toThrow(/SWAP_OUTCOME_MISMATCH/i);
+    expect(() => assertSwapOutcome(exactInRequest, exactInQuote, erc20Sibling, { siblingDustThreshold: 5n })).toThrow(/SWAP_OUTCOME_MISMATCH/i);
+    const nativeSibling = {
+      deltas: { [USDC]: -1000000n, [DAI]: 1000000n, [NATIVE]: -3n },
+      approvals: [],
+    };
+    expect(() => assertSwapOutcome(exactInRequest, exactInQuote, nativeSibling, { siblingDustThreshold: 5n })).toThrow(/SWAP_OUTCOME_MISMATCH/i);
   });
 
   it('fails closed when the request has no maximum input', () => {
@@ -1684,6 +1691,38 @@ describe('assertSwapOutcome', () => {
       approvals: [],
     };
     expect(() => assertSwapOutcome(bridgeRequest, exactInQuote, sim, {}))
+      .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*other than the one you are selling/i);
+  });
+
+  it('bridge: tolerates a native-ETH sibling fee up to the passed threshold (token input paying a native bridge fee)', () => {
+    // A token-input bridge that pays a network fee via msg.value shows
+    // native ETH leaving as a sibling. It is tolerated up to the bounded
+    // threshold the caller passes — only for a bridge, only for native.
+    const bridgeRequest = { ...exactInRequest, toChain: 'solana' };
+    const sim = {
+      deltas: { [USDC]: -1000000n, [NATIVE]: -1_000_000_000_000_000n }, // 0.001 ETH fee
+      approvals: [],
+    };
+    expect(() => assertSwapOutcome(bridgeRequest, exactInQuote, sim, { siblingDustThreshold: 2_000_000_000_000_000n })).not.toThrow();
+  });
+
+  it('bridge: rejects a native-ETH sibling above the threshold (drain vector stays closed)', () => {
+    const bridgeRequest = { ...exactInRequest, toChain: 'solana' };
+    const sim = {
+      deltas: { [USDC]: -1000000n, [NATIVE]: -5_000_000_000_000_000n }, // 0.005 ETH, above the 0.002 threshold
+      approvals: [],
+    };
+    expect(() => assertSwapOutcome(bridgeRequest, exactInQuote, sim, { siblingDustThreshold: 2_000_000_000_000_000n }))
+      .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*other than the one you are selling/i);
+  });
+
+  it('bridge: an ERC-20 sibling stays strict-zero even when a native threshold is passed', () => {
+    const bridgeRequest = { ...exactInRequest, toChain: 'solana' };
+    const sim = {
+      deltas: { [USDC]: -1000000n, '0xaaaa000000000000000000000000000000000001': -3n },
+      approvals: [],
+    };
+    expect(() => assertSwapOutcome(bridgeRequest, exactInQuote, sim, { siblingDustThreshold: 2_000_000_000_000_000n }))
       .toThrow(/SWAP_OUTCOME_MISMATCH[\s\S]*other than the one you are selling/i);
   });
 

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -1142,6 +1142,77 @@ describe('buildTradingCommands', () => {
     delete process.env.NANSEN_WALLET_PASSWORD;
   });
 
+  it('bridge: passes the tx.value guard for a token-input bridge carrying a native fee within the cap', async () => {
+    // A token-input cross-chain bridge may carry a bounded native fee in
+    // tx.value. The guard must let it through (verifySwapOutcome downstream
+    // re-bounds the actual outflow to min(tx.value, cap)) rather than aborting
+    // it as an unexpected value — otherwise the native-fee tolerance is a no-op.
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const body = opts?.body ? JSON.parse(opts.body) : {};
+      if (body.method === 'eth_getCode') return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'lifi',
+        inputMint: BASE_USDC, // token input
+        outputMint: BASE_ETH,
+        inAmount: '1000000',
+        outAmount: '500000000000000',
+        transaction: { to: LIFI_ROUTER, data: '0x12345678', value: '1000000000000000', gas: '200000' }, // 0.001 ETH fee, under the 0.002 cap
+      }],
+    }, 'base', 'local', null, 'solana', { swapMode: 'exactIn', request: evmIntent({ walletAddress: showWallet('default').evm, fromToken: BASE_USDC, toToken: BASE_ETH, toChain: 'solana' }) });
+
+    const logs = [];
+    const cmds = buildTradingCommands({
+      log: (msg) => logs.push(msg),
+      exit: () => {},
+    });
+
+    // Execution fails later (signing/broadcast), but must NOT abort at the value guard.
+    try { await cmds.execute([], null, {}, { quote: quoteId }); } catch { /* expected */ }
+    expect(logs.some(l => l.includes('non-zero tx.value'))).toBe(false);
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
+  });
+
+  it('bridge: still rejects a token-input bridge whose native tx.value exceeds the cap', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const body = opts?.body ? JSON.parse(opts.body) : {};
+      if (body.method === 'eth_getCode') return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'lifi',
+        inputMint: BASE_USDC,
+        outputMint: BASE_ETH,
+        inAmount: '1000000',
+        outAmount: '500000000000000',
+        transaction: { to: LIFI_ROUTER, data: '0x12345678', value: '5000000000000000000', gas: '200000' }, // 5 ETH, far above the cap
+      }],
+    }, 'base', 'local', null, 'solana', { swapMode: 'exactIn', request: evmIntent({ walletAddress: showWallet('default').evm, fromToken: BASE_USDC, toToken: BASE_ETH, toChain: 'solana' }) });
+
+    const logs = [];
+    const cmds = buildTradingCommands({
+      log: (msg) => logs.push(msg),
+      exit: () => {},
+    });
+
+    await expect(cmds.execute([], null, {}, { quote: quoteId })).rejects.toThrow(/All quotes failed/);
+    expect(logs.some(l => l.includes('non-zero tx.value'))).toBe(true);
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
+  });
+
   it('should pass validation for native ETH swap with matching value', async () => {
     createWallet('default', 'testpass');
     process.env.NANSEN_WALLET_PASSWORD = 'testpass';

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -5748,6 +5748,38 @@ describe('verifySwapOutcome (execute-path wiring)', () => {
     expect(r.reason).toMatch(/SWAP_OUTCOME_MISMATCH/i);
   });
 
+  it('tolerates a native-ETH bridge fee up to the declared tx.value (token input paying a native fee)', async () => {
+    // A token-input bridge that pays a fee via msg.value sends native ETH out as
+    // a sibling (a zero-address transfer normalises to the native sentinel).
+    // verifySwapOutcome tolerates it up to min(tx.value, cap); the fee here equals
+    // the declared value, so the bridge verifies instead of false-blocking.
+    const ZERO = '0x0000000000000000000000000000000000000000';
+    const feeQuote = { ...quote, transaction: { ...quote.transaction, value: '1000000000000000' } }; // 0.001 ETH
+    const bridgeData = { ...quoteData, request: { ...quoteData.request, toChain: 'solana' } };
+    global.fetch = vi.fn().mockResolvedValue(simBody([
+      tlog(USDC, WALLET, ROUTER, 1000000n),
+      tlog(ZERO, WALLET, ROUTER, 1000000000000000n), // native fee leaving the wallet
+    ]));
+    const r = await verifySwapOutcome({ chain: 'base', from: WALLET, quote: feeQuote, quoteData: bridgeData });
+    expect(r.proceed).toBe(true);
+  });
+
+  it('blocks a bridge that drains native ETH beyond the cap even when tx.value is inflated', async () => {
+    // The drain vector: a hostile quote sets a huge tx.value so an unbounded
+    // tolerance would wave through a full-balance native transfer. Capping the
+    // tolerance at min(tx.value, cap) keeps it blocked.
+    const ZERO = '0x0000000000000000000000000000000000000000';
+    const drainQuote = { ...quote, transaction: { ...quote.transaction, value: '10000000000000000000' } }; // 10 ETH declared
+    const bridgeData = { ...quoteData, request: { ...quoteData.request, toChain: 'solana' } };
+    global.fetch = vi.fn().mockResolvedValue(simBody([
+      tlog(USDC, WALLET, ROUTER, 1000000n),
+      tlog(ZERO, WALLET, ROUTER, 10000000000000000000n), // 10 ETH leaving
+    ]));
+    const r = await verifySwapOutcome({ chain: 'base', from: WALLET, quote: drainQuote, quoteData: bridgeData });
+    expect(r.proceed).toBe(false);
+    expect(r.reason).toMatch(/SWAP_OUTCOME_MISMATCH/i);
+  });
+
   it('degrades (proceed=true) for a pre-intent quote with no request recorded', async () => {
     // Without request intent, assertSwapOutcome has nothing to compare against and
     // would raise a misleading SWAP_OUTCOME_MISMATCH. Skip cleanly instead — even

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -935,7 +935,7 @@ export function assertSwapCalldataNotBareTransfer(data) {
  * Derived from the immutable persisted request intent (not the loose
  * quote/quoteData) so it can't drift between calls or across chains.
  */
-function isBridgeRequest(request) {
+export function isBridgeRequest(request) {
   return request.toChain != null
     && String(request.toChain).toLowerCase() !== String(request.chain).toLowerCase();
 }

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -8,6 +8,7 @@ import { validateAddress } from './api.js';
 import { CHAIN_RPCS } from './rpc-urls.js';
 import { parseTransactionMessage, resolveStaticAccount } from './solana-tx.js';
 import { SOL_SENTINEL } from './solana-simulation.js';
+import { EVM_NATIVE_SENTINEL } from './swap-simulation.js';
 
 const SUPPORTED_CHAINS = ['solana', 'base'];
 
@@ -145,6 +146,21 @@ const NATIVE_TOKEN_ADDRESSES = {
   solana: 'So11111111111111111111111111111111111111112',
   base: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
 };
+
+// Upper bound on native (ETH) that may leave the wallet as a *sibling* of a
+// cross-chain bridge — some bridges pay a network fee via msg.value on a
+// token-input route, which surfaces as a native outflow distinct from the input
+// token. assertSwapOutcome's no-sibling-drain check (assertion 3) is otherwise
+// strict-zero, so without a bound such a fee would false-block a legitimate
+// bridge. The tolerance is the smaller of the transaction's declared native
+// value and THIS cap (see verifySwapOutcome); capping it — rather than trusting
+// the quote's value outright — is what keeps the check from being turned into a
+// native-ETH drain (a hostile quote could otherwise set value to the whole
+// balance). Conservative and gas-independent (gas is already excluded from the
+// simulated native delta); a real bridge fee is far below it. This is a
+// defence-in-depth loss ceiling, not a fee estimate — revisit if a route ever
+// legitimately needs more.
+export const EVM_BRIDGE_NATIVE_FEE_SLACK = 2_000_000_000_000_000n; // 0.002 ETH
 
 // Native SOL has two on-chain spellings that denote the same asset: the
 // canonical wrapped-SOL mint (what the CLI resolves `SOL` to and persists as
@@ -956,8 +972,11 @@ function isBridgeRequest(request) {
  * @param {Set<string>|string[]} [ctx.expectedSpenders] - spenders the wallet may
  *   legitimately (re)approve during the swap (e.g. the approval target and the
  *   router); anything else fails assertion 4. Compared case-insensitively.
- * @param {bigint} [ctx.siblingDustThreshold=0n] - non-input outflow tolerated
- *   before assertion 3 fires (for fee-on-transfer / rounding). Strict 0 default.
+ * @param {bigint} [ctx.siblingDustThreshold=0n] - native-token (ETH) sibling
+ *   outflow tolerated before assertion 3 fires, and only for a cross-chain
+ *   bridge (some bridges pay a fee via msg.value on a token-input route). ERC-20
+ *   siblings and every same-chain swap stay strict 0. The caller must pass a
+ *   bounded value (see EVM_BRIDGE_NATIVE_FEE_SLACK). Strict 0 default.
  * @returns {{verified: true, outputAssertionSkipped: boolean}} outputAssertionSkipped
  *   is true for a cross-chain bridge, meaning assertion 2 did not run — the
  *   caller should surface this.
@@ -1127,10 +1146,18 @@ export function assertSwapOutcome(request, quote, sim, { slippage, expectedSpend
   }
 
   // --- Assertion 3: no token other than the input leaves the wallet ---
-  const dust = siblingDustThreshold > 0n ? siblingDustThreshold : 0n;
+  // A bridge may pay a network fee in native ETH via msg.value on a
+  // token-input route, which shows up here as a native sibling outflow. Tolerate
+  // that — but only native, only for a bridge, and only up to the bounded
+  // threshold the caller passes (gas is already excluded from the native delta).
+  // ERC-20 siblings and every same-chain swap keep strict-zero. This mirrors the
+  // native-only carve-out assertSolanaSwapOutcome already applies for SOL.
+  const nativeDust = isBridge && siblingDustThreshold > 0n ? siblingDustThreshold : 0n;
   for (const [token, delta] of Object.entries(deltas)) {
     if (token === inputToken) continue; // its outflow is bounded by assertion 1
-    if (delta < 0n && -delta > dust) {
+    if (delta >= 0n) continue;
+    const dust = token === EVM_NATIVE_SENTINEL ? nativeDust : 0n;
+    if (-delta > dust) {
       throw fail(`a token other than the one you are selling (${token}) left the wallet (delta ${delta}); a swap must not move any token except the input.`);
     }
   }

--- a/src/trading.js
+++ b/src/trading.js
@@ -14,7 +14,7 @@ import { buildMessageV0, fetchRecentBlockhash } from './x402-svm.js';
 import { keccak256, signSecp256k1, rlpEncode } from './crypto.js';
 import { getWalletConnectAddress, sendTransactionViaWalletConnect, sendSolanaTransactionViaWalletConnect, sendApprovalViaWalletConnect } from './walletconnect-trading.js';
 import { retrievePassword } from './keychain.js';
-import { validateQuoteInput, validateBalance, resolvePercentAmount, validateGasBalance, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, assertSolanaSwapOutcome, approvalAmountForSwap, needsAllowanceRevoke, OVERSIZED_ALLOWANCE_MULTIPLIER } from './trade-validation.js';
+import { validateQuoteInput, validateBalance, resolvePercentAmount, validateGasBalance, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, assertSolanaSwapOutcome, approvalAmountForSwap, needsAllowanceRevoke, OVERSIZED_ALLOWANCE_MULTIPLIER, EVM_BRIDGE_NATIVE_FEE_SLACK } from './trade-validation.js';
 import { readCompactU16 } from './solana-tx.js';
 export { readCompactU16 };
 import { CHAIN_RPCS } from './rpc-urls.js';
@@ -1008,7 +1008,18 @@ export async function verifySwapOutcome({ chain, from, quote, quoteData, apiKey 
       { to: tx.to, data: tx.data, value: toRpcHexValue(tx.value) },
       { from, apiKey },
     );
-    const outcome = assertSwapOutcome(quoteData.request, quote, sim, { slippage: quoteData.slippage, expectedSpenders });
+    // A cross-chain bridge may pay a fee in native ETH via msg.value on a
+    // token-input route; that surfaces as a native sibling outflow which the
+    // no-sibling-drain check (assertion 3) would otherwise reject. Tolerate it up
+    // to the smaller of the tx's declared native value and the fixed cap — never
+    // the full value, which a hostile quote could inflate to the whole balance.
+    // assertSwapOutcome applies this only for bridges and only to native.
+    let siblingDustThreshold = 0n;
+    try {
+      const declaredValue = BigInt(tx.value ?? 0);
+      siblingDustThreshold = declaredValue < EVM_BRIDGE_NATIVE_FEE_SLACK ? declaredValue : EVM_BRIDGE_NATIVE_FEE_SLACK;
+    } catch { /* non-integer value → leave 0n, assertion 3 stays strict */ }
+    const outcome = assertSwapOutcome(quoteData.request, quote, sim, { slippage: quoteData.slippage, expectedSpenders, siblingDustThreshold });
     if (outcome.outputAssertionSkipped) {
       log('  ℹ Bridge: input-outflow and sibling checks ran; output arrives on the destination chain and is not simulated here.');
     }

--- a/src/trading.js
+++ b/src/trading.js
@@ -14,7 +14,7 @@ import { buildMessageV0, fetchRecentBlockhash } from './x402-svm.js';
 import { keccak256, signSecp256k1, rlpEncode } from './crypto.js';
 import { getWalletConnectAddress, sendTransactionViaWalletConnect, sendSolanaTransactionViaWalletConnect, sendApprovalViaWalletConnect } from './walletconnect-trading.js';
 import { retrievePassword } from './keychain.js';
-import { validateQuoteInput, validateBalance, resolvePercentAmount, validateGasBalance, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, assertSolanaSwapOutcome, approvalAmountForSwap, needsAllowanceRevoke, OVERSIZED_ALLOWANCE_MULTIPLIER, EVM_BRIDGE_NATIVE_FEE_SLACK } from './trade-validation.js';
+import { validateQuoteInput, validateBalance, resolvePercentAmount, validateGasBalance, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, assertSolanaSwapOutcome, approvalAmountForSwap, needsAllowanceRevoke, OVERSIZED_ALLOWANCE_MULTIPLIER, EVM_BRIDGE_NATIVE_FEE_SLACK, isBridgeRequest } from './trade-validation.js';
 import { readCompactU16 } from './solana-tx.js';
 export { readCompactU16 };
 import { CHAIN_RPCS } from './rpc-urls.js';
@@ -2548,7 +2548,16 @@ EXAMPLES:
                   continue;
                 }
               } else {
-                if (txValue > 0n) {
+                // A token-input swap sends no native value — except a cross-chain
+                // bridge may carry a bounded native fee via msg.value. Allow that up
+                // to the same ceiling assertSwapOutcome tolerates as a native sibling
+                // (verifySwapOutcome runs below and re-bounds the actual simulated
+                // outflow to min(tx.value, cap)); reject any other non-zero value, and
+                // any bridge fee above the ceiling.
+                const bridgeFeeAllowed = quoteData?.request
+                  && isBridgeRequest(quoteData.request)
+                  && txValue <= EVM_BRIDGE_NATIVE_FEE_SLACK;
+                if (txValue > 0n && !bridgeFeeAllowed) {
                   log(`  ❌ ERC-20 swap has non-zero tx.value (${txValue}) for ${quoteName} — aborting`);
                   if (qi + 1 < endIndex) log(`  Trying next quote...`);
                   lastQuoteError = `${quoteName} unexpected tx.value`;
@@ -2915,7 +2924,16 @@ EXAMPLES:
                   continue;
                 }
               } else {
-                if (txValue > 0n) {
+                // A token-input swap sends no native value — except a cross-chain
+                // bridge may carry a bounded native fee via msg.value. Allow that up
+                // to the same ceiling assertSwapOutcome tolerates as a native sibling
+                // (verifySwapOutcome runs below and re-bounds the actual simulated
+                // outflow to min(tx.value, cap)); reject any other non-zero value, and
+                // any bridge fee above the ceiling.
+                const bridgeFeeAllowed = quoteData?.request
+                  && isBridgeRequest(quoteData.request)
+                  && txValue <= EVM_BRIDGE_NATIVE_FEE_SLACK;
+                if (txValue > 0n && !bridgeFeeAllowed) {
                   log(`  ❌ ERC-20 swap has non-zero tx.value (${txValue}) for ${quoteName} — aborting`);
                   if (qi + 1 < endIndex) log(`  Trying next quote...`);
                   lastQuoteError = `${quoteName} unexpected tx.value`;
@@ -3243,7 +3261,16 @@ EXAMPLES:
                   continue;
                 }
               } else {
-                if (txValue > 0n) {
+                // A token-input swap sends no native value — except a cross-chain
+                // bridge may carry a bounded native fee via msg.value. Allow that up
+                // to the same ceiling assertSwapOutcome tolerates as a native sibling
+                // (verifySwapOutcome runs below and re-bounds the actual simulated
+                // outflow to min(tx.value, cap)); reject any other non-zero value, and
+                // any bridge fee above the ceiling.
+                const bridgeFeeAllowed = quoteData?.request
+                  && isBridgeRequest(quoteData.request)
+                  && txValue <= EVM_BRIDGE_NATIVE_FEE_SLACK;
+                if (txValue > 0n && !bridgeFeeAllowed) {
                   log(`  ❌ ERC-20 swap has non-zero tx.value (${txValue}) for ${quoteName} — aborting`);
                   if (qi + 1 < endIndex) log(`  Trying next quote...`);
                   lastQuoteError = `${quoteName} unexpected tx.value`;


### PR DESCRIPTION
## What

Before signing a swap, `nansen trade execute` runs a balance-delta simulation and checks the result against the persisted request intent (defense-in-depth against a bad quote). One of those checks — "no token other than the input leaves the wallet" (assertion 3) — used a strict-zero tolerance for every non-input token, cross-chain bridges included.

Some bridges pay their network fee in the chain's native token (via `msg.value`) on a **token-input** route. That native value leaves the wallet as a *sibling* of the input token, so the strict-zero check rejected the quote and fell through to the next one — potentially failing an otherwise-valid bridge.

## Change

Relax assertion 3 to tolerate a **native-token** sibling outflow, but:
- **only for bridges** — same-chain swaps keep strict-zero for every token;
- **only for the native token** — every ERC-20 sibling stays strict-zero;
- **bounded** by `min(tx.value, EVM_BRIDGE_NATIVE_FEE_SLACK)`, where the cap is 0.002 ETH.

Capping at the fixed ceiling — rather than trusting the quote's declared `tx.value` outright — is what keeps the check from being turned into a native-token drain: a hostile quote can't set `tx.value` to the whole balance and have it waved through (the same `tx.value` is simulated, so a large declared value produces a large simulated outflow that trips the cap). This mirrors the native-only carve-out the Solana path already applies.

Behavior is unchanged for same-chain swaps and for any ERC-20 movement.

## Testing

- Unit tests for both `assertSwapOutcome` and the `verifySwapOutcome` wiring: a native fee within the bound verifies; above the bound blocks; an inflated `tx.value` drain still blocks at the cap; ERC-20 siblings and same-chain swaps stay strict.
- Full suite green, lint clean.
- No live bridge e2e: the native-fee slack is defense-in-depth for a route shape that is not currently reachable through the shipping quote path, so there is no route to exercise it end-to-end. The unit tests carry the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
