### PR TITLE
Add missing public API research commands

### DIFF
--- a/.changeset/public-api-endpoint-parity.md
+++ b/.changeset/public-api-endpoint-parity.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add research commands for eight previously unavailable public API endpoints.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ nansen schema [command] [--pretty]    # full command reference (no API key neede
 
 **Research categories:** `smart-money` (`sm`), `token` (`tgm`), `profiler` (`prof`), `portfolio` (`port`), `prediction-market` (`pm`), `search`, `perp`, `points`
 
+**Direct research subcommands:** `chain-rank`, `token-sectors`, `address-premium-labels`, `smart-money-pnl-leaderboard`, `position-intelligence`, `perp-pnl-summary`, `historical-token-ohlcv`, `transaction-with-token-transfer-lookup`
+
 **Trade:** `quote`, `execute`, `bridge-status`, `limit-order` — DEX swaps on Solana and Base, cross-chain bridges, and Solana limit orders.
 
 **Wallet:** `create`, `list`, `show`, `export`, `default`, `delete`, `send` — local or Privy server-side wallets (EVM + Solana).

--- a/src/__tests__/coverage.test.js
+++ b/src/__tests__/coverage.test.js
@@ -10,6 +10,9 @@ import { batchProfile, traceCounterparties, compareWallets } from '../cli.js';
 
 // All documented endpoints from Nansen API
 const DOCUMENTED_ENDPOINTS = {
+  chains: [
+    { name: 'chain-rank', method: 'chainRank', endpoint: '/api/v1/chains/chain-rank' },
+  ],
   smartMoney: [
     { name: 'netflow', method: 'smartMoneyNetflow', endpoint: '/api/v1/smart-money/netflow' },
     { name: 'holdings', method: 'smartMoneyHoldings', endpoint: '/api/v1/smart-money/holdings' },
@@ -17,10 +20,12 @@ const DOCUMENTED_ENDPOINTS = {
     { name: 'dcas', method: 'smartMoneyDcas', endpoint: '/api/v1/smart-money/dcas' },
     { name: 'perp-trades', method: 'smartMoneyPerpTrades', endpoint: '/api/v1/smart-money/perp-trades' },
     { name: 'historical-holdings', method: 'smartMoneyHistoricalHoldings', endpoint: '/api/v1/smart-money/historical-holdings' },
+    { name: 'pnl-leaderboard', method: 'smartMoneyPnlLeaderboard', endpoint: '/api/v1/smart-money/pnl-leaderboard' },
   ],
   profiler: [
     { name: 'balance', method: 'addressBalance', endpoint: '/api/v1/profiler/address/current-balance' },
     { name: 'labels', method: 'addressLabels', endpoint: '/api/v1/profiler/address/labels' },
+    { name: 'premium-labels', method: 'addressPremiumLabels', endpoint: '/api/v1/profiler/address/premium-labels' },
     { name: 'transactions', method: 'addressTransactions', endpoint: '/api/v1/profiler/address/transactions' },
     { name: 'pnl', method: 'addressPnl', endpoint: '/api/v1/profiler/address/pnl-and-trade-performance' },
     { name: 'search', method: 'entitySearch', endpoint: '/api/beta/profiler/entity-name-search' },
@@ -30,6 +35,7 @@ const DOCUMENTED_ENDPOINTS = {
     { name: 'pnl-summary', method: 'addressPnlSummary', endpoint: '/api/v1/profiler/address/pnl-summary' },
     { name: 'perp-positions', method: 'addressPerpPositions', endpoint: '/api/v1/profiler/perp-positions' },
     { name: 'perp-trades', method: 'addressPerpTrades', endpoint: '/api/v1/profiler/perp-trades' },
+    { name: 'perp-pnl-summary', method: 'addressPerpPnlSummary', endpoint: '/api/v1/profiler/perp-pnl-summary' },
     { name: 'dex-trades', method: 'addressDexTrades', endpoint: '/api/v1/profiler/dex-trades' },
   ],
   tokenGodMode: [
@@ -46,8 +52,10 @@ const DOCUMENTED_ENDPOINTS = {
     { name: 'jup-dca', method: 'tokenJupDca', endpoint: '/api/v1/tgm/jup-dca' },
     { name: 'perp-trades', method: 'tokenPerpTrades', endpoint: '/api/v1/tgm/perp-trades' },
     { name: 'perp-positions', method: 'tokenPerpPositions', endpoint: '/api/v1/tgm/perp-positions' },
+    { name: 'position-intelligence', method: 'tokenPositionIntelligence', endpoint: '/api/v1/tgm/position-intelligence' },
     { name: 'perp-pnl-leaderboard', method: 'tokenPerpPnlLeaderboard', endpoint: '/api/v1/tgm/perp-pnl-leaderboard' },
     { name: 'top-tokens', method: 'topTokens', endpoint: '/api/v1/nansen-score/top-tokens' },
+    { name: 'historical-token-ohlcv', method: 'researchHistoricalTokenOhlcv', endpoint: '/api/v1beta1/tgm/historical-token-ohlcv' },
   ],
   composite: [
     { name: 'batch-profile', fn: batchProfile, endpoint: 'composite' },
@@ -59,6 +67,10 @@ const DOCUMENTED_ENDPOINTS = {
   ],
   search: [
     { name: 'general-search', method: 'generalSearch', endpoint: '/api/v1/search/general' },
+    { name: 'token-sectors', method: 'tokenSectors', endpoint: '/api/v1/search/token-sectors' },
+  ],
+  transactions: [
+    { name: 'transaction-with-token-transfer-lookup', method: 'transactionWithTokenTransferLookup', endpoint: '/api/v1/transaction-with-token-transfer-lookup' },
   ],
   predictionMarket: [
     { name: 'ohlcv', method: 'pmOhlcv', endpoint: '/api/v1/prediction-market/ohlcv' },
@@ -84,6 +96,14 @@ const NOT_IMPLEMENTED = [
 
 describe('API Endpoint Coverage', () => {
   const api = new NansenAPI('test-key');
+
+  describe('Chain Endpoints', () => {
+    for (const ep of DOCUMENTED_ENDPOINTS.chains) {
+      it(`should have ${ep.name} method`, () => {
+        expect(typeof api[ep.method]).toBe('function');
+      });
+    }
+  });
 
   describe('Smart Money Endpoints', () => {
     for (const ep of DOCUMENTED_ENDPOINTS.smartMoney) {
@@ -133,6 +153,14 @@ describe('API Endpoint Coverage', () => {
     }
   });
 
+  describe('Transaction Endpoints', () => {
+    for (const ep of DOCUMENTED_ENDPOINTS.transactions) {
+      it(`should have ${ep.name} method`, () => {
+        expect(typeof api[ep.method]).toBe('function');
+      });
+    }
+  });
+
   describe('Prediction Market Endpoints', () => {
     for (const ep of DOCUMENTED_ENDPOINTS.predictionMarket) {
       it(`should have ${ep.name} method`, () => {
@@ -144,12 +172,14 @@ describe('API Endpoint Coverage', () => {
   describe('Coverage Summary', () => {
     it('should report implemented endpoints', () => {
       const implemented = [
+        ...DOCUMENTED_ENDPOINTS.chains,
         ...DOCUMENTED_ENDPOINTS.smartMoney,
         ...DOCUMENTED_ENDPOINTS.profiler,
         ...DOCUMENTED_ENDPOINTS.tokenGodMode,
         ...DOCUMENTED_ENDPOINTS.composite,
         ...DOCUMENTED_ENDPOINTS.portfolio,
         ...DOCUMENTED_ENDPOINTS.search,
+        ...DOCUMENTED_ENDPOINTS.transactions,
         ...DOCUMENTED_ENDPOINTS.predictionMarket,
       ];
       

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest';
 import { NansenAPI, NansenError } from '../api.js';
-import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from '../commands/research.js';
+import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS, RESEARCH_SUBCOMMANDS } from '../commands/research.js';
 
 const FROM = '2025-01-01';
 const TO = '2025-01-31';
@@ -54,6 +54,25 @@ describe('NansenAPI research (historical) methods', () => {
     expect(options.headers['Content-Type']).toBe('application/json');
     return JSON.parse(options.body);
   }
+
+  it.each([
+    ['chainRank', { timeFrame: 30, chainType: 'evm' }, '/api/v1/chains/chain-rank', 'POST', { time_frame: 30, chain_type: 'evm' }],
+    ['tokenSectors', undefined, '/api/v1/search/token-sectors', 'GET', undefined],
+    ['addressPremiumLabels', { address: ADDRESSES.ethereum, chain: 'ethereum', pagination: { page: 2, per_page: 5 } }, '/api/v1/profiler/address/premium-labels', 'POST', { address: ADDRESSES.ethereum, chain: 'ethereum', pagination: { page: 2, per_page: 5 } }],
+    ['smartMoneyPnlLeaderboard', { chains: ['ethereum'], timeframe: 30, filters: { include_smart_money_labels: ['Fund'] }, orderBy: [{ field: 'total_pnl_usd', direction: 'DESC' }], pagination: { page: 1, per_page: 10 } }, '/api/v1/smart-money/pnl-leaderboard', 'POST', { chains: ['ethereum'], timeframe: 30, filters: { include_smart_money_labels: ['Fund'] }, order_by: [{ field: 'total_pnl_usd', direction: 'DESC' }], pagination: { page: 1, per_page: 10 } }],
+    ['tokenPositionIntelligence', { tokenAddress: 'BTC' }, '/api/v1/tgm/position-intelligence', 'POST', { token_address: 'BTC' }],
+    ['addressPerpPnlSummary', { address: ADDRESSES.ethereum, fromDate: FROM, toDate: TO }, '/api/v1/profiler/perp-pnl-summary', 'POST', { address: ADDRESSES.ethereum, date: { from: FROM, to: TO } }],
+    ['researchHistoricalTokenOhlcv', { tokenAddress: TOKENS.solana, chain: 'solana', fromDate: FROM, asOfDate: TO, timeframe: '1d', applyBlacklistFilter: false }, '/api/v1beta1/tgm/historical-token-ohlcv', 'POST', { token_address: TOKENS.solana, chain: 'solana', date_from: FROM, as_of_date: TO, timeframe: '1d', apply_blacklist_filter: false }],
+    ['transactionWithTokenTransferLookup', { transactionHash: '0xabc123', chain: 'ethereum', blockTimestamp: '2025-01-01 00:00:00' }, '/api/v1/transaction-with-token-transfer-lookup', 'POST', { transaction_hash: '0xabc123', chain: 'ethereum', block_timestamp: '2025-01-01 00:00:00' }],
+  ])('%s uses the exact public endpoint and request shape', async (methodName, params, endpoint, verb, expectedBody) => {
+    setupMock();
+    await api[methodName](params);
+
+    const [url, request] = mockFetch.mock.calls.at(-1);
+    expect(url).toBe(`https://api.nansen.ai${endpoint}`);
+    expect(request.method).toBe(verb);
+    expect(request.body ? JSON.parse(request.body) : undefined).toEqual(expectedBody);
+  });
 
   describe('researchDexTrades', () => {
     it('hits historical-dex-trades with token_address, chain, and date_range {from,to}', async () => {
@@ -270,11 +289,36 @@ describe('buildResearchCommands handler', () => {
       researchWalletBalances: vi.fn().mockResolvedValue({ data: [] }),
       researchTxLookup: vi.fn().mockResolvedValue({ data: [] }),
       researchWalletTransactions: vi.fn().mockResolvedValue({ data: [] }),
+      chainRank: vi.fn().mockResolvedValue({ data: [] }),
+      tokenSectors: vi.fn().mockResolvedValue({ data: [] }),
+      addressPremiumLabels: vi.fn().mockResolvedValue({ data: [] }),
+      smartMoneyPnlLeaderboard: vi.fn().mockResolvedValue({ data: [] }),
+      tokenPositionIntelligence: vi.fn().mockResolvedValue({ data: [] }),
+      addressPerpPnlSummary: vi.fn().mockResolvedValue({ data: [] }),
+      researchHistoricalTokenOhlcv: vi.fn().mockResolvedValue({ data: [] }),
+      transactionWithTokenTransferLookup: vi.fn().mockResolvedValue({ data: [] }),
     };
   }
 
-  it('exports all 11 subcommands', () => {
-    expect(RESEARCH_HISTORICAL_SUBCOMMANDS.size).toBe(11);
+  it('exports all direct and historical subcommands', () => {
+    expect(RESEARCH_SUBCOMMANDS.size).toBe(19);
+    expect(RESEARCH_HISTORICAL_SUBCOMMANDS.size).toBe(12);
+  });
+
+  it.each([
+    ['chain-rank', 'chainRank', { 'timeframe-days': '30', 'chain-type': 'evm' }, { timeFrame: 30, chainType: 'evm' }],
+    ['token-sectors', 'tokenSectors', {}, undefined],
+    ['address-premium-labels', 'addressPremiumLabels', { address: ADDRESSES.ethereum, chain: 'ethereum', page: '2', limit: '5' }, { address: ADDRESSES.ethereum, chain: 'ethereum', pagination: { page: 2, per_page: 5 } }],
+    ['smart-money-pnl-leaderboard', 'smartMoneyPnlLeaderboard', { chains: 'ethereum,solana', 'timeframe-days': '30' }, { chains: ['ethereum', 'solana'], timeframe: 30 }],
+    ['position-intelligence', 'tokenPositionIntelligence', { symbol: 'BTC' }, { tokenAddress: 'BTC' }],
+    ['perp-pnl-summary', 'addressPerpPnlSummary', { address: ADDRESSES.ethereum, 'from-date': FROM, 'to-date': TO }, { address: ADDRESSES.ethereum, fromDate: FROM, toDate: TO }],
+    ['historical-token-ohlcv', 'researchHistoricalTokenOhlcv', { 'token-address': TOKENS.solana, chain: 'solana', 'from-date': FROM, 'as-of-date': TO, timeframe: '1d', 'apply-blacklist-filter': 'false' }, { tokenAddress: TOKENS.solana, chain: 'solana', fromDate: FROM, asOfDate: TO, timeframe: '1d', applyBlacklistFilter: false }],
+    ['transaction-with-token-transfer-lookup', 'transactionWithTokenTransferLookup', { 'transaction-hash': '0xabc', chain: 'ethereum' }, { transactionHash: '0xabc', chain: 'ethereum' }],
+  ])('dispatches %s', async (subcommand, methodName, options, expected) => {
+    mockApi = makeMockApi();
+    await cmds.research([subcommand], mockApi, {}, options);
+    if (expected === undefined) expect(mockApi[methodName]).toHaveBeenCalledWith();
+    else expect(mockApi[methodName]).toHaveBeenCalledWith(expect.objectContaining(expected));
   });
 
   it('rejects unknown subcommand', async () => {
@@ -424,6 +468,30 @@ describe('buildResearchCommands handler', () => {
     mockApi = makeMockApi();
     await expect(cmds.research(['historical-token-screener'], mockApi, {}, { chains: 'solana' }))
       .rejects.toThrow(/timeframe-days/);
+  });
+
+  it('requires exactly one historical OHLCV snapshot anchor', async () => {
+    mockApi = makeMockApi();
+    const options = { 'token-address': TOKENS.solana, 'from-date': FROM, timeframe: '1d' };
+    await expect(cmds.research(['historical-token-ohlcv'], mockApi, {}, options))
+      .rejects.toThrow(/exactly one/);
+    await expect(cmds.research(['historical-token-ohlcv'], mockApi, {}, {
+      ...options, 'as-of-date': TO, 'as-of-ts': `${TO}T00:00:00Z`,
+    })).rejects.toThrow(/exactly one/);
+  });
+
+  it('rejects an invalid pagination limit', async () => {
+    mockApi = makeMockApi();
+    await expect(cmds.research(['address-premium-labels'], mockApi, {}, {
+      address: ADDRESSES.ethereum, limit: '5x',
+    })).rejects.toThrow(/positive integer/);
+  });
+
+  it('requires a block timestamp for non-EVM transaction lookup chains', async () => {
+    mockApi = makeMockApi();
+    await expect(cmds.research(['transaction-with-token-transfer-lookup'], mockApi, {}, {
+      'transaction-hash': 'abc', chain: 'bitcoin',
+    })).rejects.toThrow(/block-timestamp/);
   });
 
   it('rejects --page/--limit on historical-token-flow-summary', async () => {

--- a/src/api.js
+++ b/src/api.js
@@ -834,6 +834,16 @@ export class NansenAPI {
     return this.request('/api/v1/account', {}, { method: 'GET', cache: false });
   }
 
+  // ============= Chain Endpoints =============
+
+  async chainRank(params = {}) {
+    const { timeFrame = 7, chainType = 'all' } = params;
+    return this.request('/api/v1/chains/chain-rank', {
+      time_frame: timeFrame,
+      chain_type: chainType
+    });
+  }
+
   // ============= Smart Money Endpoints =============
   
   async smartMoneyNetflow(params = {}) {
@@ -896,6 +906,17 @@ export class NansenAPI {
     });
   }
 
+  async smartMoneyPnlLeaderboard(params = {}) {
+    const { chains = ['solana'], timeframe = 7, filters = {}, orderBy, pagination } = params;
+    return this.request('/api/v1/smart-money/pnl-leaderboard', {
+      chains,
+      timeframe,
+      filters,
+      order_by: orderBy,
+      pagination
+    });
+  }
+
   // ============= Profiler Endpoints =============
 
   async addressBalance(params = {}) {
@@ -915,6 +936,16 @@ export class NansenAPI {
     const { address, chain = 'ethereum', pagination = { page: 1, per_page: 100 } } = params;
     if (address) requireValidAddress(address, chain);
     return this.request('/api/v1/profiler/address/labels', {
+      address,
+      chain,
+      pagination
+    });
+  }
+
+  async addressPremiumLabels(params = {}) {
+    const { address, chain = 'all', pagination = { page: 1, per_page: 100 } } = params;
+    if (address) requireValidAddress(address, chain);
+    return this.request('/api/v1/profiler/address/premium-labels', {
       address,
       chain,
       pagination
@@ -968,6 +999,10 @@ export class NansenAPI {
     };
     if (chain) body.chain = chain;
     return this.request('/api/v1/search/general', body);
+  }
+
+  async tokenSectors() {
+    return this.request('/api/v1/search/token-sectors', {}, { method: 'GET' });
   }
 
   async webSearch(params = {}) {
@@ -1089,6 +1124,24 @@ export class NansenAPI {
       filters,
       order_by: orderBy,
       pagination
+    });
+  }
+
+  async addressPerpPnlSummary(params = {}) {
+    const { address, fromDate, toDate } = params;
+    if (address) requireValidAddress(address, 'ethereum');
+    return this.request('/api/v1/profiler/perp-pnl-summary', {
+      address,
+      date: { from: fromDate, to: toDate }
+    });
+  }
+
+  async transactionWithTokenTransferLookup(params = {}) {
+    const { chain = 'ethereum', transactionHash, blockTimestamp } = params;
+    return this.request('/api/v1/transaction-with-token-transfer-lookup', {
+      chain,
+      transaction_hash: transactionHash,
+      block_timestamp: blockTimestamp
     });
   }
 
@@ -1237,6 +1290,13 @@ export class NansenAPI {
       filters,
       order_by: orderBy,
       pagination
+    });
+  }
+
+  async tokenPositionIntelligence(params = {}) {
+    const { tokenAddress } = params;
+    return this.request('/api/v1/tgm/position-intelligence', {
+      token_address: tokenAddress
     });
   }
 
@@ -1629,6 +1689,20 @@ export class NansenAPI {
       filters,
       order_by: orderBy,
       pagination,
+    });
+  }
+
+  async researchHistoricalTokenOhlcv(params = {}) {
+    const { chain = 'solana', tokenAddress, fromDate, asOfDate, asOfTs, timeframe, applyBlacklistFilter } = params;
+    if (tokenAddress) requireValidToken(tokenAddress, chain);
+    return this.request('/api/v1beta1/tgm/historical-token-ohlcv', {
+      chain,
+      token_address: tokenAddress,
+      date_from: fromDate,
+      as_of_date: asOfDate,
+      as_of_ts: asOfTs,
+      timeframe,
+      apply_blacklist_filter: applyBlacklistFilter
     });
   }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,7 +12,7 @@ import { buildLimitOrderCommands } from './limit-order.js';
 import { formatAlertsTable, buildAlertsCommands } from './commands/alerts.js';
 import { buildAgentCommands } from './commands/agent.js';
 import { buildMcpCommands } from './commands/mcp.js';
-import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from './commands/research.js';
+import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS, RESEARCH_SUBCOMMANDS } from './commands/research.js';
 import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
@@ -1638,18 +1638,19 @@ export function buildCommands(deps = {}) {
     if (!rawCategory || rawCategory === 'help') {
       return {
         categories: [...RESEARCH_CATEGORIES],
+        subcommands: [...RESEARCH_SUBCOMMANDS],
         historical: [...RESEARCH_HISTORICAL_SUBCOMMANDS],
         aliases: RESEARCH_CATEGORY_ALIASES,
         description: 'Research and analytics commands',
         example: 'nansen research smart-money netflow --chain solana'
       };
     }
-    if (RESEARCH_HISTORICAL_SUBCOMMANDS.has(rawCategory)) {
+    if (RESEARCH_SUBCOMMANDS.has(rawCategory)) {
       return researchHistorical(args, apiInstance, flags, options);
     }
     const category = RESEARCH_CATEGORY_ALIASES[rawCategory] || rawCategory;
     if (!RESEARCH_CATEGORIES.has(category)) {
-      throw new NansenError(`Unknown research category: ${rawCategory}. Available: ${[...RESEARCH_CATEGORIES, ...RESEARCH_HISTORICAL_SUBCOMMANDS].join(', ')}`, ErrorCode.UNKNOWN);
+      throw new NansenError(`Unknown research category: ${rawCategory}. Available: ${[...RESEARCH_CATEGORIES, ...RESEARCH_SUBCOMMANDS].join(', ')}`, ErrorCode.UNKNOWN);
     }
     // `research perp` reaches only the analytics half (screener/leaderboard) —
     // the trading subcommands live at the top level. Routing its help through

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -1,19 +1,21 @@
 /**
  * Nansen CLI - Research command
  *
- * Historical/point-in-time analytics. Each subcommand resolves labels and
- * metrics at the requested date rather than current state — useful for
- * backtesting and historical research.
+ * Direct API analytics, including historical/point-in-time research.
  */
 
 import { NansenError, ErrorCode } from '../api.js';
 
 // Local copies of CLI helpers to avoid a circular import with src/cli.js.
 function buildPagination(options) {
-  if (!options.limit && !options.page) return undefined;
+  if (options.limit === undefined && options.page === undefined) return undefined;
+  const perPage = options.limit === undefined ? undefined : Number(options.limit);
+  if (perPage !== undefined && (!Number.isInteger(perPage) || perPage < 1)) {
+    throw new NansenError('--limit must be a positive integer', ErrorCode.INVALID_PARAMS);
+  }
   return {
     page: Math.max(1, parseInt(options.page, 10) || 1),
-    per_page: options.limit,
+    per_page: perPage,
   };
 }
 
@@ -26,7 +28,7 @@ function parseSort(sortOption, orderByOption) {
   return [{ field, direction }];
 }
 
-const SUBCOMMANDS = [
+const HISTORICAL_SUBCOMMANDS = [
   'historical-dex-trades',
   'historical-pnl-leaderboard',
   'historical-token-flow-summary',
@@ -38,9 +40,23 @@ const SUBCOMMANDS = [
   'historical-wallet-balances',
   'historical-tx-lookup',
   'historical-wallet-transactions',
+  'historical-token-ohlcv',
 ];
 
-export const RESEARCH_HISTORICAL_SUBCOMMANDS = new Set(SUBCOMMANDS);
+const PUBLIC_API_SUBCOMMANDS = [
+  'chain-rank',
+  'token-sectors',
+  'address-premium-labels',
+  'smart-money-pnl-leaderboard',
+  'position-intelligence',
+  'perp-pnl-summary',
+  'transaction-with-token-transfer-lookup',
+];
+
+const SUBCOMMANDS = [...PUBLIC_API_SUBCOMMANDS, ...HISTORICAL_SUBCOMMANDS];
+
+export const RESEARCH_SUBCOMMANDS = new Set(SUBCOMMANDS);
+export const RESEARCH_HISTORICAL_SUBCOMMANDS = new Set(HISTORICAL_SUBCOMMANDS);
 
 function requireOptions(options, required) {
   const missing = required.filter(name => !options[name]);
@@ -65,6 +81,15 @@ function parseTimeframeDays(value) {
   return n;
 }
 
+function parseBooleanOption(options, flags, key) {
+  const value = options[key] ?? flags[key];
+  if (value === undefined) return undefined;
+  if (typeof value === 'boolean') return value;
+  if (value === 'true' || value === '1') return true;
+  if (value === 'false' || value === '0') return false;
+  throw new NansenError(`--${key} must be true or false`, ErrorCode.INVALID_PARAMS);
+}
+
 function parseChains(options) {
   if (options.chains) {
     return Array.isArray(options.chains)
@@ -75,9 +100,17 @@ function parseChains(options) {
   return undefined;
 }
 
-const HELP_TOP = `nansen research — Historical/point-in-time analytics
+const HELP_TOP = `nansen research — Direct API analytics
 
 SUBCOMMANDS:
+  chain-rank                       Rank chains by growth metrics
+  token-sectors                    List token sectors available for filtering
+  address-premium-labels           Get all labels for an address, including premium labels
+  smart-money-pnl-leaderboard      Rank smart money wallets by PnL
+  position-intelligence            Aggregate Hyperliquid positions by trader cohort
+  perp-pnl-summary                 Summarize realized Hyperliquid PnL for an address
+  transaction-with-token-transfer-lookup
+                                   Look up a transaction and its token/NFT transfers
   historical-dex-trades             Historical DEX trades for a token
   historical-pnl-leaderboard        Historical PnL leaderboard for a token
   historical-token-flow-summary     Historical token flow summary
@@ -89,6 +122,7 @@ SUBCOMMANDS:
   historical-wallet-balances        Historical token balances for a wallet
   historical-tx-lookup              Lookup a historical transaction by hash
   historical-wallet-transactions    Historical transactions for a wallet
+  historical-token-ohlcv            Historical token OHLCV candles
 
 COMMON OPTIONS:
   --from-date <YYYY-MM-DD>   Start of date range (for range-based subcommands)
@@ -102,6 +136,36 @@ COMMON OPTIONS:
 Run: nansen research <subcommand> --help`;
 
 const SUB_HELP = {
+  'chain-rank': `nansen research chain-rank — Rank chains by growth metrics
+
+USAGE:
+  nansen research chain-rank [--timeframe-days 7|30|365] [--chain-type all|evm]`,
+  'token-sectors': `nansen research token-sectors — List token sectors available for filtering
+
+USAGE:
+  nansen research token-sectors`,
+  'address-premium-labels': `nansen research address-premium-labels — Get all labels for an address, including premium labels
+
+USAGE:
+  nansen research address-premium-labels --address <addr> [--chain <chain>] [--page <n>] [--limit <n>]`,
+  'smart-money-pnl-leaderboard': `nansen research smart-money-pnl-leaderboard — Rank smart money wallets by PnL
+
+USAGE:
+  nansen research smart-money-pnl-leaderboard [--chains c1,c2] [--timeframe-days 1|7|30|90|180] [--filters '<json>'] [--sort <field[:asc|desc]>] [--page <n>] [--limit <n>]`,
+  'position-intelligence': `nansen research position-intelligence — Aggregate Hyperliquid positions by trader cohort
+
+USAGE:
+  nansen research position-intelligence --symbol <symbol>`,
+  'perp-pnl-summary': `nansen research perp-pnl-summary — Summarize realized Hyperliquid PnL for an address
+
+USAGE:
+  nansen research perp-pnl-summary --address <addr> --from-date <date> --to-date <date>`,
+  'transaction-with-token-transfer-lookup': `nansen research transaction-with-token-transfer-lookup — Look up a transaction and its token/NFT transfers
+
+USAGE:
+  nansen research transaction-with-token-transfer-lookup --transaction-hash <hash> [--chain <chain>] [--block-timestamp "YYYY-MM-DD HH:MM:SS"]
+
+NOTE: --block-timestamp is required for bitcoin, tron, ton, starknet, and sui.`,
   'historical-dex-trades': `nansen research historical-dex-trades — Historical DEX trades for a token
 
 USAGE:
@@ -152,6 +216,10 @@ NOTE: Providing --block-timestamp skips a slow hash-resolution step and returns 
 
 USAGE:
   nansen research historical-wallet-transactions --address <addr> --as-of-date <YYYY-MM-DD> [--chain <chain>]`,
+  'historical-token-ohlcv': `nansen research historical-token-ohlcv — Historical token OHLCV candles
+
+USAGE:
+  nansen research historical-token-ohlcv --token-address <addr> --from-date <date> --timeframe <5m|15m|30m|1h|1d|1w> (--as-of-date <date> | --as-of-ts <timestamp>) [--chain <chain>] [--apply-blacklist-filter <true|false>]`,
 };
 
 export function buildResearchCommands(deps = {}) {
@@ -166,7 +234,7 @@ export function buildResearchCommands(deps = {}) {
         return;
       }
 
-      if (!RESEARCH_HISTORICAL_SUBCOMMANDS.has(sub)) {
+      if (!RESEARCH_SUBCOMMANDS.has(sub)) {
         throw new NansenError(
           `Unknown research subcommand: ${sub}. Available: ${SUBCOMMANDS.join(', ')}`,
           ErrorCode.UNKNOWN,
@@ -183,6 +251,83 @@ export function buildResearchCommands(deps = {}) {
       const filters = options.filters || {};
       const { fromDate, toDate } = resolveDateRange(options);
       const asOfDate = options['as-of-date'];
+
+      if (sub === 'chain-rank') {
+        return apiInstance.chainRank({
+          timeFrame: parseTimeframeDays(options['timeframe-days']) ?? 7,
+          chainType: options['chain-type'] || 'all',
+        });
+      }
+
+      if (sub === 'token-sectors') return apiInstance.tokenSectors();
+
+      if (sub === 'address-premium-labels') {
+        requireOptions({ address: options.address }, ['address']);
+        return apiInstance.addressPremiumLabels({
+          address: options.address,
+          chain: options.chain || 'all',
+          pagination,
+        });
+      }
+
+      if (sub === 'smart-money-pnl-leaderboard') {
+        return apiInstance.smartMoneyPnlLeaderboard({
+          chains: parseChains(options) || ['solana'],
+          timeframe: parseTimeframeDays(options['timeframe-days']) ?? 7,
+          filters, orderBy, pagination,
+        });
+      }
+
+      if (sub === 'position-intelligence') {
+        const symbol = options.symbol || options['token-address'] || options.token;
+        requireOptions({ symbol }, ['symbol']);
+        return apiInstance.tokenPositionIntelligence({ tokenAddress: symbol });
+      }
+
+      if (sub === 'perp-pnl-summary') {
+        requireOptions(
+          { address: options.address, 'from-date': fromDate, 'to-date': toDate },
+          ['address', 'from-date', 'to-date'],
+        );
+        return apiInstance.addressPerpPnlSummary({ address: options.address, fromDate, toDate });
+      }
+
+      if (sub === 'transaction-with-token-transfer-lookup') {
+        const chain = options.chain || 'ethereum';
+        const blockTimestamp = options['block-timestamp'];
+        requireOptions({ 'transaction-hash': options['transaction-hash'] }, ['transaction-hash']);
+        if (['bitcoin', 'tron', 'ton', 'starknet', 'sui'].includes(chain)) {
+          requireOptions({ 'block-timestamp': blockTimestamp }, ['block-timestamp']);
+        }
+        return apiInstance.transactionWithTokenTransferLookup({
+          transactionHash: options['transaction-hash'],
+          chain,
+          blockTimestamp,
+        });
+      }
+
+      if (sub === 'historical-token-ohlcv') {
+        const asOfTs = options['as-of-ts'];
+        requireOptions(
+          { 'token-address': options['token-address'] || options.token, 'from-date': fromDate, timeframe: options.timeframe },
+          ['token-address', 'from-date', 'timeframe'],
+        );
+        if (Boolean(asOfDate) === Boolean(asOfTs)) {
+          throw new NansenError(
+            'Provide exactly one of --as-of-date or --as-of-ts',
+            ErrorCode.INVALID_PARAMS,
+          );
+        }
+        return apiInstance.researchHistoricalTokenOhlcv({
+          tokenAddress: options['token-address'] || options.token,
+          chain: options.chain || 'solana',
+          fromDate,
+          asOfDate,
+          asOfTs,
+          timeframe: options.timeframe,
+          applyBlacklistFilter: parseBooleanOption(options, flags, 'apply-blacklist-filter'),
+        });
+      }
 
       // Range-based token endpoints (require --from-date + --to-date)
       const rangeTokenHandlers = {

--- a/src/schema.json
+++ b/src/schema.json
@@ -1162,6 +1162,127 @@
             }
           }
         },
+        "chain-rank": {
+          "endpoint": "/api/v1/chains/chain-rank",
+          "description": "Rank chains by growth metrics",
+          "options": {
+            "timeframe-days": {
+              "type": "number",
+              "enum": [7, 30, 365],
+              "default": 7
+            },
+            "chain-type": {
+              "enum": ["all", "evm"],
+              "default": "all"
+            }
+          }
+        },
+        "token-sectors": {
+          "endpoint": "/api/v1/search/token-sectors",
+          "description": "List token sectors available for filtering"
+        },
+        "address-premium-labels": {
+          "endpoint": "/api/v1/profiler/address/premium-labels",
+          "description": "Get all labels for an address, including premium labels",
+          "options": {
+            "address": {
+              "required": true
+            },
+            "chain": {
+              "default": "all"
+            }
+          }
+        },
+        "smart-money-pnl-leaderboard": {
+          "endpoint": "/api/v1/smart-money/pnl-leaderboard",
+          "description": "Rank smart money wallets by PnL",
+          "options": {
+            "chains": {
+              "default": "solana",
+              "description": "Comma-separated chains"
+            },
+            "timeframe-days": {
+              "type": "number",
+              "enum": [1, 7, 30, 90, 180],
+              "default": 7
+            }
+          }
+        },
+        "position-intelligence": {
+          "endpoint": "/api/v1/tgm/position-intelligence",
+          "description": "Aggregate Hyperliquid positions by trader cohort",
+          "options": {
+            "symbol": {
+              "required": true,
+              "description": "Hyperliquid asset symbol"
+            }
+          }
+        },
+        "perp-pnl-summary": {
+          "endpoint": "/api/v1/profiler/perp-pnl-summary",
+          "description": "Summarize realized Hyperliquid PnL for an address",
+          "options": {
+            "address": {
+              "required": true
+            },
+            "from-date": {
+              "required": true,
+              "description": "Start of date range"
+            },
+            "to-date": {
+              "required": true,
+              "description": "End of date range"
+            }
+          }
+        },
+        "historical-token-ohlcv": {
+          "endpoint": "/api/v1beta1/tgm/historical-token-ohlcv",
+          "description": "Historical token OHLCV candles",
+          "options": {
+            "token-address": {
+              "required": true,
+              "description": "Token address or Hyperliquid asset symbol"
+            },
+            "chain": {
+              "enum": ["base", "bnb", "ethereum", "hyperliquid", "solana"],
+              "default": "solana"
+            },
+            "from-date": {
+              "required": true,
+              "description": "Start of data window"
+            },
+            "as-of-date": {
+              "description": "End of data window; mutually exclusive with --as-of-ts"
+            },
+            "as-of-ts": {
+              "description": "Exact Hyperliquid cutoff; mutually exclusive with --as-of-date"
+            },
+            "timeframe": {
+              "required": true,
+              "enum": ["5m", "15m", "30m", "1h", "1d", "1w"]
+            },
+            "apply-blacklist-filter": {
+              "type": "boolean",
+              "description": "Apply blacklist filtering for 1d/1w non-Hyperliquid requests"
+            }
+          }
+        },
+        "transaction-with-token-transfer-lookup": {
+          "endpoint": "/api/v1/transaction-with-token-transfer-lookup",
+          "description": "Look up a transaction and its token/NFT transfers",
+          "options": {
+            "transaction-hash": {
+              "required": true
+            },
+            "chain": {
+              "enum": ["all", "arbitrum", "avalanche", "base", "bitcoin", "bnb", "ethereum", "hyperevm", "injective", "iotaevm", "linea", "mantle", "mantra", "monad", "near", "optimism", "plasma", "robinhood", "sei", "sonic", "starknet", "sui", "ton", "tron"],
+              "default": "ethereum"
+            },
+            "block-timestamp": {
+              "description": "Block timestamp (required for bitcoin, tron, ton, starknet, and sui)"
+            }
+          }
+        },
         "historical-dex-trades": {
           "endpoint": "/api/v1beta1/tgm/historical-dex-trades",
           "description": "Historical DEX trades for a token at a point in time",


### PR DESCRIPTION
## Summary

- expose eight public API endpoints as direct `nansen research` subcommands
- document command options and endpoint-specific constraints in the CLI schema and README
- add mocked exact-path/request-shape coverage and refresh the endpoint inventory

## Validation

- `npm test -- --reporter=dot` — 2,571 passed, 2 skipped
- `npm run lint`
- `git diff --check`