### PR TITLE
Announce the HL-USDC bridge amount floor instead of applying it silently

### DIFF
--- a/.changeset/announce-hl-usdc-bridge-floor.md
+++ b/.changeset/announce-hl-usdc-bridge-floor.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+`bridge quote` now prints a notice when a Hyperliquid USDC amount is floored to the 6-decimal precision the bridge signs, instead of adjusting the amount silently. The adjustment is unchanged (it's what keeps the persisted amount matching what gets signed); it's just no longer hidden.

--- a/src/__tests__/bridge-amount.test.js
+++ b/src/__tests__/bridge-amount.test.js
@@ -135,6 +135,44 @@ describe('bridge quote --amount-unit (M2)', () => {
     expect(api.captured.params.amount).toBe('200000000');
   });
 
+  // The floor changes what gets signed, so it must not be silent. Announce the
+  // before -> after adjustment on the default base-units path...
+  it('announces the floor on the default base-units path', async () => {
+    const msgs = [];
+    const cmds = buildBridgeCommands({ log: (m) => msgs.push(m) });
+    await cmds.quote([], fakeApi(), {}, {
+      'from-chain': 'hyperliquid', 'to-chain': 'base',
+      'from-token': 'USDC', amount: '200000050', wallet: 'w',
+    });
+    expect(msgs.some((m) => /floored 200000050 → 200000000 base units/.test(m))).toBe(true);
+  });
+
+  // ...and stay quiet when nothing was dropped, so aligned amounts don't emit a
+  // no-op notice.
+  it('emits no floor notice when the base-units amount is already aligned', async () => {
+    const msgs = [];
+    const cmds = buildBridgeCommands({ log: (m) => msgs.push(m) });
+    await cmds.quote([], fakeApi(), {}, {
+      'from-chain': 'hyperliquid', 'to-chain': 'base',
+      'from-token': 'USDC', amount: '200000000', wallet: 'w',
+    });
+    expect(msgs.some((m) => /floored/.test(m))).toBe(false);
+  });
+
+  // The second floor call site (the --amount-unit conversion path) announces too.
+  // 2.00000105 USDC at HL's 8 decimals is 200000105, floored to 200000100.
+  it('announces the floor on the --amount-unit token path', async () => {
+    const msgs = [];
+    const cmds = buildBridgeCommands({ log: (m) => msgs.push(m) });
+    const api = fakeApi();
+    await cmds.quote([], api, {}, {
+      'from-chain': 'hyperliquid', 'to-chain': 'base',
+      'from-token': 'USDC', amount: '2.00000105', 'amount-unit': 'token', wallet: 'w',
+    });
+    expect(api.captured.params.amount).toBe('200000100');
+    expect(msgs.some((m) => /floored 200000105 → 200000100 base units/.test(m))).toBe(true);
+  });
+
   it('rejects an unknown --amount-unit instead of silently using base units', async () => {
     const cmds = buildBridgeCommands({ log: () => {} });
     const api = fakeApi();

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1176,6 +1176,16 @@ OPTIONS:
       // Default: --amount is base units. With --amount-unit, accept a human token
       // or USD amount and convert client-side using the source token's decimals.
       let resolvedAmount = amountInput;
+      // HL-USDC flooring drops sub-6dp digits so the persisted amount matches the
+      // 6-decimal precision the bridge actually signs (see
+      // floorHyperliquidUsdcBridgeAmount). The adjustment is tiny (< 1e-6 USDC)
+      // but it changes what gets signed, so announce it rather than adjusting
+      // silently. No-op notice when nothing was dropped.
+      const notifyIfFloored = (before, after) => {
+        if (after !== before) {
+          log(`  Note: amount floored ${before} → ${after} base units to match the 6-decimal USDC precision the bridge signs.`);
+        }
+      };
       if (amountUnit === 'token' || amountUnit === 'usd') {
         try {
           const decimals = await resolveBridgeTokenDecimals(originToken, originChain);
@@ -1191,7 +1201,9 @@ OPTIONS:
             humanAmount = (parseFloat(amountInput) / price).toFixed(decimals);
           }
           resolvedAmount = convertToBaseUnits(humanAmount, decimals);
+          const beforeFloor = resolvedAmount;
           resolvedAmount = floorHyperliquidUsdcBridgeAmount(resolvedAmount, decimals, originToken, originChain);
+          notifyIfFloored(beforeFloor, resolvedAmount);
         } catch (err) {
           throw new Error(`Error converting --amount: ${err.message}`, { cause: err });
         }
@@ -1207,7 +1219,9 @@ OPTIONS:
         // origins (floorHyperliquidUsdcBridgeAmount only acts on HL USDC), where
         // HL USDC's 8 decimals are the only case; the guard skips non-integer
         // input so a malformed base-units amount still surfaces the API's error.
+        const beforeFloor = resolvedAmount;
         resolvedAmount = floorHyperliquidUsdcBridgeAmount(resolvedAmount, 8, originToken, originChain);
+        notifyIfFloored(beforeFloor, resolvedAmount);
       }
 
       log(`\n  Fetching bridge quote: ${originChain} → ${destinationChain}...`);


### PR DESCRIPTION
Fast-follow to #533. Addresses the one actionable non-blocking observation from that review — the HL-USDC amount floor was silent.

## What
`bridge quote` floors a Hyperliquid USDC amount to the 6-decimal precision the bridge actually signs, so the persisted amount matches the signed `sendAsset` amount. That flooring was silent on **both** call sites (the default base-units path and the `--amount-unit` conversion path): `--amount 200000050` sent `200000000` with no notice.

This adds a one-line notice at both floor sites when the value actually changes, via a shared `notifyIfFloored` helper, and stays quiet when the amount was already aligned.

The floor behaviour itself is unchanged — this is purely making an existing adjustment visible.

## Not in scope
The other two observations from #533 need no action (confirmed in that review): pre-fix quotes self-heal via the "request a new quote" error, and the `isBridgeUsdc` gating isn't a reachable false-block since the action-intent token pin rejects non-canonical tokens first. The EVM deposit leg (`processEvmStep`) is tracked separately.

## Testing
- `npm test` — full suite green (2343 passed, 2 skipped)
- `npm run lint` — clean
- New tests in `bridge-amount.test.js`: notice fires on the default base-units path, notice fires on the `--amount-unit` token path, and no notice when the amount is already 6dp-aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)