### PR TITLE
[parity] add the missing research smart-money pnl-leaderboard command

### DIFF
--- a/.changeset/cli-sm-pnl-leaderboard.md
+++ b/.changeset/cli-sm-pnl-leaderboard.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add `nansen research smart-money pnl-leaderboard` — ranks smart money wallets by realized/unrealized PnL over a `--timeframe` of 1, 7, 30, 90, or 180 days.

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -123,6 +123,11 @@ const MOCK_RESPONSES = {
       { token_symbol: 'SOL', date: '2024-01-01', balance_usd: 100000 }
     ]
   },
+  smartMoneyPnlLeaderboard: {
+    data: [
+      { address: 'abc', address_label: 'Fund', total_pnl_usd: 250000, n_trades: 42 }
+    ]
+  },
   // New Profiler endpoints
   addressHistoricalBalances: {
     balances: [
@@ -740,6 +745,59 @@ describe('NansenAPI', () => {
 
         const body = expectFetchCalledWith('/api/v1/smart-money/historical-holdings');
         expect(body.order_by).toEqual([{ field: 'balance_usd', direction: 'DESC' }]);
+      });
+    });
+
+    describe('smartMoneyPnlLeaderboard', () => {
+      it('should fetch PnL leaderboard with correct endpoint and default timeframe', async () => {
+        setupMock(MOCK_RESPONSES.smartMoneyPnlLeaderboard);
+
+        const result = await api.smartMoneyPnlLeaderboard({ chains: ['solana'] });
+
+        const body = expectFetchCalledWith('/api/v1/smart-money/pnl-leaderboard', {
+          chains: ['solana'],
+          timeframe: 7
+        });
+        expect(body.filters).toBeUndefined(); // empty filters stripped by cleanBody
+
+        expect(result.data).toBeInstanceOf(Array);
+        expect(result.data[0]).toHaveProperty('total_pnl_usd', 250000);
+      });
+
+      it('should pass custom chains and timeframe', async () => {
+        setupMock(MOCK_RESPONSES.smartMoneyPnlLeaderboard);
+
+        await api.smartMoneyPnlLeaderboard({ chains: ['ethereum', 'base'], timeframe: 30 });
+
+        const body = expectFetchCalledWith('/api/v1/smart-money/pnl-leaderboard');
+        expect(body.chains).toEqual(['ethereum', 'base']);
+        expect(body.timeframe).toBe(30);
+      });
+
+      it('should pass filters parameter', async () => {
+        setupMock(MOCK_RESPONSES.smartMoneyPnlLeaderboard);
+
+        await api.smartMoneyPnlLeaderboard({
+          chains: ['solana'],
+          filters: { include_smart_money_labels: ['Fund'] }
+        });
+
+        const body = expectFetchCalledWith('/api/v1/smart-money/pnl-leaderboard');
+        expect(body.filters.include_smart_money_labels).toEqual(['Fund']);
+      });
+
+      it('should pass orderBy and pagination parameters', async () => {
+        setupMock(MOCK_RESPONSES.smartMoneyPnlLeaderboard);
+
+        await api.smartMoneyPnlLeaderboard({
+          chains: ['solana'],
+          orderBy: [{ field: 'total_pnl_usd', direction: 'DESC' }],
+          pagination: { page: 2, per_page: 25 }
+        });
+
+        const body = expectFetchCalledWith('/api/v1/smart-money/pnl-leaderboard');
+        expect(body.order_by).toEqual([{ field: 'total_pnl_usd', direction: 'DESC' }]);
+        expect(body.pagination).toEqual({ page: 2, per_page: 25 });
       });
     });
   });

--- a/src/__tests__/coverage.test.js
+++ b/src/__tests__/coverage.test.js
@@ -17,6 +17,7 @@ const DOCUMENTED_ENDPOINTS = {
     { name: 'dcas', method: 'smartMoneyDcas', endpoint: '/api/v1/smart-money/dcas' },
     { name: 'perp-trades', method: 'smartMoneyPerpTrades', endpoint: '/api/v1/smart-money/perp-trades' },
     { name: 'historical-holdings', method: 'smartMoneyHistoricalHoldings', endpoint: '/api/v1/smart-money/historical-holdings' },
+    { name: 'pnl-leaderboard', method: 'smartMoneyPnlLeaderboard', endpoint: '/api/v1/smart-money/pnl-leaderboard' },
   ],
   profiler: [
     { name: 'balance', method: 'addressBalance', endpoint: '/api/v1/profiler/address/current-balance' },

--- a/src/api.js
+++ b/src/api.js
@@ -896,6 +896,17 @@ export class NansenAPI {
     });
   }
 
+  async smartMoneyPnlLeaderboard(params = {}) {
+    const { chains = ['solana'], timeframe = 7, filters = {}, orderBy, pagination } = params;
+    return this.request('/api/v1/smart-money/pnl-leaderboard', {
+      chains,
+      timeframe,
+      filters,
+      order_by: orderBy,
+      pagination
+    });
+  }
+
   // ============= Profiler Endpoints =============
 
   async addressBalance(params = {}) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1222,6 +1222,7 @@ export function buildCommands(deps = {}) {
       }
 
       const days = options.days ? parseInt(options.days) : 30;
