### PR TITLE
Fix mcp verify command routing

### DIFF
--- a/.changeset/fix-mcp-command-merge.md
+++ b/.changeset/fix-mcp-command-merge.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix `nansen mcp verify` routing after merging MCP install commands.

--- a/src/__tests__/mcp.test.js
+++ b/src/__tests__/mcp.test.js
@@ -374,12 +374,12 @@ describe('mcp command handler', () => {
 });
 
 describe('schema + CLI registration', () => {
-  it('schema.json documents mcp install/uninstall', async () => {
+  it('schema.json documents mcp install/uninstall/verify', async () => {
     const { fileURLToPath } = await import('url');
     const schema = JSON.parse(fs.readFileSync(
       path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'schema.json'), 'utf8'));
     expect(Object.keys(schema.commands)).toContain('mcp');
-    expect(Object.keys(schema.commands.mcp.subcommands).sort()).toEqual(['install', 'uninstall']);
+    expect(Object.keys(schema.commands.mcp.subcommands).sort()).toEqual(['install', 'uninstall', 'verify']);
     expect(schema.commands.mcp.subcommands.uninstall.options['dry-run'].type).toBe('boolean');
   });
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -17,7 +17,6 @@ import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
 import { getAuthStatus, runDoctorChecks, runConnectivityChecks, formatDoctorReport } from './doctor.js';
-import { DEFAULT_MCP_URL, formatMcpVerifyReport, runMcpVerifyChecks } from './mcp-verify.js';
 import { refreshCostMapIfStale, getCostForEndpoint, creditsCharged } from './cost-cache.js';
 import { creditWarning, noticeWarnings } from './response-meta.js';
 import { trackCommandSucceeded, trackCommandFailed } from './telemetry.js';
@@ -736,13 +735,12 @@ COMMANDS:
   agent       Ask the Nansen AI research agent (fast/expert modes)
   alerts      list, create, update, toggle, delete
   web         search, fetch
-  mcp         install/uninstall the Nansen MCP server (claude-code, claude-desktop, cursor)
+  mcp         install/uninstall/verify the Nansen MCP server
   account     Show API key status, plan, and remaining credits
   auth        status — offline auth status: key source, wallets (no network)
   login       Save API key (--api-key <key>, --human, or NANSEN_API_KEY env var)
   logout      Remove saved API key
   doctor      Diagnostics: auth, wallets, caches, connectivity (--offline --json)
-  mcp         Verify hosted MCP setup with an authenticated data call (~1 credit)
   schema      JSON schema for all commands (use "nansen schema <cmd>" for one)
   cache       clear
   changelog   --since <version> to filter
@@ -890,9 +888,7 @@ export function buildCommands(deps = {}) {
     deleteConfigFn = deleteConfig,
     getConfigFileFn = getConfigFile,
     isTTY = process.stdin.isTTY,
-    env = process.env,
-    fetchFn = fetch,
-    devConfigPath
+    env = process.env
   } = deps;
 
   const cmds = {
@@ -925,70 +921,6 @@ export function buildCommands(deps = {}) {
       log(formatDoctorReport(checks, { cliVersion: VERSION, offline: Boolean(flags.offline) }));
     },
 
-    'mcp': async (args, _apiInstance, flags, options) => {
-      const subcommand = args[0];
-      const usage = `nansen mcp — Verify the hosted Nansen MCP setup\n\nUSAGE:\n  nansen mcp verify [--api-key <key>] [--url <url>] [--json]`;
-      if (!subcommand || subcommand === 'help' || flags.help || flags.h) {
-        log(usage);
-        return;
-      }
-      if (subcommand !== 'verify') {
-        throw new NansenError(`Unknown mcp subcommand: ${subcommand}. Available: verify`, ErrorCode.UNKNOWN);
-      }
-      // A valueless --api-key parses as a flag and would silently fall back to
-      // the saved key — the exact false positive this command exists to catch.
-      if (flags['api-key']) {
-        throw new NansenError('--api-key requires a value. Usage: nansen mcp verify --api-key <key>', ErrorCode.MISSING_PARAM);
-      }
-      // parseArgs JSON-parses option values, so `--api-key null` arrives as
-      // null and a repeated flag as an array — both must fail, not fall back.
-      if ('api-key' in options && typeof options['api-key'] !== 'string') {
-        throw new NansenError('--api-key must be a single key string. Usage: nansen mcp verify --api-key <key>', ErrorCode.INVALID_PARAMS);
-      }
-      // Same guards for --url: a valueless flag or a repeated/JSON-parsed value
-      // must fail loudly, not flow an array into fetch or silently fall back.
-      if (flags.url) {
-        throw new NansenError('--url requires a value. Usage: nansen mcp verify --url <url>', ErrorCode.MISSING_PARAM);
-      }
-      if ('url' in options && typeof options.url !== 'string') {
-        throw new NansenError('--url must be a single URL string. Usage: nansen mcp verify --url <url>', ErrorCode.INVALID_PARAMS);
-      }
-
-      const url = options.url || DEFAULT_MCP_URL;
-      const checks = await runMcpVerifyChecks({
-        apiKey: options['api-key'],
-        url,
-        env,
-        fetchFn,
-        devConfigPath,
-      });
-      const verified = checks.some(checkItem => checkItem.id === 'mcp-auth' && checkItem.status === 'ok');
-      const result = {
-        verified,
-        url,
-        checks,
-        errors: checks.filter(checkItem => checkItem.status === 'error').length,
-        warnings: checks.filter(checkItem => checkItem.status === 'warn').length,
-      };
-
-      if (verified) {
-        if (flags.json) return result;
-        log(formatMcpVerifyReport(checks, url, true));
-        return;
-      }
-
-      const reason = (checks.find(checkItem => checkItem.status === 'error')
-        || checks.find(checkItem => checkItem.id === 'mcp-auth' && checkItem.status !== 'ok'))?.message
-        || 'the paid data path did not complete';
-      const message = `MCP setup verification failed — ${reason}`;
-      if (flags.json) throw new CommandError(message, 'MCP_VERIFY_FAILED', result);
-      log(formatMcpVerifyReport(checks, url, false));
-      // The human report above is the complete failure output; mark the error
-      // so runCLI exits non-zero without also emitting the JSON envelope.
-      const reportedError = new CommandError(message, 'MCP_VERIFY_FAILED');
-      reportedError.reported = true;
-      throw reportedError;
-    },
 
     'web': async (args, apiInstance, flags, options) => {
       const subcommand = args[0] || 'help';

--- a/src/commands/mcp.js
+++ b/src/commands/mcp.js
@@ -7,6 +7,7 @@
  */
 
 import { CommandError } from '../api.js';
+import { DEFAULT_MCP_URL, formatMcpVerifyReport, runMcpVerifyChecks } from '../mcp-verify.js';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -35,6 +36,8 @@ const MCP_USAGE = `nansen mcp — Install the Nansen MCP server into a local MCP
 USAGE:
   nansen mcp install <client>     Add the Nansen MCP server to the client's config
   nansen mcp uninstall <client>   Remove the Nansen MCP server from the client's config
+  nansen mcp verify [--api-key <key>] [--url <url>] [--json]
+                                  Verify the hosted MCP server and API key
 
 CLIENTS:
   claude-code      ~/.claude.json (user scope)
@@ -142,6 +145,8 @@ export function buildMcpCommands(deps = {}) {
     platform = process.platform,
     homedirFn = houseHomedir,
     env = process.env,
+    fetchFn = fetch,
+    devConfigPath,
   } = deps;
 
   // Follow symlinks so dotfile-managed configs are edited in place instead of
@@ -207,14 +212,74 @@ export function buildMcpCommands(deps = {}) {
     }
   };
 
+  const verify = async (flags, options) => {
+    // A valueless --api-key parses as a flag and would silently fall back to
+    // the saved key - the exact false positive this command exists to catch.
+    if (flags['api-key']) {
+      throw new CommandError('--api-key requires a value. Usage: nansen mcp verify --api-key <key>', 'MISSING_PARAM');
+    }
+    // parseArgs JSON-parses option values, so `--api-key null` arrives as
+    // null and a repeated flag as an array - both must fail, not fall back.
+    if ('api-key' in options && typeof options['api-key'] !== 'string') {
+      throw new CommandError('--api-key must be a single key string. Usage: nansen mcp verify --api-key <key>', 'INVALID_PARAMS');
+    }
+    // Same guards for --url: a valueless flag or a repeated/JSON-parsed value
+    // must fail loudly, not flow an array into fetch or silently fall back.
+    if (flags.url) {
+      throw new CommandError('--url requires a value. Usage: nansen mcp verify --url <url>', 'MISSING_PARAM');
+    }
+    if ('url' in options && typeof options.url !== 'string') {
+      throw new CommandError('--url must be a single URL string. Usage: nansen mcp verify --url <url>', 'INVALID_PARAMS');
+    }
+
+    const url = options.url || DEFAULT_MCP_URL;
+    const checks = await runMcpVerifyChecks({
+      apiKey: options['api-key'],
+      url,
+      env,
+      fetchFn,
+      devConfigPath,
+    });
+    const verified = checks.some(checkItem => checkItem.id === 'mcp-auth' && checkItem.status === 'ok');
+    const result = {
+      verified,
+      url,
+      checks,
+      errors: checks.filter(checkItem => checkItem.status === 'error').length,
+      warnings: checks.filter(checkItem => checkItem.status === 'warn').length,
+    };
+
+    if (verified) {
+      if (flags.json) return result;
+      log(formatMcpVerifyReport(checks, url, true));
+      return undefined;
+    }
+
+    const reason = (checks.find(checkItem => checkItem.status === 'error')
+      || checks.find(checkItem => checkItem.id === 'mcp-auth' && checkItem.status !== 'ok'))?.message
+      || 'the paid data path did not complete';
+    const message = `MCP setup verification failed - ${reason}`;
+    if (flags.json) throw new CommandError(message, 'MCP_VERIFY_FAILED', result);
+    log(formatMcpVerifyReport(checks, url, false));
+    // The human report above is the complete failure output; mark the error
+    // so runCLI exits non-zero without also emitting the JSON envelope.
+    const reportedError = new CommandError(message, 'MCP_VERIFY_FAILED');
+    reportedError.reported = true;
+    throw reportedError;
+  };
+
   return {
-    'mcp': async (args, apiInstance, flags, _options) => {
+    'mcp': async (args, apiInstance, flags, options) => {
       const sub = args[0];
       const client = args[1];
 
       if (!sub || flags.help || flags.h) {
         log(MCP_USAGE);
         return undefined;
+      }
+
+      if (sub === 'verify') {
+        return verify(flags, options);
       }
 
       if (sub !== 'install' && sub !== 'uninstall') {

--- a/src/schema.json
+++ b/src/schema.json
@@ -1894,34 +1894,6 @@
         "nansen doctor --json --pretty"
       ]
     },
-    "mcp": {
-      "description": "Verify the hosted Nansen MCP server setup with an authenticated paid data call (~1 credit). The unauthenticated tools/list response alone cannot validate an API key.",
-      "subcommands": {
-        "verify": {
-          "description": "Check MCP server reachability and verify an API key on the paid data path (~1 credit)",
-          "options": {
-            "api-key": {
-              "type": "string",
-              "description": "API key to test; overrides NANSEN_API_KEY and ~/.nansen/config.json"
-            },
-            "url": {
-              "type": "string",
-              "default": "https://mcp.nansen.ai/ra/mcp",
-              "description": "Hosted MCP server URL"
-            },
-            "json": {
-              "type": "boolean",
-              "description": "Return machine-readable verification checks and exit non-zero on failure"
-            }
-          },
-          "examples": [
-            "npx -y nansen-cli mcp verify --api-key <key>",
-            "nansen mcp verify --api-key <key> --json",
-            "nansen mcp verify --url https://mcp.example.dev/ra/mcp --api-key <key>"
-          ]
-        }
-      }
-    },
     "web": {
       "description": "Web search and fetch commands",
       "subcommands": {
@@ -1992,8 +1964,31 @@
       ]
     },
     "mcp": {
-      "description": "Install the hosted Nansen MCP server (https://mcp.nansen.ai/ra/mcp) into a local MCP client's config",
+      "description": "Install, uninstall, or verify the hosted Nansen MCP server (https://mcp.nansen.ai/ra/mcp)",
       "subcommands": {
+        "verify": {
+          "description": "Check MCP server reachability and verify an API key on the paid data path (~1 credit)",
+          "options": {
+            "api-key": {
+              "type": "string",
+              "description": "API key to test; overrides NANSEN_API_KEY and ~/.nansen/config.json"
+            },
+            "url": {
+              "type": "string",
+              "default": "https://mcp.nansen.ai/ra/mcp",
+              "description": "Hosted MCP server URL"
+            },
+            "json": {
+              "type": "boolean",
+              "description": "Return machine-readable verification checks and exit non-zero on failure"
+            }
+          },
+          "examples": [
+            "npx -y nansen-cli mcp verify --api-key <key>",
+            "nansen mcp verify --api-key <key> --json",
+            "nansen mcp verify --url https://mcp.example.dev/ra/mcp --api-key <key>"
+          ]
+        },
         "install": {
           "description": "Add the Nansen MCP server to a client's config. Client (positional): claude-code, claude-desktop, or cursor. Uses the API key from `nansen login` / NANSEN_API_KEY; re-run after key rotation to update the entry.",
           "options": {


### PR DESCRIPTION
## Summary
- merge `mcp verify` into the active MCP command handler so it is not overwritten by install/uninstall routing
- collapse duplicate `mcp` schema entries into one install/uninstall/verify command surface
- update MCP schema/help coverage and add a patch changeset

## Root cause
The last merged MCP changes left two top-level `mcp` handlers. `runCLI()` spreads `buildMcpCommands()` after `buildCommands()`, so the install/uninstall handler overwrote the verifier handler. `schema.json` also had duplicate top-level `mcp` keys, so JSON parsing kept only the last one and dropped `verify`.

## Test plan
- `npm run lint`
- `npm test`
