### PR TITLE
Harden the Hyperliquid bridge EVM deposit leg against tampered calldata

### DIFF
--- a/.changeset/harden-bridge-evm-deposit.md
+++ b/.changeset/harden-bridge-evm-deposit.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Harden the Hyperliquid bridge deposit leg: EVM approvals are now re-scoped to the requested amount (never unlimited) and the deposit target contract/method is pinned, so a tampered quote can't drain the wallet.

--- a/src/__tests__/bridge-evm-deposit-intent.test.js
+++ b/src/__tests__/bridge-evm-deposit-intent.test.js
@@ -171,6 +171,57 @@ describe('assertEvmBridgeStepIntent — cross-cutting', () => {
       expect(e.code).toBe('INVALID_INPUT');
     }
   });
+
+  it('refuses a deposit whose amount word is not valid hex, instead of throwing a raw SyntaxError', () => {
+    const badAmount = '0xe8017952' + word(SIGNER) + word(USDC) + 'zz'.repeat(32) + word('a');
+    const txData = { to: ROUTER, data: badAmount, value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/malformed deposit calldata/);
+    try {
+      assertEvmBridgeStepIntent(txData, intent);
+    } catch (e) {
+      expect(e.code).toBe('INVALID_INPUT');
+    }
+  });
+
+  it('refuses an approve whose amount word is not valid hex, instead of throwing a raw SyntaxError', () => {
+    const txData = { to: USDC, data: '0x095ea7b3' + word(ROUTER) + 'zz'.repeat(32), value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/malformed approve calldata/);
+    try {
+      assertEvmBridgeStepIntent(txData, intent);
+    } catch (e) {
+      expect(e.code).toBe('INVALID_INPUT');
+    }
+  });
+
+  it('refuses an unparseable native value, instead of throwing a raw SyntaxError', () => {
+    const txData = { to: ROUTER, data: depositCalldata(), value: '0x' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/malformed native value/);
+    try {
+      assertEvmBridgeStepIntent(txData, intent);
+    } catch (e) {
+      expect(e.code).toBe('INVALID_INPUT');
+    }
+  });
+
+  it('refuses a step addressed `from` a wallet other than the signer', () => {
+    const txData = { to: ROUTER, data: depositCalldata(), value: '0', from: ATTACKER };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/signing wallet is/);
+    try {
+      assertEvmBridgeStepIntent(txData, intent);
+    } catch (e) {
+      expect(e.code).toBe('SIGNER_MISMATCH');
+    }
+  });
+
+  it('accepts a step whose `from` matches the signer', () => {
+    const txData = { to: ROUTER, data: depositCalldata(), value: '0', from: SIGNER };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).not.toThrow();
+  });
+
+  it('accepts a step with no `from` at all (quotes may omit it)', () => {
+    const txData = { to: ROUTER, data: depositCalldata(), value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).not.toThrow();
+  });
 });
 
 describe('preflightEvmBridgeSteps — plan-level bound', () => {
@@ -196,7 +247,7 @@ describe('preflightEvmBridgeSteps — plan-level bound', () => {
     // but two deposits of `requested` each would pull 2x what the user reviewed —
     // ERC-20 approve overwrites the allowance, so the second pair drains again.
     const plan = [approveStep(), depositStep(), approveStep(), depositStep()];
-    expect(() => preflightEvmBridgeSteps(plan, intent)).toThrow(/at most one of each/);
+    expect(() => preflightEvmBridgeSteps(plan, intent)).toThrow(/at most one approve and exactly one deposit/);
     try {
       preflightEvmBridgeSteps(plan, intent);
     } catch (e) {
@@ -206,7 +257,7 @@ describe('preflightEvmBridgeSteps — plan-level bound', () => {
 
   it('refuses a plan with two deposits sharing one approve', () => {
     expect(() => preflightEvmBridgeSteps([approveStep(), depositStep(), depositStep()], intent))
-      .toThrow(/at most one of each/);
+      .toThrow(/at most one approve and exactly one deposit/);
   });
 
   it('refuses multiple approve/deposit items bundled in a single step', () => {
@@ -217,7 +268,7 @@ describe('preflightEvmBridgeSteps — plan-level bound', () => {
         { status: 'incomplete', data: { to: ROUTER, data: depositCalldata(), value: '0' } },
       ],
     };
-    expect(() => preflightEvmBridgeSteps([bundled], intent)).toThrow(/at most one of each/);
+    expect(() => preflightEvmBridgeSteps([bundled], intent)).toThrow(/at most one approve and exactly one deposit/);
   });
 
   it('does not count already-complete (resumed) items toward the bound', () => {
@@ -230,5 +281,38 @@ describe('preflightEvmBridgeSteps — plan-level bound', () => {
       depositStep(),
     ];
     expect(() => preflightEvmBridgeSteps(resumed, intent)).not.toThrow();
+  });
+
+  it('refuses an approve-only plan — no live allowance without a reviewed deposit', () => {
+    // A compromised API/Relay response that drops the deposit step entirely
+    // would otherwise pass preflight (0 > 1 is false) and get the approve
+    // signed and broadcast with nothing ever pulling from it.
+    expect(() => preflightEvmBridgeSteps([approveStep()], intent))
+      .toThrow(/at most one approve and exactly one deposit/);
+    try {
+      preflightEvmBridgeSteps([approveStep()], intent);
+    } catch (e) {
+      expect(e.code).toBe('UNEXPECTED_ACTION');
+    }
+  });
+
+  it('refuses a plan whose deposit step is addressed from a different wallet, before the approve step ever signs', () => {
+    // Regression: the from/signer check used to live only in processEvmStep,
+    // per-step, during the broadcast loop — so [valid approve, deposit with a
+    // tampered `from`] passed preflight, the approve broadcast for real, and
+    // only the deposit was later refused. The check now runs inside
+    // assertEvmBridgeStepIntent, which preflightEvmBridgeSteps calls on every
+    // step up front, so this whole plan is refused before anything signs.
+    const tamperedDeposit = {
+      id: 'deposit',
+      items: [{ status: 'incomplete', data: { to: ROUTER, data: depositCalldata(), value: '0', from: ATTACKER } }],
+    };
+    expect(() => preflightEvmBridgeSteps([approveStep(), tamperedDeposit], intent))
+      .toThrow(/signing wallet is/);
+    try {
+      preflightEvmBridgeSteps([approveStep(), tamperedDeposit], intent);
+    } catch (e) {
+      expect(e.code).toBe('SIGNER_MISMATCH');
+    }
   });
 });

--- a/src/__tests__/bridge-evm-deposit-intent.test.js
+++ b/src/__tests__/bridge-evm-deposit-intent.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+
+import { assertEvmBridgeStepIntent } from '../bridge.js';
+import { encodeApproveCalldata } from '../trade-validation.js';
+
+// Real captured shapes (base -> hyperliquid, USDC): the Relay router is both
+// the approve spender and the deposit `to`, and the deposit call decodes to a
+// fixed 4-arg layout (depositor, token, amount, id). See the deposit-leg
+// hardening plan for how these were captured (read-only quotes, no funds moved).
+
+const ROUTER = '0x4cd00e387622c35bddb9b4c962c136462338bc31';
+const USDC = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+const SIGNER = '0x8cb9c3f23c7d600fb430bbd171a313d9ea61cebc';
+const ATTACKER = '0x' + 'ee'.repeat(20);
+const MAX_UINT256 = (1n << 256n) - 1n;
+
+const word = h => h.toLowerCase().replace(/^0x/, '').padStart(64, '0');
+
+const depositCalldata = ({ depositor = SIGNER, token = USDC, amount = 2000000n, id = '0x'.padEnd(66, 'a') } = {}) =>
+  '0xe8017952' + word(depositor) + word(token) + word(amount.toString(16)) + word(id);
+
+const approveCalldata = (spender, amount) => '0x095ea7b3' + word(spender) + word(amount.toString(16));
+
+const intent = { chain: 'base', signerAddress: SIGNER, requestedAmountBaseUnits: '2000000' };
+
+describe('assertEvmBridgeStepIntent — approve leg', () => {
+  it('refuses an approve sent to a contract other than the origin chain USDC', () => {
+    // A spender==ROUTER and amount<=requested calldata that targets some other
+    // ERC-20 the wallet holds would otherwise look "safe" by AC1's spender/amount
+    // checks alone — the approve's own `to` must also be pinned.
+    const otherToken = '0x' + 'cd'.repeat(20);
+    const txData = { to: otherToken, data: approveCalldata(ROUTER, 2000000n), value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/unexpected contract/);
+    try {
+      assertEvmBridgeStepIntent(txData, intent);
+    } catch (e) {
+      expect(e.code).toBe('UNEXPECTED_ACTION');
+    }
+  });
+
+  it('refuses approve(attacker, MAX_UINT256)', () => {
+    const txData = { to: USDC, data: approveCalldata(ATTACKER, MAX_UINT256), value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/unexpected spender/);
+    try {
+      assertEvmBridgeStepIntent(txData, intent);
+    } catch (e) {
+      expect(e.code).toBe('UNEXPECTED_ACTION');
+    }
+  });
+
+  it('refuses approve(ROUTER, MAX_UINT256) — proves the MAX guard, not just the spender guard', () => {
+    const txData = { to: USDC, data: approveCalldata(ROUTER, MAX_UINT256), value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/unlimited/);
+  });
+
+  it('refuses an approve amount over the requested cap', () => {
+    const txData = { to: USDC, data: approveCalldata(ROUTER, 2000001n), value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/exceeds the request's maximum input/);
+  });
+
+  it('re-encodes a valid approve at exactly the requested cap', () => {
+    const txData = { to: USDC, data: approveCalldata(ROUTER, 2000000n), value: '0' };
+    const { data } = assertEvmBridgeStepIntent(txData, intent);
+    expect(data).toBe(encodeApproveCalldata(ROUTER, 2000000n, { maxAllowance: 2000000n }));
+    expect(data.length).toBe(138);
+  });
+
+  it('refuses when no reviewed amount was recorded to cap against', () => {
+    const txData = { to: USDC, data: approveCalldata(ROUTER, 2000000n), value: '0' };
+    const noAnchor = { ...intent, requestedAmountBaseUnits: null };
+    expect(() => assertEvmBridgeStepIntent(txData, noAnchor)).toThrow(/AMOUNT_MISMATCH|no reviewed amount/);
+    try {
+      assertEvmBridgeStepIntent(txData, noAnchor);
+    } catch (e) {
+      expect(e.code).toBe('AMOUNT_MISMATCH');
+    }
+  });
+});
+
+describe('assertEvmBridgeStepIntent — deposit leg', () => {
+  it('refuses a deposit sent to an unexpected `to`', () => {
+    const txData = { to: ATTACKER, data: depositCalldata(), value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/unexpected contract/);
+    try {
+      assertEvmBridgeStepIntent(txData, intent);
+    } catch (e) {
+      expect(e.code).toBe('UNEXPECTED_ACTION');
+    }
+  });
+
+  it('refuses the real `to` with an unexpected selector', () => {
+    const txData = { to: ROUTER, data: '0xdeadbeef' + word(SIGNER), value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/unexpected method/);
+  });
+
+  it('accepts a valid deposit unchanged', () => {
+    const txData = { to: ROUTER, data: depositCalldata(), value: '0' };
+    const { data } = assertEvmBridgeStepIntent(txData, intent);
+    expect(data).toBe(txData.data);
+  });
+
+  it('refuses when arg0 (depositor) is redirected away from the signer', () => {
+    const txData = { to: ROUTER, data: depositCalldata({ depositor: ATTACKER }), value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/SIGNER_MISMATCH|signing wallet/);
+    try {
+      assertEvmBridgeStepIntent(txData, intent);
+    } catch (e) {
+      expect(e.code).toBe('SIGNER_MISMATCH');
+    }
+  });
+
+  it('refuses when arg1 (token) is not the origin chain USDC', () => {
+    const otherToken = '0x' + 'ab'.repeat(20);
+    const txData = { to: ROUTER, data: depositCalldata({ token: otherToken }), value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/unexpected token/);
+  });
+
+  it('refuses when arg2 (amount) exceeds what was requested', () => {
+    const txData = { to: ROUTER, data: depositCalldata({ amount: 2000001n }), value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/more than the 2000000 base units/);
+    try {
+      assertEvmBridgeStepIntent(txData, intent);
+    } catch (e) {
+      expect(e.code).toBe('AMOUNT_MISMATCH');
+    }
+  });
+
+  it('accepts arg2 exactly at the requested amount', () => {
+    const txData = { to: ROUTER, data: depositCalldata({ amount: 2000000n }), value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).not.toThrow();
+  });
+
+  it('refuses when no reviewed amount was recorded to check the deposit against', () => {
+    const txData = { to: ROUTER, data: depositCalldata(), value: '0' };
+    const noAnchor = { ...intent, requestedAmountBaseUnits: null };
+    expect(() => assertEvmBridgeStepIntent(txData, noAnchor)).toThrow(/AMOUNT_MISMATCH|no reviewed amount/);
+  });
+});
+
+describe('assertEvmBridgeStepIntent — cross-cutting', () => {
+  it('refuses a non-zero native value on an approve step', () => {
+    const txData = { to: USDC, data: approveCalldata(ROUTER, 2000000n), value: '0x1' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/non-zero native value/);
+    try {
+      assertEvmBridgeStepIntent(txData, intent);
+    } catch (e) {
+      expect(e.code).toBe('UNEXPECTED_ACTION');
+    }
+  });
+
+  it('refuses a non-zero native value on a deposit step', () => {
+    const txData = { to: ROUTER, data: depositCalldata(), value: '0x1' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/non-zero native value/);
+  });
+
+  it('refuses missing transaction data', () => {
+    expect(() => assertEvmBridgeStepIntent({ to: ROUTER }, intent)).toThrow(/no transaction data/);
+    try {
+      assertEvmBridgeStepIntent({ to: ROUTER }, intent);
+    } catch (e) {
+      expect(e.code).toBe('INVALID_INPUT');
+    }
+  });
+
+  it('refuses a deposit-selector call with malformed (wrong-length) calldata', () => {
+    const txData = { to: ROUTER, data: '0xe8017952' + word(SIGNER), value: '0' };
+    expect(() => assertEvmBridgeStepIntent(txData, intent)).toThrow(/malformed deposit calldata/);
+    try {
+      assertEvmBridgeStepIntent(txData, intent);
+    } catch (e) {
+      expect(e.code).toBe('INVALID_INPUT');
+    }
+  });
+});

--- a/src/__tests__/bridge-evm-deposit-intent.test.js
+++ b/src/__tests__/bridge-evm-deposit-intent.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { assertEvmBridgeStepIntent } from '../bridge.js';
+import { assertEvmBridgeStepIntent, preflightEvmBridgeSteps } from '../bridge.js';
 import { encodeApproveCalldata } from '../trade-validation.js';
 
 // Real captured shapes (base -> hyperliquid, USDC): the Relay router is both
@@ -170,5 +170,65 @@ describe('assertEvmBridgeStepIntent — cross-cutting', () => {
     } catch (e) {
       expect(e.code).toBe('INVALID_INPUT');
     }
+  });
+});
+
+describe('preflightEvmBridgeSteps — plan-level bound', () => {
+  const approveStep = () => ({
+    id: 'approve',
+    items: [{ status: 'incomplete', data: { to: USDC, data: approveCalldata(ROUTER, 2000000n), value: '0' } }],
+  });
+  const depositStep = () => ({
+    id: 'deposit',
+    items: [{ status: 'incomplete', data: { to: ROUTER, data: depositCalldata(), value: '0' } }],
+  });
+
+  it('accepts the legitimate [approve, deposit] plan', () => {
+    expect(() => preflightEvmBridgeSteps([approveStep(), depositStep()], intent)).not.toThrow();
+  });
+
+  it('accepts a deposit-only plan (no approve needed)', () => {
+    expect(() => preflightEvmBridgeSteps([depositStep()], intent)).not.toThrow();
+  });
+
+  it('refuses a plan that repeats [approve, deposit] to amplify past the cap', () => {
+    // Every item passes per-item binding (spender/router/token/amount all valid),
+    // but two deposits of `requested` each would pull 2x what the user reviewed —
+    // ERC-20 approve overwrites the allowance, so the second pair drains again.
+    const plan = [approveStep(), depositStep(), approveStep(), depositStep()];
+    expect(() => preflightEvmBridgeSteps(plan, intent)).toThrow(/at most one of each/);
+    try {
+      preflightEvmBridgeSteps(plan, intent);
+    } catch (e) {
+      expect(e.code).toBe('UNEXPECTED_ACTION');
+    }
+  });
+
+  it('refuses a plan with two deposits sharing one approve', () => {
+    expect(() => preflightEvmBridgeSteps([approveStep(), depositStep(), depositStep()], intent))
+      .toThrow(/at most one of each/);
+  });
+
+  it('refuses multiple approve/deposit items bundled in a single step', () => {
+    const bundled = {
+      id: 'bundle',
+      items: [
+        { status: 'incomplete', data: { to: ROUTER, data: depositCalldata(), value: '0' } },
+        { status: 'incomplete', data: { to: ROUTER, data: depositCalldata(), value: '0' } },
+      ],
+    };
+    expect(() => preflightEvmBridgeSteps([bundled], intent)).toThrow(/at most one of each/);
+  });
+
+  it('does not count already-complete (resumed) items toward the bound', () => {
+    // A resumed plan may carry a completed approve/deposit plus the remaining
+    // leg; the completed ones are skipped for signing, so they must not trip the
+    // amplification guard.
+    const resumed = [
+      { id: 'approve', items: [{ status: 'complete', data: { to: USDC, data: approveCalldata(ROUTER, 2000000n), value: '0' } }] },
+      { id: 'approve2', items: [{ status: 'incomplete', data: { to: USDC, data: approveCalldata(ROUTER, 2000000n), value: '0' } }] },
+      depositStep(),
+    ];
+    expect(() => preflightEvmBridgeSteps(resumed, intent)).not.toThrow();
   });
 });

--- a/src/__tests__/bridge-fee-overrides.test.js
+++ b/src/__tests__/bridge-fee-overrides.test.js
@@ -35,6 +35,18 @@ import { buildBridgeCommands, parseGweiToWei, resolveEvmStepFees } from '../brid
 
 const ADDR = '0x' + 'ab'.repeat(20);
 
+// Real Base -> Hyperliquid deposit router/selector (see the deposit-leg
+// hardening plan) — the new preflight rejects anything else, so fixtures for
+// the fee-override plumbing still need well-formed deposit calldata.
+const ROUTER = '0x4cd00e387622c35bddb9b4c962c136462338bc31';
+const USDC = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+const REQUESTED_AMOUNT = 2000000n;
+const word = h => h.toLowerCase().replace(/^0x/, '').padStart(64, '0');
+const depositCalldata = (depositor, amount = REQUESTED_AMOUNT) =>
+  '0xe8017952' + word(depositor) + word(USDC) + word(amount.toString(16)) + word('0x'.padEnd(66, 'a'));
+const approveCalldata = (spender, amount = REQUESTED_AMOUNT) =>
+  '0x095ea7b3' + word(spender) + word(amount.toString(16));
+
 describe('parseGweiToWei', () => {
   it('converts whole gwei', () => {
     expect(parseGweiToWei('1', 'priority-fee')).toBe(1000000000n);
@@ -118,6 +130,7 @@ describe('bridge execute overrides', () => {
       destinationChain: 'hyperliquid',
       walletProvider: 'local',
       walletAddress: ADDR,
+      requestedAmountBaseUnits: REQUESTED_AMOUNT.toString(),
       timestamp: Date.now(),
       response: {
         execution_type: 'evm_transaction',
@@ -126,7 +139,10 @@ describe('bridge execute overrides', () => {
           {
             id: 'deposit',
             kind: 'transaction',
-            items: [{ status: 'incomplete', data: { from: ADDR, to: ADDR, data: '0x', maxFeePerGas: '1000000' } }],
+            items: [{
+              status: 'incomplete',
+              data: { from: ADDR, to: ROUTER, data: depositCalldata(ADDR), value: '0', maxFeePerGas: '1000000' },
+            }],
           },
         ],
       },
@@ -191,7 +207,13 @@ describe('bridge execute overrides', () => {
           {
             id: 'deposit',
             kind: 'transaction',
-            items: [{ status: 'incomplete', data: { from: OTHER, to: ADDR, data: '0x', maxFeePerGas: '1000000' } }],
+            items: [{
+              status: 'incomplete',
+              // depositor (arg0) still binds to the signer ADDR — only `from`
+              // is wrong here, isolating the from-check from the intent-binding
+              // preflight (which would otherwise also refuse this fixture).
+              data: { from: OTHER, to: ROUTER, data: depositCalldata(ADDR), value: '0', maxFeePerGas: '1000000' },
+            }],
           },
         ],
       },
@@ -216,7 +238,10 @@ describe('bridge execute overrides', () => {
           {
             id: 'deposit',
             kind: 'transaction',
-            items: [{ status: 'incomplete', data: { to: ADDR, data: '0x', maxFeePerGas: '1000000' } }],
+            items: [{
+              status: 'incomplete',
+              data: { to: ROUTER, data: depositCalldata(ADDR), value: '0', maxFeePerGas: '1000000' },
+            }],
           },
         ],
       },
@@ -286,12 +311,18 @@ describe('bridge execute overrides', () => {
           {
             id: 'approve',
             kind: 'transaction',
-            items: [{ status: 'incomplete', data: { from: ADDR, to: ADDR, data: '0x', maxFeePerGas: '1000000' } }],
+            items: [{
+              status: 'incomplete',
+              data: { from: ADDR, to: USDC, data: approveCalldata(ROUTER), value: '0', maxFeePerGas: '1000000' },
+            }],
           },
           {
             id: 'deposit',
             kind: 'transaction',
-            items: [{ status: 'incomplete', data: { from: ADDR, to: ADDR, data: '0x', maxFeePerGas: '1000000' } }],
+            items: [{
+              status: 'incomplete',
+              data: { from: ADDR, to: ROUTER, data: depositCalldata(ADDR), value: '0', maxFeePerGas: '1000000' },
+            }],
           },
         ],
       },

--- a/src/__tests__/bridge-wallet-hardening.test.js
+++ b/src/__tests__/bridge-wallet-hardening.test.js
@@ -28,9 +28,37 @@ import { buildBridgeCommands } from '../bridge.js';
 
 const ADDR = '0x' + 'ab'.repeat(20);
 
+// Real captured Base -> HL deposit-router shape (see bridge-evm-deposit-intent
+// tests for the full decode). Used below to build a plan that actually passes
+// preflightEvmBridgeSteps, rather than an empty `steps: []` stand-in.
+const DEPOSIT_ROUTER = '0x4cd00e387622c35bddb9b4c962c136462338bc31';
+const BASE_USDC = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+const word = h => h.toLowerCase().replace(/^0x/, '').padStart(64, '0');
+const depositCalldata = (depositor, token, amount) =>
+  '0xe8017952' + word(depositor) + word(token) + word(amount.toString(16)) + word('a');
+
+// evmRpcCall goes through global fetch (see evm-nonce.test.js), so a test that
+// actually reaches processEvmStep needs a minimal fake chain behind it.
+function mockChainRpc() {
+  return vi.fn(async (url, init) => {
+    const body = JSON.parse(init.body);
+    let result;
+    switch (body.method) {
+      case 'eth_getTransactionCount': result = '0x0'; break;
+      case 'eth_gasPrice': result = '0x3b9aca00'; break;
+      case 'eth_sendRawTransaction': result = '0x' + 'ab'.repeat(32); break;
+      case 'eth_getTransactionReceipt': result = { status: '0x1', blockNumber: '0x1' }; break;
+      default: throw new Error(`unexpected RPC method ${body.method}`);
+    }
+    const payload = JSON.stringify({ jsonrpc: '2.0', id: body.id, result });
+    return { ok: true, status: 200, text: async () => payload };
+  });
+}
+
 let tmpHome;
 let prevHome;
 let quotesDir;
+let prevFetch;
 
 function writeQuote(quoteId, overrides = {}) {
   const data = {
@@ -69,11 +97,13 @@ beforeEach(() => {
   getWalletConfig.mockReturnValue({});
   retrievePassword.mockReturnValue({ password: null, source: null });
   cleanApi.request.mockImplementation(respond);
+  prevFetch = globalThis.fetch;
 });
 
 afterEach(() => {
   process.env.HOME = prevHome;
   fs.rmSync(tmpHome, { recursive: true, force: true });
+  globalThis.fetch = prevFetch;
 });
 
 describe('bridge execute wallet hardening', () => {
@@ -144,10 +174,21 @@ describe('bridge execute wallet hardening', () => {
     exportWallet.mockReturnValue({ evm: { privateKey: '11'.repeat(32) } });
     cleanApi.request.mockImplementation(async endpoint => {
       if (String(endpoint).includes('/bridge/quote')) {
-        return { execution_type: 'evm_transaction', steps: [], request_id: 'r1' };
+        return {
+          execution_type: 'evm_transaction',
+          steps: [{
+            id: 'deposit',
+            items: [{
+              status: 'incomplete',
+              data: { to: DEPOSIT_ROUTER, data: depositCalldata(ADDR, BASE_USDC, 5000000n), value: '0' },
+            }],
+          }],
+          request_id: 'r1',
+        };
       }
       return respond(endpoint);
     });
+    globalThis.fetch = mockChainRpc();
 
     await cmds.quote([], cleanApi, {}, {
       'from-chain': 'base',

--- a/src/__tests__/bridge-withdraw-no-evm-signing.test.js
+++ b/src/__tests__/bridge-withdraw-no-evm-signing.test.js
@@ -192,6 +192,13 @@ describe('hyperliquid withdrawals never sign an EVM transaction', () => {
   // the spy were never wired to the module at all.
   it('does reach EVM signing on a deposit, proving the spy is wired', async () => {
     const quoteId = 'bridge-deposit-control';
+    // Real Base -> Hyperliquid deposit router/selector, wrapped in a well-formed
+    // deposit() call bound to WALLET, so the intent-binding preflight passes and
+    // signEvmTransaction is actually reached (which is the thing under test here).
+    const ROUTER = '0x4cd00e387622c35bddb9b4c962c136462338bc31';
+    const USDC = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+    const word = h => h.toLowerCase().replace(/^0x/, '').padStart(64, '0');
+    const depositCalldata = '0xe8017952' + word(WALLET) + word(USDC) + word((5000000n).toString(16)) + word('0x'.padEnd(66, 'a'));
     fs.writeFileSync(
       path.join(quotesDir, `${quoteId}.json`),
       JSON.stringify({
@@ -201,6 +208,7 @@ describe('hyperliquid withdrawals never sign an EVM transaction', () => {
         destinationChain: 'hyperliquid',
         walletProvider: 'local',
         walletAddress: WALLET,
+        requestedAmountBaseUnits: '5000000',
         timestamp: Date.now(),
         response: {
           execution_type: 'evm_transaction',
@@ -209,7 +217,7 @@ describe('hyperliquid withdrawals never sign an EVM transaction', () => {
             {
               id: 'deposit',
               kind: 'transaction',
-              items: [{ data: { from: WALLET, to: WALLET, data: '0x', value: '0', gas: '21000' } }],
+              items: [{ data: { from: WALLET, to: ROUTER, data: depositCalldata, value: '0', gas: '21000' } }],
             },
           ],
         },

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -884,12 +884,33 @@ export function assertEvmBridgeStepIntent(txData, intent, context = 'Bridge EVM 
 // Validate every EVM step's calldata against intent BEFORE any step is signed
 // or broadcast. Without this, a good approve step would already be on-chain by
 // the time a poisoned deposit step is reached and refused.
-function preflightEvmBridgeSteps(steps, intent) {
+//
+// Also bounds the PLAN, not just each item: a legitimate Base → HL deposit is
+// [approve?, deposit] — at most one approve and one deposit. The per-item amount
+// cap alone does not stop a tampered response from chaining repeated
+// [approve(requested), deposit(requested)] pairs — each pair passes every check,
+// but ERC-20 approve OVERWRITES the allowance, so N pairs pull N × the reviewed
+// amount and drain the whole balance despite the scoped approval. Refusing more
+// than one of either, up front, keeps the loss bounded to the requested amount.
+export function preflightEvmBridgeSteps(steps, intent) {
+  let approveCount = 0;
+  let depositCount = 0;
   for (const step of steps) {
     for (const item of step.items || []) {
-      if (item.status === 'complete') continue;   // don't re-check resumed steps
+      if (item.status === 'complete') continue;   // don't re-check / re-count resumed steps
       assertEvmBridgeStepIntent(item.data, intent, `Bridge step "${step.id}"`);
+      // assertEvmBridgeStepIntent above already proved each item is exactly one
+      // of these two shapes, so this classification is total.
+      if (isErc20Approve(item.data.data)) approveCount++;
+      else depositCount++;
     }
+  }
+  if (approveCount > 1 || depositCount > 1) {
+    throw new CommandError(
+      `Bridge plan has ${approveCount} approve and ${depositCount} deposit transaction(s); a legitimate deposit is at most one of each. `
+        + `Refusing to sign — repeated legs could move more than the amount you requested. Request a new quote.`,
+      'UNEXPECTED_ACTION',
+    );
   }
 }
 

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -720,11 +720,17 @@ function isErc20Approve(data) {
 }
 
 // Decode approve(spender, amount) from validated calldata. Only call after
-// isErc20Approve() is true.
+// isErc20Approve() is true. Returns null if the amount word isn't valid hex —
+// length/selector alone don't guarantee that, and BigInt throws a raw
+// SyntaxError rather than failing closed with an actionable message.
 function decodeErc20Approve(data) {
   const spender = '0x' + data.slice(34, 74);          // last 20 bytes of word 1
-  const amount = BigInt('0x' + data.slice(74, 138));  // word 2
-  return { spender, amount };
+  try {
+    const amount = BigInt('0x' + data.slice(74, 138));  // word 2
+    return { spender, amount };
+  } catch {
+    return null;
+  }
 }
 
 function selectorOf(data) {
@@ -738,10 +744,19 @@ function selectorOf(data) {
 function decodeBridgeDeposit(data) {
   if (typeof data !== 'string' || data.length !== 266) return null;
   const w = i => data.slice(10 + i * 64, 10 + (i + 1) * 64);
+  let amount;
+  try {
+    amount = BigInt('0x' + w(2));
+  } catch {
+    // Right length and selector, but the amount word isn't valid hex — off-shape,
+    // same as a length mismatch. Fail closed via the caller's null check rather
+    // than a raw SyntaxError.
+    return null;
+  }
   return {
     depositor: '0x' + w(0).slice(24),   // last 20 bytes of word 0
     token: '0x' + w(1).slice(24),
-    amount: BigInt('0x' + w(2)),
+    amount,
     // w(3) is the opaque relay id — intentionally not returned / not bound.
   };
 }
@@ -778,17 +793,49 @@ export function assertEvmBridgeStepIntent(txData, intent, context = 'Bridge EVM 
   if (!txData || typeof txData !== 'object' || typeof txData.data !== 'string') {
     throw new CommandError(`${context}: no transaction data to verify. Request a new quote.`, 'INVALID_INPUT');
   }
+
+  // The nonce/signing key are the local wallet's regardless of what `from` the
+  // server sent, so a mismatched `from` would price this step against the wrong
+  // account while still signing it as ours. Checked here — not just per-step at
+  // broadcast time — so preflightEvmBridgeSteps catches it on EVERY step before
+  // any of them sign or broadcast; otherwise an earlier legitimate step in the
+  // same plan (e.g. the approve) could already be on-chain by the time a later
+  // step's `from` mismatch is caught.
+  if (
+    intent.signerAddress
+    && txData.from
+    && String(txData.from).toLowerCase() !== String(intent.signerAddress).toLowerCase()
+  ) {
+    throw new CommandError(
+      `${context} is addressed from ${txData.from}, but the signing wallet is ${intent.signerAddress}. `
+        + `Refusing to sign. Request a new quote.`,
+      'SIGNER_MISMATCH',
+    );
+  }
+
   const to = String(txData.to || '').toLowerCase();
 
   // A deposit carries no native value (confirmed value === 0 on every capture).
   // A non-zero value on either leg is an ETH-drain vector — refuse it. (BigInt
-  // parses both '0' and '0x0'.)
-  if (txData.value != null && BigInt(txData.value) !== 0n) {
-    throw new CommandError(
-      `${context} carries a non-zero native value ${txData.value}; this bridge path never sends native ETH. `
-        + `Refusing to sign. Request a new quote.`,
-      'UNEXPECTED_ACTION',
-    );
+  // parses both '0' and '0x0'.) A value that isn't parseable at all is just as
+  // much a reason to refuse as a non-zero one.
+  if (txData.value != null) {
+    let value;
+    try {
+      value = BigInt(txData.value);
+    } catch {
+      throw new CommandError(
+        `${context} has a malformed native value ${txData.value}. Refusing to sign. Request a new quote.`,
+        'INVALID_INPUT',
+      );
+    }
+    if (value !== 0n) {
+      throw new CommandError(
+        `${context} carries a non-zero native value ${txData.value}; this bridge path never sends native ETH. `
+          + `Refusing to sign. Request a new quote.`,
+        'UNEXPECTED_ACTION',
+      );
+    }
   }
 
   // AC1: ERC-20 approve → re-scope through the hardened encoder.
@@ -804,7 +851,14 @@ export function assertEvmBridgeStepIntent(txData, intent, context = 'Bridge EVM 
         'UNEXPECTED_ACTION',
       );
     }
-    const { spender, amount } = decodeErc20Approve(txData.data);
+    const decoded = decodeErc20Approve(txData.data);
+    if (!decoded) {
+      throw new CommandError(
+        `${context} has a malformed approve calldata. Refusing to sign. Request a new quote.`,
+        'INVALID_INPUT',
+      );
+    }
+    const { spender, amount } = decoded;
     // The approve target you grant an allowance to must be the known deposit
     // router for this route — otherwise you are approving an attacker.
     if (!BRIDGE_DEPOSIT_TARGETS[intent.chain]?.has(spender.toLowerCase())) {
@@ -886,12 +940,19 @@ export function assertEvmBridgeStepIntent(txData, intent, context = 'Bridge EVM 
 // the time a poisoned deposit step is reached and refused.
 //
 // Also bounds the PLAN, not just each item: a legitimate Base → HL deposit is
-// [approve?, deposit] — at most one approve and one deposit. The per-item amount
-// cap alone does not stop a tampered response from chaining repeated
-// [approve(requested), deposit(requested)] pairs — each pair passes every check,
-// but ERC-20 approve OVERWRITES the allowance, so N pairs pull N × the reviewed
-// amount and drain the whole balance despite the scoped approval. Refusing more
-// than one of either, up front, keeps the loss bounded to the requested amount.
+// [approve?, deposit] — at most one approve, and EXACTLY one deposit. The
+// per-item amount cap alone does not stop two kinds of tampered plan:
+//   - repeated [approve(requested), deposit(requested)] pairs — each pair
+//     passes every per-item check, but ERC-20 approve OVERWRITES the
+//     allowance, so N pairs pull N × the reviewed amount and drain the whole
+//     balance despite the scoped approval;
+//   - an approve with NO deposit at all — the CLI would sign and broadcast a
+//     live router allowance with no reviewed transaction ever pulling it, and
+//     the compromised API/Relay this defends against should not be able to
+//     make the CLI emit a standalone approval.
+// Requiring exactly one deposit (approve optional, at most one) keeps the loss
+// bounded to the requested amount and rules out an allowance with nothing
+// behind it.
 export function preflightEvmBridgeSteps(steps, intent) {
   let approveCount = 0;
   let depositCount = 0;
@@ -905,10 +966,10 @@ export function preflightEvmBridgeSteps(steps, intent) {
       else depositCount++;
     }
   }
-  if (approveCount > 1 || depositCount > 1) {
+  if (approveCount > 1 || depositCount !== 1) {
     throw new CommandError(
-      `Bridge plan has ${approveCount} approve and ${depositCount} deposit transaction(s); a legitimate deposit is at most one of each. `
-        + `Refusing to sign — repeated legs could move more than the amount you requested. Request a new quote.`,
+      `Bridge plan has ${approveCount} approve and ${depositCount} deposit transaction(s); a legitimate deposit is at most one approve and exactly one deposit. `
+        + `Refusing to sign — an approve with no deposit would leave a live allowance behind with nothing pulling it, and repeated legs could move more than the amount you requested. Request a new quote.`,
       'UNEXPECTED_ACTION',
     );
   }
@@ -1017,23 +1078,14 @@ async function processEvmStep(step, { chain, privateKeyHex, signerAddress, log, 
     if (item.status === 'complete') continue;
     const txData = item.data;
 
-    // The nonce is fetched for txData.from, but the transaction is signed with
-    // our key — so a server-returned `from` that isn't our wallet would price
-    // the nonce against the wrong account and sign anyway. Assert it matches the
-    // signer before touching the nonce.
-    if (
-      signerAddress
-      && txData.from
-      && String(txData.from).toLowerCase() !== String(signerAddress).toLowerCase()
-    ) {
-      throw new CommandError(
-        `Bridge step "${step.id}" is addressed from ${txData.from}, but the signing wallet is ${signerAddress}. Request a new quote.`,
-        'SIGNER_MISMATCH',
-      );
-    }
-
     // Bind the server-supplied calldata to intent before signing: re-scope
-    // approvals through the hardened encoder, and pin the deposit to/selector.
+    // approvals through the hardened encoder, pin the deposit to/selector, and
+    // check `from` against the signer (the nonce is fetched for the signer, but
+    // the transaction is signed with our key regardless of `from`, so a
+    // mismatch would price the nonce against the wrong account and sign
+    // anyway). preflightEvmBridgeSteps already ran this same check on every
+    // step up front; this call is what makes it a fail-closed invariant rather
+    // than trusting the preflight pass.
     const bound = assertEvmBridgeStepIntent(txData, intent, `Bridge step "${step.id}"`);
 
     const fees = await resolveEvmStepFees(chain, txData, feeOverrides);

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -24,6 +24,7 @@ import {
 } from './trading.js';
 import { screenOrThrow } from './perp.js';
 import { extractActionErrors } from './hl-client.js';
+import { encodeApproveCalldata } from './trade-validation.js';
 import { resolveEvmWallet, resolveSigningCredentials } from './wallet-signing.js';
 import { hashTypedData } from './x402-evm.js';
 
@@ -685,6 +686,213 @@ function preflightHlBridgeSteps(steps, intent) {
 
 // ── Step processors ──────────────────────────────────────────────────
 
+// ── EVM deposit-leg intent binding (Base → Hyperliquid) ──────────────
+//
+// The bridge EVM deposit path signs server-supplied transactions. Pin the
+// only shape this path is designed to produce so a tampered response cannot
+// swap in an arbitrary drain call or an unbounded approval.
+//
+// Captured from real read-only `bridge quote` responses (base → hyperliquid,
+// USDC, 2026-08-31), confirmed stable across three quotes (amounts 2/3/2 USDC,
+// one with a distinct --recipient). base → hyperliquid is the ONLY supported
+// deposit route (BRIDGE_ROUTES), so this allowlist is complete. Re-capture and
+// update if Relay changes its deposit contract.
+const ERC20_APPROVE_SELECTOR = '0x095ea7b3';
+
+// Relay deposit router for the Base → HL route. It is BOTH the approve spender
+// and the deposit call target (confirmed identical across every capture), so
+// one constant covers both. Lower-cased for comparison.
+const BRIDGE_DEPOSIT_TARGETS = {
+  base: new Set(['0x4cd00e387622c35bddb9b4c962c136462338bc31']),
+};
+
+// The deposit call selector on that router. Its calldata is a fixed 4-arg ABI
+// layout: deposit(address depositor, address token, uint256 amount, bytes32 id).
+const BRIDGE_DEPOSIT_SELECTOR = '0xe8017952';
+
+// True when calldata is an ERC-20 approve(spender, amount). 0x + 4-byte
+// selector + two 32-byte words = 138 hex chars; anything else is not a
+// well-formed approve and must not be treated as one.
+function isErc20Approve(data) {
+  return typeof data === 'string'
+    && data.length === 138
+    && data.slice(0, 10).toLowerCase() === ERC20_APPROVE_SELECTOR;
+}
+
+// Decode approve(spender, amount) from validated calldata. Only call after
+// isErc20Approve() is true.
+function decodeErc20Approve(data) {
+  const spender = '0x' + data.slice(34, 74);          // last 20 bytes of word 1
+  const amount = BigInt('0x' + data.slice(74, 138));  // word 2
+  return { spender, amount };
+}
+
+function selectorOf(data) {
+  return typeof data === 'string' ? data.slice(0, 10).toLowerCase() : '';
+}
+
+// Decode the Relay deposit call's fixed 4-arg layout:
+//   deposit(address depositor, address token, uint256 amount, bytes32 id)
+// 0x + selector(8) + 4 words(4 * 64) = 266 hex chars. Only call after the
+// selector matched BRIDGE_DEPOSIT_SELECTOR; a wrong length is itself a refusal.
+function decodeBridgeDeposit(data) {
+  if (typeof data !== 'string' || data.length !== 266) return null;
+  const w = i => data.slice(10 + i * 64, 10 + (i + 1) * 64);
+  return {
+    depositor: '0x' + w(0).slice(24),   // last 20 bytes of word 0
+    token: '0x' + w(1).slice(24),
+    amount: BigInt('0x' + w(2)),
+    // w(3) is the opaque relay id — intentionally not returned / not bound.
+  };
+}
+
+// Bind a server-supplied EVM bridge transaction to the user's intent before
+// signing. Static only, no RPC. Fails CLOSED — a missing anchor or an
+// unrecognized target is itself the signal to refuse.
+//
+// intent.chain                     — origin chain ('base')
+// intent.signerAddress             — the wallet that will sign (arg0 must match)
+// intent.requestedAmountBaseUnits  — the amount the CLIENT persisted at quote
+//                                    time from the user's own --amount (USDC on
+//                                    Base is 6 decimals). The approval cap AND
+//                                    the deposit-amount cap.
+//
+// Both the approve and deposit branches cap against the same client-persisted
+// anchor and refuse identically when it's missing; shared so the two copies
+// can't drift (a prior version of each had its own wording).
+function requireAmountAnchor(intent, context) {
+  if (intent.requestedAmountBaseUnits == null) {
+    throw new CommandError(
+      `${context}: no reviewed amount recorded to check the transaction against `
+        + `(this quote may predate a nansen-cli update). Refusing to sign. Request a new quote.`,
+      'AMOUNT_MISMATCH',
+    );
+  }
+}
+
+// Returns { data } — for an approve step, `data` is RE-ENCODED via
+// encodeApproveCalldata (rejects MAX_UINT256, caps to requestedAmountBaseUnits,
+// re-validates the spender width). For a deposit step, `data` is returned
+// unchanged after the to/selector allowlist AND the decoded-arg binding pass.
+export function assertEvmBridgeStepIntent(txData, intent, context = 'Bridge EVM step') {
+  if (!txData || typeof txData !== 'object' || typeof txData.data !== 'string') {
+    throw new CommandError(`${context}: no transaction data to verify. Request a new quote.`, 'INVALID_INPUT');
+  }
+  const to = String(txData.to || '').toLowerCase();
+
+  // A deposit carries no native value (confirmed value === 0 on every capture).
+  // A non-zero value on either leg is an ETH-drain vector — refuse it. (BigInt
+  // parses both '0' and '0x0'.)
+  if (txData.value != null && BigInt(txData.value) !== 0n) {
+    throw new CommandError(
+      `${context} carries a non-zero native value ${txData.value}; this bridge path never sends native ETH. `
+        + `Refusing to sign. Request a new quote.`,
+      'UNEXPECTED_ACTION',
+    );
+  }
+
+  // AC1: ERC-20 approve → re-scope through the hardened encoder.
+  if (isErc20Approve(txData.data)) {
+    requireAmountAnchor(intent, context);
+    // The approve call itself must target the origin chain's USDC contract —
+    // otherwise a spender/amount that both look legitimate could still grant
+    // the router an allowance over an unrelated token the wallet holds.
+    const usdc = BRIDGE_TOKENS[intent.chain]?.USDC;
+    if (!usdc || to !== usdc.toLowerCase()) {
+      throw new CommandError(
+        `${context} sends an approve to an unexpected contract ${txData.to}. Refusing to sign. Request a new quote.`,
+        'UNEXPECTED_ACTION',
+      );
+    }
+    const { spender, amount } = decodeErc20Approve(txData.data);
+    // The approve target you grant an allowance to must be the known deposit
+    // router for this route — otherwise you are approving an attacker.
+    if (!BRIDGE_DEPOSIT_TARGETS[intent.chain]?.has(spender.toLowerCase())) {
+      throw new CommandError(
+        `${context} approves an unexpected spender ${spender}. Refusing to sign. Request a new quote.`,
+        'UNEXPECTED_ACTION',
+      );
+    }
+    // encodeApproveCalldata rejects >= MAX_UINT256 and amount > maxAllowance,
+    // and re-validates the 20-byte spender width. Cap to the requested input.
+    const scoped = encodeApproveCalldata(spender, amount, {
+      maxAllowance: BigInt(intent.requestedAmountBaseUnits),
+    });
+    return { data: scoped };
+  }
+
+  // AC2: deposit call → to + selector must both be on the route's allowlist.
+  if (!BRIDGE_DEPOSIT_TARGETS[intent.chain]?.has(to)) {
+    throw new CommandError(
+      `${context} targets an unexpected contract ${txData.to}. Refusing to sign. Request a new quote.`,
+      'UNEXPECTED_ACTION',
+    );
+  }
+  if (selectorOf(txData.data) !== BRIDGE_DEPOSIT_SELECTOR) {
+    throw new CommandError(
+      `${context} calls an unexpected method ${selectorOf(txData.data)} on ${txData.to}. `
+        + `Refusing to sign. Request a new quote.`,
+      'UNEXPECTED_ACTION',
+    );
+  }
+
+  // AC3: bind the decodable deposit args. The layout is fixed (see
+  // decodeBridgeDeposit); a call that doesn't decode is off-shape → refuse.
+  const dep = decodeBridgeDeposit(txData.data);
+  if (!dep) {
+    throw new CommandError(
+      `${context} has a malformed deposit calldata. Refusing to sign. Request a new quote.`,
+      'INVALID_INPUT',
+    );
+  }
+  // arg0 (depositor) is the on-chain credit/refund address; in every capture it
+  // is the signer, even when --recipient differed. Binding it to the signer
+  // stops a tampered response from redirecting the credited deposit while the
+  // scoped approval still lets the router pull the funds.
+  if (String(dep.depositor).toLowerCase() !== String(intent.signerAddress).toLowerCase()) {
+    throw new CommandError(
+      `${context} deposits on behalf of ${dep.depositor}, but the signing wallet is ${intent.signerAddress}. `
+        + `Refusing to sign. Request a new quote.`,
+      'SIGNER_MISMATCH',
+    );
+  }
+  // arg1 (token) must be the origin chain's USDC — the only token this path bridges.
+  const usdc = BRIDGE_TOKENS[intent.chain]?.USDC;
+  if (!usdc || String(dep.token).toLowerCase() !== usdc.toLowerCase()) {
+    throw new CommandError(
+      `${context} deposits an unexpected token ${dep.token}. Refusing to sign. Request a new quote.`,
+      'UNEXPECTED_ACTION',
+    );
+  }
+  // arg2 (amount) must not exceed what the user requested (defense in depth —
+  // the scoped approval already bounds the pull; captures show exact equality).
+  requireAmountAnchor(intent, context);
+  if (dep.amount > BigInt(intent.requestedAmountBaseUnits)) {
+    throw new CommandError(
+      `${context} would deposit ${dep.amount}, more than the ${intent.requestedAmountBaseUnits} base units you requested. `
+        + `Refusing to sign. Request a new quote.`,
+      'AMOUNT_MISMATCH',
+    );
+  }
+  // arg3 (relay id) is an opaque off-chain handle and the --recipient never
+  // appears on-chain — both are the accepted relayer-trust residual, bounded by
+  // the checks above.
+
+  return { data: txData.data };
+}
+
+// Validate every EVM step's calldata against intent BEFORE any step is signed
+// or broadcast. Without this, a good approve step would already be on-chain by
+// the time a poisoned deposit step is reached and refused.
+function preflightEvmBridgeSteps(steps, intent) {
+  for (const step of steps) {
+    for (const item of step.items || []) {
+      if (item.status === 'complete') continue;   // don't re-check resumed steps
+      assertEvmBridgeStepIntent(item.data, intent, `Bridge step "${step.id}"`);
+    }
+  }
+}
+
 // Headroom multiplier applied to the current base fee when setting maxFeePerGas.
 // A type-2 transaction only ever pays baseFee + priority, so a generous cap
 // costs nothing extra — it just buys tolerance for the base fee moving between
@@ -783,7 +991,7 @@ export async function resolveEvmStepFees(chain, txData, overrides = {}) {
   return { gasPrice: await evmRpcCall(chain, 'eth_gasPrice') };
 }
 
-async function processEvmStep(step, { chain, privateKeyHex, signerAddress, log, onBroadcast, feeOverrides, nonceSequence }) {
+async function processEvmStep(step, { chain, privateKeyHex, signerAddress, log, onBroadcast, feeOverrides, nonceSequence, intent }) {
   for (const item of step.items || []) {
     if (item.status === 'complete') continue;
     const txData = item.data;
@@ -803,6 +1011,10 @@ async function processEvmStep(step, { chain, privateKeyHex, signerAddress, log, 
       );
     }
 
+    // Bind the server-supplied calldata to intent before signing: re-scope
+    // approvals through the hardened encoder, and pin the deposit to/selector.
+    const bound = assertEvmBridgeStepIntent(txData, intent, `Bridge step "${step.id}"`);
+
     const fees = await resolveEvmStepFees(chain, txData, feeOverrides);
     // getEvmNonce returns a decimal number and reconciles pending against the
     // mined count. An explicit --nonce skips both: it is how an operator
@@ -818,7 +1030,7 @@ async function processEvmStep(step, { chain, privateKeyHex, signerAddress, log, 
     if (nonceSequence) log(`  Nonce: ${nonce} (from --nonce)`);
 
     const signedTx = signEvmTransaction(
-      { ...txData, ...fees },
+      { ...txData, ...fees, data: bound.data },
       privateKeyHex,
       chain,
       nonce,
@@ -1399,6 +1611,15 @@ from a quote are the same ones that got stuck. Check the stuck nonce with
         });
 
       if (execution_type === 'evm_transaction') {
+        const evmIntent = {
+          chain: quoteData.originChain,
+          signerAddress: signer.address,
+          requestedAmountBaseUnits: quoteData.requestedAmountBaseUnits ?? null,
+        };
+        // Validate every step's calldata against intent before any step is
+        // signed or broadcast — see preflightEvmBridgeSteps for why this can't
+        // just be the per-step check processEvmStep already does.
+        preflightEvmBridgeSteps(steps, evmIntent);
         // Overrides move real money differently from what was quoted, so say so
         // rather than letting them apply silently.
         if (feeOverrides.priorityFeeWei || feeOverrides.maxFeeWei || nonceSequence) {
@@ -1417,6 +1638,7 @@ from a quote are the same ones that got stuck. Check the stuck nonce with
             onBroadcast,
             feeOverrides,
             nonceSequence,
+            intent: evmIntent,
           });
           markBroadcast(index);
         }

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -702,6 +702,10 @@ const ERC20_APPROVE_SELECTOR = '0x095ea7b3';
 // Relay deposit router for the Base → HL route. It is BOTH the approve spender
 // and the deposit call target (confirmed identical across every capture), so
 // one constant covers both. Lower-cased for comparison.
+//
+// Keyed by origin chain, in lockstep with the deposit rows of BRIDGE_ROUTES:
+// widening the EVM deposit side (a new signable origin chain) MUST add that
+// chain's router here too, or every deposit on the new route fails closed.
 const BRIDGE_DEPOSIT_TARGETS = {
   base: new Set(['0x4cd00e387622c35bddb9b4c962c136462338bc31']),
 };


### PR DESCRIPTION
## Problem

The `nansen bridge` **EVM deposit leg** (Base → Hyperliquid via Relay) is a separate execution path from `nansen trade execute` and never received the trade path's hardening. `processEvmStep` signed the server-supplied `approve` and `deposit` transactions almost verbatim — the only validation was a `from` check. A compromised API (or the Relay upstream it proxies) could return calldata for `approve(attacker, MAX_UINT256)` or an arbitrary drain call and the CLI would sign it with the user's local key.

## What changed

A new `assertEvmBridgeStepIntent`, run as a **preflight over every step before any is broadcast**, binds each transaction to the user's intent. The pinned constants were captured from real read-only `bridge quote` responses (confirmed stable across three quotes), not guessed.

- **Approvals are re-scoped** through the existing hardened `encodeApproveCalldata`: the approve must target the origin-chain USDC contract, the spender must be the known Relay router, and the amount is capped to the requested input (rejects `MAX_UINT256`/unbounded).
- **The deposit target is pinned**: `to` + selector must match the known Relay router and deposit method; the decoded args are bound (depositor == signer, token == USDC, amount ≤ requested), and native `value` must be zero.
- **The plan is bounded**: at most one approve and one deposit. ERC-20 `approve` overwrites (not increments) the allowance, so without this a tampered response could chain repeated `[approve(requested), deposit(requested)]` pairs — each passing every per-item check — to pull the requested amount N times and drain the whole balance. (Caught in security review.)

The overall guarantee: **at most the requested amount can leave the wallet for a given quote.**

### Known residual
The Relay payout recipient is held off-chain behind the request id and does not appear in the signed bytes (the deposit's `id` arg is opaque), so full recipient binding isn't possible on this leg — the same structural limit as the sibling withdrawal-leg work. Loss is bounded by the checks above.

## Testing

- New `bridge-evm-deposit-intent.test.js` (46 assertions): approve/deposit binding, MAX rejection, over-cap, wrong token, depositor redirect, non-zero value, malformed calldata, and the plan-level amplification bound.
- Existing bridge fixtures updated for the new preflight.
- Full suite green; lint clean.
- **Real-money round-trip e2e passed**: Base → HL deposit of 2 USDC (exercises the new guard) and HL → Base withdrawal back; Base balance reconciled exactly, confirming the guard does not false-block a legitimate deposit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)