### PR TITLE
fix: honor original HTTP method on x402 paid retries

### DIFF
--- a/.changeset/x402-retry-respect-method.md
+++ b/.changeset/x402-retry-respect-method.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Honor the original HTTP method on x402 paid retries so GET/DELETE/PATCH requests are not resent as POST after payment.

--- a/src/__tests__/x402-api-retry.test.js
+++ b/src/__tests__/x402-api-retry.test.js
@@ -104,6 +104,64 @@ describe('NansenAPI._x402Retry', () => {
     expect(mockFetch).toHaveBeenCalledOnce();
     const [, requestInit] = mockFetch.mock.calls[0];
     expect(requestInit.headers['Payment-Signature']).toBe('my-payment-sig');
+    expect(requestInit.method).toBe('POST');
+    expect(requestInit.body).toBeDefined();
+  });
+
+  it('defaults to POST with a JSON body when options.method is omitted', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
+
+    const api = makeApi();
+    await api._x402Retry(
+      'sig', null, null, 'https://api.nansen.ai/test', { hello: 'world' },
+    );
+
+    const [, requestInit] = mockFetch.mock.calls[0];
+    expect(requestInit.method).toBe('POST');
+    expect(requestInit.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(requestInit.body)).toEqual({ hello: 'world' });
+  });
+
+  it('retries with GET and omits body when options.method is GET', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ account: true }) });
+
+    const api = makeApi();
+    await api._x402Retry(
+      'sig', null, null, 'https://api.nansen.ai/api/v1/account', {}, { method: 'GET' },
+    );
+
+    const [, requestInit] = mockFetch.mock.calls[0];
+    expect(requestInit.method).toBe('GET');
+    expect(requestInit.body).toBeUndefined();
+    expect(requestInit.headers['Content-Type']).toBeUndefined();
+    expect(requestInit.headers['Payment-Signature']).toBe('sig');
+  });
+
+  it('retries with DELETE and omits body when options.method is DELETE', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ deleted: true }) });
+
+    const api = makeApi();
+    await api._x402Retry(
+      'sig', null, null, 'https://api.nansen.ai/api/v1/smart-alert/1', { ignored: true }, { method: 'DELETE' },
+    );
+
+    const [, requestInit] = mockFetch.mock.calls[0];
+    expect(requestInit.method).toBe('DELETE');
+    expect(requestInit.body).toBeUndefined();
+  });
+
+  it('retries with PATCH and keeps a JSON body', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ patched: true }) });
+
+    const api = makeApi();
+    await api._x402Retry(
+      'sig', null, null, 'https://api.nansen.ai/api/v1/smart-alert', { id: '1' }, { method: 'PATCH' },
+    );
+
+    const [, requestInit] = mockFetch.mock.calls[0];
+    expect(requestInit.method).toBe('PATCH');
+    expect(JSON.parse(requestInit.body)).toEqual({ id: '1' });
+    expect(requestInit.headers['Content-Type']).toBe('application/json');
   });
 
   it('propagates json() rejection when the paid response body is not valid JSON', async () => {

--- a/src/api.js
+++ b/src/api.js
@@ -538,7 +538,7 @@ export class NansenAPI {
    * @param {string|null} network - x402 network string for balance check, e.g. "eip155:8453"
    * @param {string} url - Request URL
    * @param {object} body - Request body (will be cleaned)
-   * @param {object} [options={}] - Request options (may include .headers)
+   * @param {object} [options={}] - Request options (may include .method, .headers)
    * @returns {Promise<object|null>} Parsed JSON on success, null if rejected
    *
    * TODO: full fix — extract the entire x402 provider dispatch from request() into
@@ -546,10 +546,14 @@ export class NansenAPI {
    * touching that one method, not hunting inside the retry loop.
    */
   async _x402Retry(signature, walletLabel, network, url, body, options = {}, asset = null) {
+    // Mirror request(): paid retries must use the original method. Hardcoding
+    // POST burned a payment signature then hit the wrong route for GET/DELETE/PATCH.
+    const method = options.method || 'POST';
+    const isGet = method === 'GET';
     const paidResponse = await fetch(url, {
-      method: 'POST',
+      method,
       headers: {
-        'Content-Type': 'application/json',
+        ...(!isGet && { 'Content-Type': 'application/json' }),
         'X-Client-Type': 'nansen-cli',
         'X-Client-Version': packageVersion,
         ...telemetryHeaders(),
@@ -557,7 +561,7 @@ export class NansenAPI {
         ...this.defaultHeaders,
         ...options.headers,
       },
-      body: JSON.stringify(NansenAPI.cleanBody(body)),
+      ...(!isGet && method !== 'DELETE' && { body: JSON.stringify(NansenAPI.cleanBody(body)) }),
     });
     if (!paidResponse.ok) return null;
     if (walletLabel) {


### PR DESCRIPTION
## Summary
- `_x402Retry` always resent paid requests as `POST` with a JSON body
- After paying for a GET/DELETE/PATCH call, the retry hit the wrong route and could fail while still consuming the payment authorization
- Mirror `request()`: use `options.method` (default `POST`); omit body for GET/DELETE; keep JSON body for POST/PATCH
- Add regression tests for default POST, GET, DELETE, and PATCH

## Test plan
- [x] `npx vitest run src/__tests__/x402-api-retry.test.js`
- [x] default / omitted method → POST + JSON body
- [x] `method: 'GET'` → no body, no Content-Type
- [x] `method: 'DELETE'` → no body
- [x] `method: 'PATCH'` → JSON body kept