### PR TITLE
Refuse x402 payment requirements with a missing payTo recipient

### DIFF
--- a/.changeset/x402-missing-payto-guard.md
+++ b/.changeset/x402-missing-payto-guard.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Refuse x402 auto-payments whose payment requirement is missing a payTo/pay_to recipient, matching the existing missing-amount check. Previously this fell through to the per-signing-path field validation inconsistently, and the WalletConnect path had no check at all.

--- a/src/__tests__/x402-policy.test.js
+++ b/src/__tests__/x402-policy.test.js
@@ -148,6 +148,16 @@ describe('evaluatePaymentRequirement — allowlist and basic pass', () => {
     expect(result.reason).toMatch(/payTo field is missing/i);
   });
 
+  it('13. payTo and pay_to both empty strings → refused, not resolved to "" (reviewer regression)', () => {
+    // resolvePayTo("") falls through to pay_to, but pay_to is also "" here, so
+    // the resolved value is itself "" — must be treated as missing, not as a
+    // real (empty) recipient that then reaches a signer's deriveATA/EIP-712.
+    const req = { ...BASE_USDC_REQUIREMENT, payTo: '', pay_to: '' };
+    const result = evaluatePaymentRequirement(req);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/payTo field is missing/i);
+  });
+
   it('uses pay_to field when payTo is absent', () => {
     const req = { ...BASE_USDC_REQUIREMENT };
     delete req.payTo;

--- a/src/__tests__/x402-policy.test.js
+++ b/src/__tests__/x402-policy.test.js
@@ -139,6 +139,15 @@ describe('evaluatePaymentRequirement — allowlist and basic pass', () => {
     expect(result.reason).toMatch(/negative amount/i);
   });
 
+  it('12. missing payTo and pay_to → refused with clear message', () => {
+    const req = { ...BASE_USDC_REQUIREMENT };
+    delete req.payTo;
+    delete req.pay_to;
+    const result = evaluatePaymentRequirement(req);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/payTo field is missing/i);
+  });
+
   it('uses pay_to field when payTo is absent', () => {
     const req = { ...BASE_USDC_REQUIREMENT };
     delete req.payTo;

--- a/src/x402-policy.js
+++ b/src/x402-policy.js
@@ -145,7 +145,7 @@ export function evaluatePaymentRequirement(requirement) {
     };
   }
 
-  if (payTo === undefined || payTo === null) {
+  if (payTo === undefined || payTo === null || payTo === '') {
     return {
       ok: false,
       reason: 'Refusing to auto-pay: payTo field is missing from the payment requirement.',

--- a/src/x402-policy.js
+++ b/src/x402-policy.js
@@ -145,6 +145,13 @@ export function evaluatePaymentRequirement(requirement) {
     };
   }
 
+  if (payTo === undefined || payTo === null) {
+    return {
+      ok: false,
+      reason: 'Refusing to auto-pay: payTo field is missing from the payment requirement.',
+    };
+  }
+
   if (!isPayToAllowed(payTo, network)) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary

Fast-follow from PR #539's final review. `evaluatePaymentRequirement()` in `src/x402-policy.js` explicitly refused a payment requirement with a missing `amount`, but a missing `payTo`/`pay_to` silently passed — `isPayToAllowed()` returns `true` unconditionally when `NANSEN_X402_ALLOWED_PAYTO` is unset (the default), without ever checking that `payTo` was defined.

This wasn't a fund-loss bug (there's no attacker-controlled address to redirect a payment to when the field is simply absent), but it was an inconsistency in the guard's own validation completeness, and it behaved differently per signing path:

- The local-key EVM signer happened to fail closed (throws `Missing EIP-712 field: to`), but that error was silently swallowed by the `catch { continue }` loop in `x402.js`'s `createPaymentSignatures`.
- The WalletConnect path (`walletconnect-x402.js`) had no such check at all — it would send a `to: undefined` EIP-712 typed-data request out for the user's external wallet to sign.

## What changed

- Added an explicit `payTo === undefined || payTo === null` check in `evaluatePaymentRequirement`, mirroring the existing missing-amount check, with a clear refusal message.
- Added a regression test (`src/__tests__/x402-policy.test.js`).
- Added a changeset (patch).

## Tests

Full suite: 62/62 files, 2519 passed / 2 skipped. Lint clean.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)