### PR TITLE
fix: harden parseAmount against whitespace-wrapped and malformed inputs

### DIFF
--- a/.changeset/harden-parseamount-input-validation.md
+++ b/.changeset/harden-parseamount-input-validation.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Harden `parseAmount` input validation: reject negative amounts wrapped in whitespace (previously silently miscalculated), and reject non-numeric or malformed inputs (e.g. `abc`, empty string, `1.`, `.5`) with a clear error instead of throwing a raw error or silently returning `0`.

--- a/src/__tests__/transfer.test.js
+++ b/src/__tests__/transfer.test.js
@@ -96,6 +96,24 @@ describe('Amount Parsing', () => {
     expect(() => parseAmount('-1.5', 6)).toThrow('Amount must be positive');
     expect(() => parseAmount('-0.1', 18)).toThrow('Amount must be positive');
   });
+
+  test('rejects negative amounts with surrounding whitespace', () => {
+    expect(() => parseAmount(' -1.5', 6)).toThrow('Amount must be positive');
+    expect(() => parseAmount('-1.5 ', 6)).toThrow('Amount must be positive');
+  });
+
+  test('rejects non-numeric and malformed amounts', () => {
+    expect(() => parseAmount('abc', 6)).toThrow('Amount must be a valid number');
+    expect(() => parseAmount('', 6)).toThrow('Amount must be a valid number');
+    expect(() => parseAmount('1.2.3', 6)).toThrow('Amount must be a valid number');
+    expect(() => parseAmount('1.', 6)).toThrow('Amount must be a valid number');
+    expect(() => parseAmount('.5', 6)).toThrow('Amount must be a valid number');
+  });
+
+  test('trims surrounding whitespace on valid amounts', () => {
+    expect(parseAmount(' 1.5 ', 6)).toBe(1500000n);
+  });
+
   test('pads short decimals', () => {
     expect(parseAmount('1.1', 18)).toBe(1100000000000000000n);
   });

--- a/src/transfer.js
+++ b/src/transfer.js
@@ -49,8 +49,10 @@ function validateSolanaAddress(address) {
 // ============= Amount Parsing =============
 
 function parseAmount(amountStr, decimals) {
-  if (String(amountStr).startsWith('-')) throw new Error('Amount must be positive');
-  const parts = amountStr.split('.');
+  const str = String(amountStr).trim();
+  if (str.startsWith('-')) throw new Error('Amount must be positive');
+  if (!/^\d+(\.\d+)?$/.test(str)) throw new Error('Amount must be a valid number');
+  const parts = str.split('.');
   const whole = parts[0] || '0';
   let frac = (parts[1] || '').padEnd(decimals, '0').slice(0, decimals);
   return BigInt(whole) * (10n ** BigInt(decimals)) + BigInt(frac);


### PR DESCRIPTION
## Problem

Follow-up hardening for `parseAmount` in `src/transfer.js`. The recent negative-amount fix rejected inputs starting with `-`, but a few input-validation gaps remained:

- **Whitespace-prefixed negative (real bug):** `parseAmount(' -1.5', 6)` bypassed the `.startsWith('-')` guard and returned `-500000` — a silently wrong value. Reachable via `nansen wallet send --amount " -1.5"`, since the CLI layer only checks that `--amount` is present, not that it's numeric.
- **Non-numeric input:** `parseAmount('abc', 6)` threw a raw `BigInt` `SyntaxError` instead of an actionable message.
- **Empty / malformed input:** `parseAmount('', 6)` silently returned `0n`.

## Fix

Trim the input and validate its full format before parsing:

```js
const str = String(amountStr).trim();
if (str.startsWith('-')) throw new Error('Amount must be positive');
if (!/^\d+(\.\d+)?$/.test(str)) throw new Error('Amount must be a valid number');
```

- `trim()` closes the whitespace-bypass bug.
- The numeric-format check rejects non-numeric, empty, and malformed inputs with a clear error.
- The specific "Amount must be positive" message is kept for negatives.

Since `parseAmount` is a shared helper, this protects all send/transfer callers and the limit-order path.

## Behavior change

The format check also rejects `1.` (trailing dot) and `.5` (leading dot), which were previously accepted. Both are junk inputs, so rejecting them is intended.

## Verification

- Added unit tests for whitespace-wrapped negatives, non-numeric/malformed inputs, and trimmed-valid inputs (`src/__tests__/transfer.test.js`).
- Full suite: 2544 passed, 2 skipped. Lint clean.
- Exercised via the real CLI (`node ./src/index.js wallet send ...`): malformed amounts are rejected before any signing/broadcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)