### PR TITLE
fix: reject negative amounts in parseAmount to prevent silent wrong-value computation

### DIFF
--- a/.changeset/fix-parseamount-negative.md
+++ b/.changeset/fix-parseamount-negative.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix `parseAmount` silently producing wrong values for negative decimal inputs. Negative amounts are now rejected with a clear error.

--- a/src/__tests__/transfer.test.js
+++ b/src/__tests__/transfer.test.js
@@ -92,6 +92,10 @@ describe('Amount Parsing', () => {
     expect(parseAmount('1.123456789', 6)).toBe(1123456n);
   });
 
+  test('rejects negative amounts', () => {
+    expect(() => parseAmount('-1.5', 6)).toThrow('Amount must be positive');
+    expect(() => parseAmount('-0.1', 18)).toThrow('Amount must be positive');
+  });
   test('pads short decimals', () => {
     expect(parseAmount('1.1', 18)).toBe(1100000000000000000n);
   });

--- a/src/transfer.js
+++ b/src/transfer.js
@@ -49,7 +49,7 @@ function validateSolanaAddress(address) {
 // ============= Amount Parsing =============
 
 function parseAmount(amountStr, decimals) {
-  if (typeof amountStr === 'string' && amountStr.startsWith('-')) throw new Error('Amount must be positive');
+  if (String(amountStr).startsWith('-')) throw new Error('Amount must be positive');
   const parts = amountStr.split('.');
   const whole = parts[0] || '0';
   let frac = (parts[1] || '').padEnd(decimals, '0').slice(0, decimals);

--- a/src/transfer.js
+++ b/src/transfer.js
@@ -49,6 +49,7 @@ function validateSolanaAddress(address) {
 // ============= Amount Parsing =============
 
 function parseAmount(amountStr, decimals) {
+  if (typeof amountStr === 'string' && amountStr.startsWith('-')) throw new Error('Amount must be positive');
   const parts = amountStr.split('.');
   const whole = parts[0] || '0';
   let frac = (parts[1] || '').padEnd(decimals, '0').slice(0, decimals);


### PR DESCRIPTION
Closes #547

## Problem

`parseAmount('-1.5', 6)` returns `-500000` (i.e. -0.5 tokens) instead of `-1500000` (-1.5 tokens). The integer part is negative but the fractional part is always positive, so they partially cancel instead of combining.

No input validation rejects negative amounts before `parseAmount` is called.

## Fix

Add a guard at the top of `parseAmount` that rejects negative inputs with a clear error. A send/transfer command should never accept a negative amount.