### PR TITLE
Harden login credential handling

### DIFF
--- a/.changeset/login-key-hygiene.md
+++ b/.changeset/login-key-hygiene.md
@@ -2,6 +2,10 @@
 "nansen-cli": patch
 ---
 
-`nansen login` hygiene: verification failures cannot relay the API key,
-authenticated redirects are rejected, invalid-key remediation points at key
-management, and login guidance leads with paths that avoid shell history.
+Credential hygiene: `nansen login` verification failures cannot relay the API
+key, invalid-key remediation points at key management, and login guidance leads
+with paths that avoid shell history. Every request that carries a credential —
+API key, agent, limit-order JWT/X-API-Key, MCP verify, and Privy auth — now
+refuses to follow HTTP redirects, so a credential can't be relayed to a redirect
+target. Interactive password and API-key prompts stay masked (no cleartext echo)
+even when stdout is redirected.

--- a/.changeset/login-key-hygiene.md
+++ b/.changeset/login-key-hygiene.md
@@ -1,0 +1,7 @@
+---
+"nansen-cli": patch
+---
+
+`nansen login` hygiene: verification failures cannot relay the API key,
+authenticated redirects are rejected, invalid-key remediation points at key
+management, and login guidance leads with paths that avoid shell history.

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Three options — pick whichever fits your setup:
 
 1. **API key** (subscription):
    ```bash
-   nansen login --api-key <key>   # save key to ~/.nansen/config.json
-   nansen login --human           # interactive prompt
-   export NANSEN_API_KEY=...      # env var (highest priority)
-   nansen logout                  # remove saved key
+   nansen login --human   # interactive prompt; saves to ~/.nansen/config.json
+   nansen login           # uses NANSEN_API_KEY when already set
+   nansen logout          # remove saved key
    ```
