### PR TITLE
[parity] declare the API routes alerts/account/web/agent already call in schema.json

### DIFF
--- a/.changeset/schema-declare-called-endpoints.md
+++ b/.changeset/schema-declare-called-endpoints.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Declare the API routes `alerts`, `account`, `web` and `agent` already call in `src/schema.json`. The schema is what shell completions, `--help` and docs tooling read, so eight routes the code requests were invisible to them (and to the API/MCP/CLI parity check).

--- a/src/schema.json
+++ b/src/schema.json
@@ -1386,6 +1386,7 @@
       "description": "Smart alert management — create, update, toggle, delete alerts",
       "subcommands": {
         "list": {
+          "endpoint": "/api/v1/smart-alert/list",
           "description": "List all alerts",
           "returns": [
             "id",
@@ -1399,6 +1400,7 @@
           ]
         },
         "create": {
+          "endpoint": "/api/v1/smart-alert",
           "description": "Create a new alert",
           "options": {
             "name": {
@@ -1450,6 +1452,7 @@
           }
         },
         "update": {
+          "endpoint": "/api/v1/smart-alert",
           "description": "Update an existing alert. Usage: nansen alerts update <id> [options]",
           "options": {
             "name": {
@@ -1503,6 +1506,7 @@
           }
         },
         "toggle": {
+          "endpoint": "/api/v1/smart-alert/toggle",
           "description": "Enable or disable an alert. Usage: nansen alerts toggle <id> --enabled|--disabled",
           "options": {
             "enabled": {
@@ -1842,6 +1846,7 @@
       }
     },
     "account": {
+      "endpoint": "/api/v1/account",
       "description": "Show API key status, plan, and remaining credits. Does not consume credits."
     },
     "auth": {
@@ -1898,6 +1903,7 @@
       "description": "Web search and fetch commands",
       "subcommands": {
         "search": {
+          "endpoint": "/api/v1/search/web-search",
           "description": "Search the web for one or more queries in parallel",
           "options": {
             "query": {
@@ -1916,6 +1922,7 @@
           ]
         },
         "fetch": {
+          "endpoint": "/api/v1/search/web-fetch",
           "description": "Fetch and analyze content from one or more URLs using AI",
           "options": {
             "url": {
@@ -1935,6 +1942,10 @@
       }
     },
     "agent": {
+      "apiEndpoints": [
+        "/api/v1/agent/fast",
+        "/api/v1/agent/expert"
+      ],
       "description": "Nansen AI research agent — ask questions about wallets, tokens, and on-chain activity",
       "options": {
         "expert": {


### PR DESCRIPTION
## What

`src/schema.json` is the CLI's machine-readable surface description — shell completions, `--help`, docs tooling and automated surface checks all read it. It is maintained by hand, and eight routes the code already requests were never declared in it.

This PR declares them. Docs-only: no handler, request, or behaviour changes.

| Command | Route the code calls | Declared as |
|---|---|---|
| `alerts list` | `GET /api/v1/smart-alert/list` | `endpoint` |
| `alerts create` | `POST /api/v1/smart-alert` | `endpoint` |
| `alerts update` | `PATCH /api/v1/smart-alert` | `endpoint` |
| `alerts toggle` | `PATCH /api/v1/smart-alert/toggle` | `endpoint` |
| `account` | `GET /api/v1/account` | `endpoint` |
| `web search` | `POST /api/v1/search/web-search` | `endpoint` |
| `web fetch` | `POST /api/v1/search/web-fetch` | `endpoint` |
| `agent` | `POST /api/v1/agent/fast` **or** `/api/v1/agent/expert` | `apiEndpoints` |

`agent` resolves its route from `--expert` at call time (`src/commands/agent.js:210`), so it declares both under `apiEndpoints` rather than naming a single billed `endpoint` — the convention the perp commands already follow, and the one `src/__tests__/schema-bridge-perp.test.js` encodes.

## What this closes

Before this change, nine routes were requested by CLI code without being declared in `src/schema.json`. This PR declares eight of them, taking the undeclared count from nine to one.

The remaining one, `/api/v1/points/leaderboard`, is deliberately **not** declared here: #542 removes that dead route together with its schema leaf, so declaring it now would conflict. None of the declarations added here contradict the documented HTTP method for their path.

## Validation

Each declared route was checked for existence against the published API surface. No credentials, wallet addresses, or response payloads were used or reproduced.

| Route | Result | Basis |
|---|---|---|
| `POST /api/v1/search/web-search` | **confirmed reachable** | unauthenticated request resolves to this route, and the response differs from the one an unknown path produces |
| `POST /api/v1/search/web-fetch` | **confirmed reachable** | same check |
| `POST /api/v1/agent/fast` | **confirmed reachable** | same check |
| `POST /api/v1/agent/expert` | **confirmed reachable** | same check |
| `GET /api/v1/account` | **unconfirmed** | authentication is refused before routing, so the check is inconclusive without an API key; documented in the published API reference as `GET`, not deprecated |
| `GET /api/v1/smart-alert/list` | **unconfirmed** | same inconclusive reason; documented as `GET`, not deprecated |
| `POST` / `PATCH /api/v1/smart-alert` | **not safely checkable** | account-mutating (creates/updates an alert); documented as `POST` + `PATCH`, not deprecated; call sites `src/api.js:1644,1648` |
| `PATCH /api/v1/smart-alert/toggle` | **not safely checkable** | account-mutating; documented as `PATCH`, not deprecated; call site `src/api.js:1652` |

Nothing here is a removal, so no route needed proof of absence. Every declared path is one the CLI code demonstrably requests today — call sites are cited above and in the commit message.

Run from a fresh `npm ci`, with API and service credentials cleared from the environment:

- `npm test` — 62 files, 2540 passed, 2 skipped
- `npm run lint` — clean

Same result on pristine `main`, so the suite is green either side of this change.

One flake was seen on an earlier `npm test` run (`update-check.test.js` → "should show update notification on stderr for help command"). It reads and writes the real per-user update-check state file, so it races with anything else touching that file; it passes in isolation and on clean full-suite runs, on this branch and on `main` alike. Unrelated to this change — flagging it as a pre-existing test-isolation weakness, not fixing it here.

## Notes

Opened by an automated surface-parity check that compares the API's published surface against the MCP server and this CLI.

Scope is limited to the routes that check flagged. `alerts delete` calls a path-parameterised route (`/api/v1/smart-alert/{id}`), which the check excludes as a template and which was not flagged — left alone deliberately.

**This is a proposal for human review. Auto-merge is not enabled.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