+      const timeframe = options.timeframe ? parseInt(options.timeframe) : 7;
 
       const handlers = {
         'netflow': () => apiInstance.smartMoneyNetflow({ chains, filters, orderBy, pagination }),
@@ -1230,8 +1231,9 @@ export function buildCommands(deps = {}) {
         'holdings': () => apiInstance.smartMoneyHoldings({ chains, filters, orderBy, pagination }),
         'dcas': () => apiInstance.smartMoneyDcas({ filters, orderBy, pagination }),
         'historical-holdings': () => apiInstance.smartMoneyHistoricalHoldings({ chains, filters, orderBy, pagination, days }),
+        'pnl-leaderboard': () => apiInstance.smartMoneyPnlLeaderboard({ chains, filters, orderBy, pagination, timeframe }),
         'help': () => ({
-          commands: ['netflow', 'dex-trades', 'perp-trades', 'holdings', 'dcas', 'historical-holdings'],
+          commands: ['netflow', 'dex-trades', 'perp-trades', 'holdings', 'dcas', 'historical-holdings', 'pnl-leaderboard'],
           description: 'Smart Money analytics endpoints',
           example: 'nansen smart-money netflow --chain solana --labels Fund'
         })

--- a/src/schema.json
+++ b/src/schema.json
@@ -474,6 +474,41 @@
                   "default": 30
                 }
               }
+            },
+            "pnl-leaderboard": {
+              "endpoint": "/api/v1/smart-money/pnl-leaderboard",
+              "description": "Smart money wallets ranked by PnL over a timeframe",
+              "options": {
+                "chain": {
+                  "default": "solana"
+                },
+                "timeframe": {
+                  "default": 7,
+                  "enum": [
+                    1,
+                    7,
+                    30,
+                    90,
+                    180
+                  ]
+                }
+              },
+              "returns": [
+                "address",
+                "address_label",
+                "realized_pnl_usd",
+                "unrealized_pnl_usd",
+                "total_pnl_usd",
+                "avg_trade_roi",
+                "roi_percent_unrealised",
+                "win_rate",
+                "n_trades",
+                "n_tokens",
+                "open_trades",
+                "held_tokens_count",
+                "top_traded_tokens_info",
+                "top_5_balance_tokens_info"
+              ]
             }
           },
           "description": "Smart Money analytics - track sophisticated market participants"


### PR DESCRIPTION
## What

The parity checker reports `POST /api/v1/smart-money/pnl-leaderboard` as a public API endpoint
with **no CLI command**. Its six sibling smart-money endpoints all have one. This adds it:

```
nansen research smart-money pnl-leaderboard --chain solana --timeframe 7
```

Ranks smart money wallets by realized / unrealized PnL. `--timeframe` accepts the spec's
`1, 7, 30, 90, 180` (days), default `7`.

## Parity report line addressed

```
## CLI: spec endpoints with no command (8)

- `POST /api/v1/smart-money/pnl-leaderboard` — Smart Money — Get Smart Money PnL Leaderboard
```

Re-running the checker with this branch as the CLI repo takes `cli_missing` from **8 → 7**,
closing exactly `/api/v1/smart-money/pnl-leaderboard` and introducing no new findings in any
category (no new stale, no method mismatch, drift unchanged).

## Request shape

Derived from the public OpenAPI spec (`SmartMoneyPnlLeaderboardRequest`), not guessed. Wire body
with defaults — `cleanBody` strips the empty `filters`, exactly as every sibling does:

```json
{ "chains": ["solana"], "timeframe": 7 }
```

Fully populated:

```json
{
  "chains": ["all"],
  "timeframe": 30,
  "filters": { "include_smart_money_labels": ["Fund"] },
  "order_by": [{ "field": "total_pnl_usd", "direction": "DESC" }],
  "pagination": { "page": 1, "per_page": 10 }
}
```

`--chain/--chains`, `--labels`, `--sort/--order-by` and pagination all come from the existing
shared `smart-money` handler — no new option plumbing.

## Live validation

⚠️ **Not live-validated — please smoke-test before merging.**

No API key was available to this run, so no request was made to `api.nansen.ai`. This is a
*missing-coverage* finding, not a removal: the endpoint's existence and its request/response
contract come from the curated public OpenAPI spec at nansen-api `1b2d057`, so nothing here
depends on a probe. What a probe *would* have added is confirmation that the assembled body is
accepted end-to-end — that check is outstanding, and a reviewer with a key should run the command
above once before merging.

## Verification

Run in the pinned `origin/main` worktree with credentials stripped from the environment
(`env -u NANSEN_API_KEY -u GH_TOKEN -u GITHUB_TOKEN`):

- `npm test` — 62 files passed, **2545 passed, 2 skipped, 0 failed**
- `npm run lint` — clean
- `JSON.parse(src/schema.json)` — valid

New tests: `src/__tests__/api.test.js` asserts the POST path and body (defaults and fully
populated); `src/__tests__/coverage.test.js` gains the endpoint so the coverage guard now
enforces it.

## Scope

`src/api.js`, `src/cli.js`, `src/schema.json`, the two test files, and a `minor` changeset —
insertions only apart from the one-line `help` command list.

No docs changed: no README or `skills/*/SKILL.md` enumerates the smart-money subcommand set as a
contract (`nansen-smart-money-tracker/SKILL.md` documents four of the six existing subcommands and
omits `dcas`), and `skills.test.js` asserts only the limit-orders skill.

`--timeframe` is parsed as an integer but not validated client-side against the enum — no sibling
validates locally either, and the API returns its own error. Left as-is deliberately.

The other 7 CLI gaps, the 15 MCP gaps, and the schema-drift items are **not** touched here.

## Pinned SHAs audited by this run

| Repo | origin/main |
|---|---|
| nansen-api | `1b2d05709f3f747b4a1b0a4264c9ce680a838584` |
| nansen-ra | `425394130e5ea1130056fa9edbf0c63cf5a01327` |
| nansen-cli | `72e71231e22dad83c3d8b5a9a7a8708d19e2c0ff` |

---

Found by the `parity-check` skill (nansen-api) for
[API-311](https://linear.app/nansen/issue/API-311).

Opened by the parity agent as a proposal for human review — auto-merge is not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