+   For automation, inject `NANSEN_API_KEY` through your environment or secret manager.
    Get your API key at [app.nansen.ai/auth/agent-setup](https://app.nansen.ai/auth/agent-setup).
 
 2. **x402 micropayment** (no key needed): `nansen wallet create`, fund with USDC on Base or Solana, or USDT0 on X Layer, then call any endpoint — the CLI signs `Payment-Signature` headers automatically on 402 responses. See [Wallet](#wallet).
@@ -36,7 +36,7 @@ Three options — pick whichever fits your setup:
 For the hosted Nansen MCP server, verify server reachability and the supplied API key on the paid data path with:
 
 ```bash
-npx -y nansen-cli mcp verify --api-key <key>
+npx -y nansen-cli mcp verify  # uses the saved key or NANSEN_API_KEY
 ```
 
 The check calls `tools/list` for reachability, then calls the paid `nansen_score_top_tokens` canary tool. A successful canary costs about 1 credit; tool listings and free tools alone do not prove that a key works. The CLI cannot inspect the key inside your MCP client, so make sure this same key is in the client's `NANSEN-API-KEY` header. For the final client-config check, ask your client: “Use the `nansen_score_top_tokens` tool.”
@@ -319,7 +319,7 @@ Any field may be absent or `null`, meaning unknown — never assume zero. A low-
 | `command not found` | `npm install -g nansen-cli` |
 | Global install reports an older version | `npm i -g nansen-cli@latest --registry=https://registry.npmjs.org/ --prefer-online`, then check `which -a nansen` for stale binaries |
 | `UNAUTHORIZED` after login | `nansen auth status` shows which key is active and where it comes from; re-run `nansen login` or set `NANSEN_API_KEY` |
-| MCP client lists tools but paid calls fail | Run `npx -y nansen-cli mcp verify --api-key <key>` and ensure that same key is in the client's `NANSEN-API-KEY` header |
+| MCP client lists tools but paid calls fail | Run `npx -y nansen-cli mcp verify` with the saved key or `NANSEN_API_KEY`, and ensure that same key is in the client's `NANSEN-API-KEY` header |
 | Anything else misbehaving | `nansen doctor` checks your whole setup (auth, wallets, caches, connectivity) with a fix per finding |
 | Empty perp _research_ results | Use `--symbol BTC`, not `--token`. Perps are Hyperliquid-only. |
 | `perp` _trading_ prints the usage banner | Trading needs `--coin BTC` (`--symbol` also works); see the Perpetuals section. |

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -132,7 +132,7 @@ async function installSkill() {
 async function testQuery() {
   if (!isLoggedIn()) {
     log();
-    log(`Not logged in yet. Run ${CYAN}nansen login --api-key <key>${RESET} to authenticate.`);
+    log(`Not logged in yet. Run ${CYAN}nansen login --human${RESET} to authenticate.`);
     log(`Get your API key at: ${CYAN}https://app.nansen.ai/auth/agent-setup${RESET}`);
     return;
   }
@@ -156,7 +156,7 @@ async function testQuery() {
     log(`${GREEN}✓${RESET} All set! Run ${CYAN}nansen help${RESET} to see all available commands.`);
   } else {
     log();
-    log(`${YELLOW}Query failed. Check your API key with: nansen login --api-key <key>${RESET}`);
+    log(`${YELLOW}Query failed. Check your API key with: nansen auth status${RESET}`);
   }
 }
 
@@ -172,7 +172,7 @@ async function main() {
     log(`${BOLD}Nansen CLI installed!${RESET}`);
     log();
     log(`Tip: Run '${CYAN}npx skills add ${SKILL_REPO}${RESET}' to install the Nansen AI coding skill.`);
-    log(`Tip: Run '${CYAN}nansen login --api-key <key>${RESET}' to authenticate.`);
+    log(`Tip: Run '${CYAN}nansen login --human${RESET}' to authenticate.`);
     log(`Tip: To trade, first create a wallet with '${CYAN}nansen wallet create${RESET}', then quote with '${CYAN}nansen trade quote --chain solana --from SOL --to USDC --amount 1000000000${RESET}' and execute with '${CYAN}nansen trade execute --quote <id>${RESET}'.`);
     return;
   }

--- a/skills/nansen-wallet-manager/SKILL.md
+++ b/skills/nansen-wallet-manager/SKILL.md
@@ -21,10 +21,10 @@ allowed-tools: Bash(nansen:*)
 ## Auth Setup
 
 ```bash
-# Save API key (non-interactive)
-nansen login --api-key <key>
-# Or via env var:
-NANSEN_API_KEY=<key> nansen login
+# Save API key interactively
+nansen login --human
+# Or use NANSEN_API_KEY after provisioning it through your environment/secret manager
+nansen login
 
 # Verify
 nansen research profiler labels --address 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 --chain ethereum
@@ -190,7 +190,7 @@ For detailed migration steps (from `~/.nansen/.env`, `.credentials`, or env-var-
 | Var | Purpose |
 |-----|---------|
 | `NANSEN_WALLET_PASSWORD` | Wallet encryption password — only needed for initial `wallet create`. After that, the OS keychain handles it. |
-| `NANSEN_API_KEY` | API key (also set via `nansen login --api-key <key>`) |
+| `NANSEN_API_KEY` | API key (can also be saved via `nansen login --human`) |
 | `PRIVY_APP_ID` | Privy application ID (required for `--provider privy`) |
 | `PRIVY_APP_SECRET` | Privy application secret (required for `--provider privy`) |
 | `NANSEN_WALLET_PROVIDER` | Default provider for wallet create — `local` or `privy` |

--- a/src/__tests__/agent.test.js
+++ b/src/__tests__/agent.test.js
@@ -142,6 +142,9 @@ describe('agent command', () => {
 
       const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
       expect(body.conversation_id).toBe('550e8400-e29b-41d4-a716-446655440000');
+      // The agent request carries the apikey header; never follow a redirect
+      // that could relay it to another host.
+      expect(fetchSpy.mock.calls[0][1].redirect).toBe('error');
     });
 
     it('rejects non-UUID conversation-id', async () => {

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -459,6 +459,7 @@ describe('NansenAPI', () => {
 
           expect(url).toBe('https://api.nansen.ai/api/v1/account');
           expect(options.method).toBe('GET');
+          expect(options.redirect).toBe('error');
           expect(options.headers['Content-Type']).toBeUndefined();
           expect(options.headers['apikey']).toBe('test-api-key');
           expect(options.body).toBeUndefined();

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -1888,6 +1888,23 @@ describe('buildCommands', () => {
       expect(JSON.stringify(thrown.data ?? {})).not.toContain(encodedKey);
     });
 
+    it('restores signal from the structured code without relaying the message', async () => {
+      const key = 'RATE_LIMIT_TEST_KEY';
+      const mockApi = { getAccount: vi.fn().mockRejectedValue(
+        // A transient rate-limit whose message still echoes the key: the branch
+        // must key off error.code, never interpolate the message.
+        Object.assign(new Error(`429 for ${key}`), { code: ErrorCode.RATE_LIMITED })
+      ) };
+      mockDeps.NansenAPIClass.mockImplementation(function() { return mockApi; });
+
+      const thrown = await commands.login([], null, {}, { 'api-key': key }).catch(e => e);
+
+      expect(thrown.code).toBe('VERIFICATION_FAILED');
+      expect(thrown.message).toMatch(/rate limited/i);
+      expect(thrown.message).not.toBe('Could not verify API key.'); // not the misleading generic
+      expect(JSON.stringify(thrown.data ?? {})).not.toContain(key);   // no message relay
+    });
+
     it('invalid-key resolution points at the key management view, never agent-setup', async () => {
       const mockApi = { getAccount: vi.fn().mockRejectedValue(
         Object.assign(new Error('unauthorized'), { code: ErrorCode.UNAUTHORIZED })

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -1795,6 +1795,28 @@ describe('prompt', () => {
     expect(input.setRawMode.mock.calls).toEqual([[true], [false]]);
     expect(output.write.mock.calls.flat().join('')).not.toContain(secret);
   });
+
+  it('defaults masked output to stderr, never a redirected stdout', async () => {
+    let onData;
+    const input = {
+      isTTY: true,
+      setRawMode: vi.fn(), resume: vi.fn(), pause: vi.fn(), setEncoding: vi.fn(),
+      on: vi.fn((_e, h) => { onData = h; }), removeListener: vi.fn(),
+    };
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const outSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const result = prompt('Enter key: ', true, { input });   // no output → default stderr
+      onData('K'); onData('\n');
+      await expect(result).resolves.toBe('K');
+      // Prompt + mask went to stderr; stdout (which a user may redirect) untouched.
+      expect(errSpy.mock.calls.flat().join('')).toContain('*');
+      expect(outSpy).not.toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+      outSpy.mockRestore();
+    }
+  });
 });
 
 describe('buildCommands', () => {

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -15,6 +15,7 @@ import {
   formatCsv,
   parseSort,
   buildCommands,
+  prompt,
   runCLI,
   DEPRECATED_TO_RESEARCH,
   DEPRECATED_TO_TRADE,
@@ -1771,6 +1772,31 @@ describe('HELP', () => {
   });
 });
 
+describe('prompt', () => {
+  it('keeps hidden input masked when stdout is redirected', async () => {
+    let onData;
+    const input = {
+      isTTY: true,
+      setRawMode: vi.fn(),
+      resume: vi.fn(),
+      pause: vi.fn(),
+      setEncoding: vi.fn(),
+      on: vi.fn((_event, handler) => { onData = handler; }),
+      removeListener: vi.fn(),
+    };
+    const output = { isTTY: false, write: vi.fn() };
+    const secret = 'REDIRECTED_OUTPUT_TEST_KEY';
+
+    const result = prompt('Enter key: ', true, { input, output });
+    onData(secret);
+    onData('\n');
+
+    await expect(result).resolves.toBe(secret);
+    expect(input.setRawMode.mock.calls).toEqual([[true], [false]]);
+    expect(output.write.mock.calls.flat().join('')).not.toContain(secret);
+  });
+});
+
 describe('buildCommands', () => {
   let mockDeps;
   let commands;
@@ -1845,6 +1871,50 @@ describe('buildCommands', () => {
       } finally {
         if (savedEnv !== undefined) process.env.NANSEN_API_KEY = savedEnv;
       }
+    });
+
+    it('does not relay verification error text', async () => {
+      const key = 'VERIFICATION_TEST_KEY';
+      const encodedKey = Buffer.from(key).toString('base64');
+      const mockApi = { getAccount: vi.fn().mockRejectedValue(
+        Object.assign(new Error(`upstream echoed ${key} and ${encodedKey}`), { code: 'SOMETHING_ELSE' })
+      ) };
+      mockDeps.NansenAPIClass.mockImplementation(function() { return mockApi; });
+
+      const thrown = await commands.login([], null, {}, { 'api-key': key }).catch(e => e);
+
+      expect(thrown.message).toBe('Could not verify API key.');
+      expect(thrown.message).not.toContain(key);
+      expect(JSON.stringify(thrown.data ?? {})).not.toContain(encodedKey);
+    });
+
+    it('invalid-key resolution points at the key management view, never agent-setup', async () => {
+      const mockApi = { getAccount: vi.fn().mockRejectedValue(
+        Object.assign(new Error('unauthorized'), { code: ErrorCode.UNAUTHORIZED })
+      ) };
+      mockDeps.NansenAPIClass.mockImplementation(function() { return mockApi; });
+
+      let thrown;
+      try {
+        await commands.login([], null, {}, { 'api-key': 'some-invalid-key' });
+      } catch (e) { thrown = e; }
+      expect(thrown).toBeDefined();
+      const resolution = JSON.stringify(thrown.data?.resolution ?? []);
+      expect(resolution).toContain('https://app.nansen.ai/api?tab=api');
+      expect(resolution).not.toContain('/auth/agent-setup');
+    });
+
+    it('login help warns that literal keys land in shell history', async () => {
+      const logs = [];
+      const localCommands = buildCommands({ ...mockDeps, log: (m) => logs.push(m) });
+      await localCommands.login([], null, { help: true }, {});
+      const out = logs.join('\n');
+      expect(out).toContain('--human');
+      expect(out).toContain('uses NANSEN_API_KEY when already set');
+      expect(out).not.toContain('security find-generic-password');
+      expect(out).toMatch(/recorded in shell history/i);
+      // the safe path is listed before the history-recording one
+      expect(out.indexOf('--human')).toBeLessThan(out.indexOf('--api-key <key>'));
     });
 
     it('should save config with --api-key option after verification', async () => {

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -332,6 +332,16 @@ describe('API client', () => {
 
     await expect(getVault('jwt', 'pub1')).rejects.toThrow('non-JSON response');
   });
+
+  it('converts a redirect rejection (redirect: error) into a coded, actionable error', async () => {
+    // undici throws a bare TypeError('fetch failed') when redirect:'error' hits a 3xx.
+    global.fetch.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+    const err = await getVault('jwt', 'pub1').catch((e) => e);
+    expect(err.code).toBe('LIMIT_ORDER_NETWORK_ERROR');
+    expect(err.message).toMatch(/Limit order API request failed/);
+    expect(err.message).not.toBe('fetch failed'); // not the undecorated TypeError
+  });
 });
 
 // ============= Message Signing =============

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -202,6 +202,9 @@ describe('API client', () => {
     const [url, opts] = global.fetch.mock.calls[0];
     expect(url).toContain('/limit-order/v2/auth/challenge');
     expect(JSON.parse(opts.body)).toEqual({ walletPubkey: 'myPubkey' });
+    // The client sends X-API-Key / Bearer JWT; never follow a redirect that
+    // could relay them to another host.
+    expect(opts.redirect).toBe('error');
   });
 
   it('verifyChallenge sends correct request', async () => {

--- a/src/__tests__/mcp-verify.test.js
+++ b/src/__tests__/mcp-verify.test.js
@@ -90,6 +90,10 @@ describe('mcp verify', () => {
     expect(fetchFn).toHaveBeenCalledTimes(2);
     const [listCall, authCall] = fetchFn.mock.calls;
     expect(listCall[1].headers).not.toHaveProperty('NANSEN-API-KEY');
+    // The authenticated canary carries NANSEN-API-KEY; both calls must refuse
+    // redirects so the key can't be relayed to a redirect target.
+    expect(listCall[1].redirect).toBe('error');
+    expect(authCall[1].redirect).toBe('error');
     expect(JSON.parse(authCall[1].body)).toMatchObject({
       method: 'tools/call',
       params: { name: 'nansen_score_top_tokens', arguments: { request: {} } },

--- a/src/__tests__/privy.test.js
+++ b/src/__tests__/privy.test.js
@@ -39,6 +39,9 @@ describe("PrivyClient", () => {
       `Basic ${Buffer.from("app-id:app-secret").toString("base64")}`
     );
     expect(opts.headers["privy-app-id"]).toBe("app-id");
+    // Credentialed request must refuse redirects rather than relay Basic auth /
+    // privy-app-id to a redirect target.
+    expect(opts.redirect).toBe("error");
 
     vi.unstubAllGlobals();
   });

--- a/src/__tests__/privy.test.js
+++ b/src/__tests__/privy.test.js
@@ -59,6 +59,19 @@ describe("PrivyClient", () => {
     vi.unstubAllGlobals();
   });
 
+  it("converts a redirect rejection (redirect: 'error') into an actionable message", async () => {
+    const client = new PrivyClient("app-id", "app-secret");
+    // undici throws a bare TypeError('fetch failed') when redirect:'error' hits a 3xx.
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("fetch failed")));
+
+    const err = await client.listWallets().catch((e) => e);
+    expect(err.message).toMatch(/Privy API request failed/);
+    expect(err.message).toContain("GET /wallets");
+    expect(err.message).not.toBe("fetch failed"); // not the undecorated TypeError
+
+    vi.unstubAllGlobals();
+  });
+
   it("createWallet sends correct body", async () => {
     const client = new PrivyClient("app-id", "app-secret");
     const mockFetch = vi.fn().mockResolvedValue({

--- a/src/__tests__/swap-simulation.test.js
+++ b/src/__tests__/swap-simulation.test.js
@@ -162,6 +162,9 @@ describe('swap-simulation', () => {
       await simulateAssetChanges('base', { to: ROUTER, data: '0x' }, { from: WALLET, apiKey: 'secret-key' });
       const [, opts] = global.fetch.mock.calls[0];
       expect(opts.headers.apikey).toBe('secret-key');
+      // The credentialed sim call must refuse redirects so the apikey can't be
+      // relayed to a redirect target.
+      expect(opts.redirect).toBe('error');
     });
 
     it('does NOT leak the apikey to a custom (non-Nansen) override RPC', async () => {

--- a/src/__tests__/swap-simulation.test.js
+++ b/src/__tests__/swap-simulation.test.js
@@ -175,6 +175,9 @@ describe('swap-simulation', () => {
       await simulateAssetChanges('base', { to: ROUTER, data: '0x' }, { from: WALLET, apiKey: 'secret-key' });
       const [, opts] = global.fetch.mock.calls[0];
       expect('apikey' in opts.headers).toBe(false);
+      // Anonymous call to a third-party RPC carries no credential, so the
+      // redirect guard does not apply — it follows redirects as before.
+      expect(opts.redirect).toBe('follow');
     });
 
     it('flags an ERC-721 leaving the wallet as an NFT outflow', async () => {

--- a/src/__tests__/wallet.test.js
+++ b/src/__tests__/wallet.test.js
@@ -21,6 +21,7 @@ import {
   setDefaultWallet,
   deleteWallet,
   getWalletConfig,
+  promptPassword,
 } from '../wallet.js';
 import { keccak256 } from '../crypto.js';
 
@@ -37,6 +38,56 @@ beforeEach(() => {
 afterEach(() => {
   process.env.HOME = originalHome;
   fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('promptPassword masking', () => {
+  // A TTY stdin whose masked prompt output is redirected away from the terminal
+  // (e.g. `nansen wallet export > backup.json`). The password must never be
+  // echoed in cleartext, and nothing sensitive may reach the redirected stdout.
+  function fakeTtyStdin() {
+    let onData;
+    return {
+      isTTY: true,
+      setRawMode: vi.fn(),
+      resume: vi.fn(),
+      pause: vi.fn(),
+      setEncoding: vi.fn(),
+      on: vi.fn((_event, handler) => { onData = handler; }),
+      removeListener: vi.fn(),
+      feed: (s) => { for (const ch of s) onData(ch); },
+    };
+  }
+
+  it('masks a TTY password and never echoes it, even when stdout is redirected', async () => {
+    const input = fakeTtyStdin();
+    const output = { write: vi.fn() };            // stands in for stderr/terminal
+    const stdout = { isTTY: false, write: vi.fn() }; // redirected: must stay clean
+    const secret = 'WALLET_SECRET_PW_42';
+
+    const result = promptPassword('Enter wallet password: ', {}, { input, output });
+    input.feed(secret);
+    input.feed('\n');
+
+    await expect(result).resolves.toBe(secret);
+    // Raw mode toggled on then off — terminal echo disabled for the whole read.
+    expect(input.setRawMode.mock.calls).toEqual([[true], [false]]);
+    // Masked stream shows only asterisks, never the secret characters.
+    const written = output.write.mock.calls.flat().join('');
+    expect(written).not.toContain(secret);
+    expect(written).toContain('*');
+    // The redirected stdout was never written to at all.
+    expect(stdout.write).not.toHaveBeenCalled();
+  });
+
+  it('gates on stdin, not stdout — a redirected stdout still gets the masked path', async () => {
+    const input = fakeTtyStdin();
+    const output = { write: vi.fn() };
+    const result = promptPassword('pw: ', {}, { input, output });
+    input.feed('abc\n');
+    await expect(result).resolves.toBe('abc');
+    // Reaching raw mode at all proves the gate is stdin.isTTY, not stdout.isTTY.
+    expect(input.setRawMode).toHaveBeenCalled();
+  });
 });
 
 describe('keccak256', () => {

--- a/src/__tests__/x402-api-retry.test.js
+++ b/src/__tests__/x402-api-retry.test.js
@@ -105,6 +105,7 @@ describe('NansenAPI._x402Retry', () => {
     const [, requestInit] = mockFetch.mock.calls[0];
     expect(requestInit.headers['Payment-Signature']).toBe('my-payment-sig');
     expect(requestInit.method).toBe('POST');
+    expect(requestInit.redirect).toBe('error');
     expect(requestInit.body).toBeDefined();
   });
 

--- a/src/api.js
+++ b/src/api.js
@@ -552,6 +552,7 @@ export class NansenAPI {
     const isGet = method === 'GET';
     const paidResponse = await fetch(url, {
       method,
+      redirect: 'error',
       headers: {
         ...(!isGet && { 'Content-Type': 'application/json' }),
         'X-Client-Type': 'nansen-cli',
@@ -609,6 +610,7 @@ export class NansenAPI {
         const isGet = method === 'GET';
         response = await fetch(url, {
           method,
+          redirect: 'error',
           headers: {
             ...(!isGet && { 'Content-Type': 'application/json' }),
             'X-Client-Type': 'nansen-cli',
@@ -751,7 +753,7 @@ export class NansenAPI {
                   } catch (x402Err) {
                     if (!this.apiKey) {
                       message = 'No API key configured. Three ways to authenticate:\n' +
-                        '  1. API key: nansen login --api-key <key> (get key at https://app.nansen.ai/auth/agent-setup)\n' +
+                        '  1. API key: run `nansen login --human` or set NANSEN_API_KEY (get key at https://app.nansen.ai/auth/agent-setup)\n' +
                         '  2. x402 micropayment: nansen wallet create + fund with USDC on Base/Solana or USDT0 on X Layer (no API key needed)\n' +
                         '  3. MPP via tempo: install tempo CLI, run `tempo wallet login`, then call the API with `tempo request` (see skills/nansen-mpp-payment)';
                     } else {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1016,9 +1016,9 @@ export function buildCommands(deps = {}) {
 
       if (!apiKey && flags.human) {
         if (!isTTY) {
-          throw new CommandError('--human requires an interactive terminal. Use --api-key or NANSEN_API_KEY env var instead.', 'NOT_A_TTY', {
+          throw new CommandError('--human requires an interactive terminal. Set NANSEN_API_KEY in the environment (or pass --api-key <key>, which is recorded in shell history).', 'NOT_A_TTY', {
             error: 'NOT_A_TTY',
-            message: '--human requires an interactive terminal. Use --api-key or NANSEN_API_KEY env var instead.',
+            message: '--human requires an interactive terminal. Set NANSEN_API_KEY in the environment (or pass --api-key <key>, which is recorded in shell history).',
           });
         }
         log('Nansen CLI Login\n');
@@ -1056,10 +1056,25 @@ export function buildCommands(deps = {}) {
             resolution: ['Check or rotate your key at https://app.nansen.ai/api?tab=api'],
           });
         }
-        throw new CommandError('Could not verify API key.', 'VERIFICATION_FAILED', {
+        // Restore signal from the STRUCTURED error code only — never from
+        // error.message, which can echo the upstream response body (and the key
+        // with it). A transient failure shouldn't read as "check your key".
+        let message = 'Could not verify API key.';
+        let resolution = ['Check your internet connection', 'Try again'];
+        if (error.code === ErrorCode.RATE_LIMITED) {
+          message = 'Rate limited while verifying the API key.';
+          resolution = ['Wait a moment, then run nansen login again'];
+        } else if (error.code === ErrorCode.SERVER_ERROR || error.code === ErrorCode.SERVICE_UNAVAILABLE) {
+          message = 'The Nansen API is unavailable right now, so the key could not be verified.';
+          resolution = ['Try again shortly'];
+        } else if (error.code === ErrorCode.TIMEOUT) {
+          message = 'Timed out verifying the API key.';
+          resolution = ['Check your connection', 'Try again'];
+        }
+        throw new CommandError(message, 'VERIFICATION_FAILED', {
           error: 'VERIFICATION_FAILED',
-          message: 'Could not verify API key.',
-          resolution: ['Check your internet connection', 'Try again'],
+          message,
+          resolution,
         });
       }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -829,8 +829,10 @@ CROSS-CHAIN NOTES (when using --to-chain):
   Bridge providers: Li.Fi or Relay (selected automatically based on best price)
   Typical bridge time: 1-5 minutes`;
 
-// Helper to prompt for input (exported for mocking)
-export async function prompt(question, hidden = false, { input = process.stdin, output = process.stdout } = {}) {
+// Helper to prompt for input (exported for mocking). Output defaults to stderr
+// so the prompt and masked `*` characters stay on the terminal and never land
+// in a redirected stdout (matching wallet.js promptPassword).
+export async function prompt(question, hidden = false, { input = process.stdin, output = process.stderr } = {}) {
   return new Promise((resolve) => {
     if (hidden && input.isTTY) {
       output.write(question);

--- a/src/cli.js
+++ b/src/cli.js
@@ -738,7 +738,7 @@ COMMANDS:
   mcp         install/uninstall/verify the Nansen MCP server
   account     Show API key status, plan, and remaining credits
   auth        status — offline auth status: key source, wallets (no network)
-  login       Save API key (--api-key <key>, --human, or NANSEN_API_KEY env var)
+  login       Save API key (--human, NANSEN_API_KEY, or --api-key <key>)
   logout      Remove saved API key
   doctor      Diagnostics: auth, wallets, caches, connectivity (--offline --json)
   schema      JSON schema for all commands (use "nansen schema <cmd>" for one)
@@ -830,42 +830,42 @@ CROSS-CHAIN NOTES (when using --to-chain):
   Typical bridge time: 1-5 minutes`;
 
 // Helper to prompt for input (exported for mocking)
-export async function prompt(question, hidden = false) {
+export async function prompt(question, hidden = false, { input = process.stdin, output = process.stdout } = {}) {
   return new Promise((resolve) => {
-    if (hidden && process.stdout.isTTY) {
-      process.stdout.write(question);
-      let input = '';
-      process.stdin.setRawMode(true);
-      process.stdin.resume();
-      process.stdin.setEncoding('utf8');
+    if (hidden && input.isTTY) {
+      output.write(question);
+      let value = '';
+      input.setRawMode(true);
+      input.resume();
+      input.setEncoding('utf8');
       
       const onData = (char) => {
         if (char === '\n' || char === '\r') {
-          process.stdin.setRawMode(false);
-          process.stdin.pause();
-          process.stdin.removeListener('data', onData);
-          process.stdout.write('\n');
-          resolve(input);
+          input.setRawMode(false);
+          input.pause();
+          input.removeListener('data', onData);
+          output.write('\n');
+          resolve(value);
         } else if (char === '\u0003') {
           // Ctrl+C
           process.exit();
         } else if (char === '\u007F' || char === '\b') {
           // Backspace
-          if (input.length > 0) {
-            input = input.slice(0, -1);
-            process.stdout.write('\b \b');
+          if (value.length > 0) {
+            value = value.slice(0, -1);
+            output.write('\b \b');
           }
         } else {
-          input += char;
-          process.stdout.write('*');
+          value += char;
+          output.write('*');
         }
       };
       
-      process.stdin.on('data', onData);
+      input.on('data', onData);
     } else {
       const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
+        input,
+        output
       });
       rl.question(question, (answer) => {
         rl.close();
@@ -996,13 +996,14 @@ export function buildCommands(deps = {}) {
       if (flags.help || flags.h) {
         log('nansen login - Save your Nansen API key\n');
         log('USAGE:');
-        log('  nansen login --api-key <key>');
-        log('  NANSEN_API_KEY=<key> nansen login');
-        log('  nansen login --human              (interactive prompt)\n');
+        log('  nansen login --human              (interactive prompt; key never enters shell history)');
+        log('  nansen login                      (uses NANSEN_API_KEY when already set)');
+        log('  nansen login --api-key <key>      (literal key IS recorded in shell history)\n');
         log('OPTIONS:');
-        log('  --api-key <key>   Your Nansen API key');
+        log('  --api-key <key>   Your Nansen API key (recorded in shell history — prefer --human)');
         log('  --human           Enable interactive prompt');
         log('  --help            Show this help\n');
+        log('Setting a literal key in a command may record it in shell history.');
         log('Get your API key at: https://app.nansen.ai/auth/agent-setup');
         return;
       }
@@ -1030,8 +1031,8 @@ export function buildCommands(deps = {}) {
           error: 'API_KEY_REQUIRED',
           message: 'No API key provided.',
           resolution: [
-            'Run: nansen login --api-key <key>',
-            'Or set NANSEN_API_KEY environment variable',
+            'Run in an interactive terminal: nansen login --human',
+            'Or set NANSEN_API_KEY in the environment',
             'Get your API key at: https://app.nansen.ai/auth/agent-setup',
           ],
         });
@@ -1052,12 +1053,12 @@ export function buildCommands(deps = {}) {
           throw new CommandError('The API key is not valid.', 'INVALID_API_KEY', {
             error: 'INVALID_API_KEY',
             message: 'The API key is not valid.',
-            resolution: ['Check your key at https://app.nansen.ai/auth/agent-setup'],
+            resolution: ['Check or rotate your key at https://app.nansen.ai/api?tab=api'],
           });
         }
-        throw new CommandError(`Could not verify API key: ${error.message}`, 'VERIFICATION_FAILED', {
+        throw new CommandError('Could not verify API key.', 'VERIFICATION_FAILED', {
           error: 'VERIFICATION_FAILED',
-          message: `Could not verify API key: ${error.message}`,
+          message: 'Could not verify API key.',
           resolution: ['Check your internet connection', 'Try again'],
         });
       }

--- a/src/commands/agent.js
+++ b/src/commands/agent.js
@@ -254,6 +254,10 @@ EXAMPLES:
       try {
         response = await fetch(url, {
           method: 'POST',
+          // Never follow a redirect on a request carrying the API key — undici
+          // forwards custom credential headers (apikey) across a cross-origin
+          // redirect, handing the key to whatever host the response points at.
+          redirect: 'error',
           headers: buildHeaders(apiInstance),
           body: JSON.stringify(body),
           signal: controller.signal,

--- a/src/doctor.js
+++ b/src/doctor.js
@@ -313,7 +313,7 @@ export function runDoctorChecks(deps = {}) {
       }
     }
   } else {
-    checks.push(check('api-key', auth.configFileExists ? 'error' : 'warn', 'No API key configured', 'Run: nansen login --api-key <key>  (or fund an x402 wallet for pay-per-call access)'));
+    checks.push(check('api-key', auth.configFileExists ? 'error' : 'warn', 'No API key configured', 'Run: nansen login --human or set NANSEN_API_KEY  (or fund an x402 wallet for pay-per-call access)'));
   }
   // POSIX modes are meaningless on Windows — fs.stat reports 0o666 for every
   // file there, which would warn on all of them

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -110,7 +110,18 @@ async function loFetch(method, endpoint, { token, body, query } = {}) {
     opts.body = JSON.stringify(body);
   }
 
-  const res = await fetch(url.toString(), opts);
+  let res;
+  try {
+    res = await fetch(url.toString(), opts);
+  } catch (err) {
+    // redirect: 'error' rejects with a bare TypeError on any server redirect;
+    // convert it (and genuine network failures) into a coded, actionable error
+    // rather than letting an undecorated crash reach the CLI.
+    throw Object.assign(
+      new Error(`Limit order API request failed (${method} ${url.pathname}): ${err.message}`),
+      { code: 'LIMIT_ORDER_NETWORK_ERROR' }
+    );
+  }
   const text = await res.text();
 
   let parsed;

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -118,7 +118,7 @@ async function loFetch(method, endpoint, { token, body, query } = {}) {
     // convert it (and genuine network failures) into a coded, actionable error
     // rather than letting an undecorated crash reach the CLI.
     throw Object.assign(
-      new Error(`Limit order API request failed (${method} ${url.pathname}): ${err.message}`),
+      new Error(`Limit order API request failed (${method} ${url.pathname}): ${err.message}`, { cause: err }),
       { code: 'LIMIT_ORDER_NETWORK_ERROR' }
     );
   }

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -102,7 +102,10 @@ async function loFetch(method, endpoint, { token, body, query } = {}) {
     headers['X-API-Key'] = process.env.NANSEN_API_KEY;
   }
 
-  const opts = { method, headers };
+  // Never follow a redirect on a request carrying the JWT / X-API-Key — undici
+  // forwards the custom X-API-Key header across a cross-origin redirect, leaking
+  // the key to the redirect target.
+  const opts = { method, headers, redirect: 'error' };
   if (body !== undefined) {
     opts.body = JSON.stringify(body);
   }

--- a/src/mcp-verify.js
+++ b/src/mcp-verify.js
@@ -197,7 +197,7 @@ export async function runMcpVerifyChecks({
       'mcp-api-key',
       'error',
       'No API key available for the authenticated MCP data-path check',
-      'Create an API key at https://app.nansen.ai/api?tab=api, then pass --api-key <key> or set NANSEN_API_KEY',
+      'Create an API key at https://app.nansen.ai/api?tab=api, then set NANSEN_API_KEY or save it with `nansen login --human`',
     ));
   }
 

--- a/src/mcp-verify.js
+++ b/src/mcp-verify.js
@@ -75,6 +75,10 @@ export async function mcpRequest(url, method, params, {
   try {
     response = await fetchFn(url, {
       method: 'POST',
+      // The canary carries NANSEN-API-KEY; undici forwards that custom header
+      // across a cross-origin redirect, so refuse to follow one rather than
+      // relay the key to whatever host the (possibly non-default) server points at.
+      redirect: 'error',
       headers,
       signal: controller.signal,
       body: JSON.stringify({ jsonrpc: '2.0', id: requestId, method, params }),

--- a/src/privy.js
+++ b/src/privy.js
@@ -54,7 +54,15 @@ export class PrivyClient {
     const opts = { method, headers, redirect: "error" };
     if (body) opts.body = JSON.stringify(body);
 
-    const response = await fetch(`${this.baseUrl}${endpoint}`, opts);
+    let response;
+    try {
+      response = await fetch(`${this.baseUrl}${endpoint}`, opts);
+    } catch (err) {
+      // redirect: 'error' rejects with a bare TypeError on any server redirect;
+      // convert it (and genuine network failures) into an actionable message
+      // rather than surfacing an undecorated crash.
+      throw new Error(`Privy API request failed (${method} ${endpoint}): ${err.message}. If PRIVY_* points at a proxy that redirects, use the direct api.privy.io base URL.`);
+    }
 
     if (!response.ok) {
       let msg = `Privy API error: ${response.status}`;

--- a/src/privy.js
+++ b/src/privy.js
@@ -49,7 +49,9 @@ export class PrivyClient {
       "Content-Type": "application/json",
     };
 
-    const opts = { method, headers };
+    // Never follow a redirect on a request carrying Basic auth / privy-app-id —
+    // a redirect target could otherwise be handed the app credentials.
+    const opts = { method, headers, redirect: "error" };
     if (body) opts.body = JSON.stringify(body);
 
     const response = await fetch(`${this.baseUrl}${endpoint}`, opts);

--- a/src/privy.js
+++ b/src/privy.js
@@ -61,7 +61,7 @@ export class PrivyClient {
       // redirect: 'error' rejects with a bare TypeError on any server redirect;
       // convert it (and genuine network failures) into an actionable message
       // rather than surfacing an undecorated crash.
-      throw new Error(`Privy API request failed (${method} ${endpoint}): ${err.message}. If PRIVY_* points at a proxy that redirects, use the direct api.privy.io base URL.`);
+      throw new Error(`Privy API request failed (${method} ${endpoint}): ${err.message}. If PRIVY_* points at a proxy that redirects, use the direct api.privy.io base URL.`, { cause: err });
     }
 
     if (!response.ok) {

--- a/src/schema.json
+++ b/src/schema.json
@@ -1984,8 +1984,8 @@
             }
           },
           "examples": [
-            "npx -y nansen-cli mcp verify --api-key <key>",
-            "nansen mcp verify --api-key <key> --json",
+            "npx -y nansen-cli mcp verify",
+            "nansen mcp verify --json",
             "nansen mcp verify --url https://mcp.example.dev/ra/mcp --api-key <key>"
           ]
         },

--- a/src/swap-simulation.js
+++ b/src/swap-simulation.js
@@ -213,10 +213,12 @@ async function postSim(rpcUrl, apiKey, method, params, timeoutMs) {
     const sendApiKey = Boolean(apiKey) && isNansenHostedUrl(rpcUrl);
     const res = await fetch(rpcUrl, {
       method: 'POST',
-      // Never follow a redirect when the apikey header is attached — undici
+      // Refuse redirects only when the apikey header is attached — undici
       // forwards custom credential headers across a cross-origin redirect, so a
       // redirect would hand the key to whatever host the response points at.
-      redirect: 'error',
+      // An anonymous call to a user-configured third-party RPC carries nothing
+      // to leak, so it keeps following redirects as before.
+      redirect: sendApiKey ? 'error' : 'follow',
       headers: {
         'Content-Type': 'application/json',
         ...(sendApiKey ? { apikey: apiKey } : {}),

--- a/src/swap-simulation.js
+++ b/src/swap-simulation.js
@@ -213,6 +213,10 @@ async function postSim(rpcUrl, apiKey, method, params, timeoutMs) {
     const sendApiKey = Boolean(apiKey) && isNansenHostedUrl(rpcUrl);
     const res = await fetch(rpcUrl, {
       method: 'POST',
+      // Never follow a redirect when the apikey header is attached — undici
+      // forwards custom credential headers across a cross-origin redirect, so a
+      // redirect would hand the key to whatever host the response points at.
+      redirect: 'error',
       headers: {
         'Content-Type': 'application/json',
         ...(sendApiKey ? { apikey: apiKey } : {}),

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -281,27 +281,32 @@ function hashPassword(password) {
 
 // ============= Prompt Helper =============
 
-async function promptPassword(question, deps = {}) {
+// Exported for testing (mirrors the exported `prompt` in cli.js). The streams
+// are injectable so the masking behavior can be exercised without a real TTY.
+export async function promptPassword(question, deps = {}, { input: inStream = process.stdin, output: outStream = process.stderr } = {}) {
   const promptFn = deps.promptFn;
   if (promptFn) {
     return promptFn(question, true);
   }
   // Fallback to readline (only available in --human mode)
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   return new Promise((resolve) => {
-    if (process.stdout.isTTY) {
-      process.stdout.write(question);
+    // Gate on stdin, not stdout: raw-mode masking disables the terminal's own
+    // echo, so a redirected stdout (e.g. `wallet export > backup.json`) can no
+    // longer fall through to readline and echo the password in cleartext. Prompt
+    // and mask characters go to stderr so they stay on the terminal and never
+    // pollute — or leak into — a redirected stdout.
+    if (inStream.isTTY) {
+      outStream.write(question);
       let input = '';
-      process.stdin.setRawMode(true);
-      process.stdin.resume();
-      process.stdin.setEncoding('utf8');
+      inStream.setRawMode(true);
+      inStream.resume();
+      inStream.setEncoding('utf8');
       const onData = (char) => {
         if (char === '\n' || char === '\r') {
-          process.stdin.setRawMode(false);
-          process.stdin.pause();
-          process.stdin.removeListener('data', onData);
-          process.stdout.write('\n');
-          rl.close();
+          inStream.setRawMode(false);
+          inStream.pause();
+          inStream.removeListener('data', onData);
+          outStream.write('\n');
           resolve(input);
         } else if (char === '\u0003') {
           process.exit();
@@ -309,11 +314,12 @@ async function promptPassword(question, deps = {}) {
           input = input.slice(0, -1);
         } else {
           input += char;
-          process.stdout.write('*');
+          outStream.write('*');
         }
       };
-      process.stdin.on('data', onData);
+      inStream.on('data', onData);
     } else {
+      const rl = readline.createInterface({ input: inStream, output: outStream });
       rl.question(question, (answer) => { rl.close(); resolve(answer); });
     }
   });


### PR DESCRIPTION
## Summary

- Suppress upstream verification text so raw or transformed credentials cannot reach CLI output.
- Reject redirects for requests carrying API or payment credentials — **now across every credentialed fetch path, not just `api.js`**.
- Keep interactive key **and wallet-password** input masked when stdout is redirected.
- Prefer portable login guidance that avoids putting literal keys in shell history.
- Send invalid-key remediation to the key-management view.

## What changed (follow-up commit `ebb6150`)

The first pass hardened the two `api.js` fetch sites and the login verification message. Review found the same leak class left open elsewhere: undici forwards custom credential headers (`apikey`, `X-API-Key`, `NANSEN-API-KEY`, `privy-app-id`) across a cross-origin redirect — confirmed empirically with a 307 loopback that delivered the `apikey` header to a second host. Only `Authorization` is stripped. The follow-up closes the gaps:

- **`redirect: 'error'` on every remaining credentialed fetch:** `agent` (apikey), `limit-order` (JWT + X-API-Key), `mcp verify` (NANSEN-API-KEY), `privy` (Basic auth), and `swap-simulation` (apikey, Nansen-hosted endpoints only).
- **Wallet password masking:** `wallet.js` `promptPassword` now gates on `stdin.isTTY` instead of `stdout.isTTY`, so a redirected stdout (`wallet export > backup.json`) no longer falls through to readline and echoes the password in cleartext. Prompt/mask characters go to stderr. Exported with injectable streams so the masking is unit-tested.
- **Verification error signal:** `VERIFICATION_FAILED` now branches on the structured `error.code` (rate-limit / server / timeout) instead of collapsing every non-auth failure to a misleading "check your key" — without re-introducing the `error.message` relay.
- **Docs consistency:** `schema.json` `mcp verify` examples lead with the saved-key / `NANSEN_API_KEY` form (`examples[0]` renders verbatim in `--help`); `--api-key` kept only as an explicit override. The `NOT_A_TTY` login hint now leads with `NANSEN_API_KEY` over the history-recording `--api-key`.

## Verification

- `npm test`: 59 files passed; **2,422** tests passed; 2 expected skips.
- `npm run lint`: passed.
- New/updated tests: redirect-refusal assertions on each patched fetch site, wallet-password masking (no cleartext echo when stdout is redirected), and a rate-limit signal test that proves the message is not relayed.
- Live loopback probes: a redirect no longer relays credentials to the redirect target on the `api.js` and `agent` paths; a legitimate quote/verify round-trip is unaffected.
