### PR TITLE
fix(ci): set persist-credentials: false on publish checkout step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:


### PR DESCRIPTION
The `publish` job's `actions/checkout` step was missing `persist-credentials: false`, unlike the `lint` and `test` jobs which already had it set. The `changesets/action` authenticates git operations via the `GITHUB_TOKEN` env var it receives, so persisted credentials are not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)