### PR TITLE
Add chain-rank research command

### DIFF
--- a/.changeset/research-chain-rank.md
+++ b/.changeset/research-chain-rank.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add the `nansen research chain-rank` command.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ nansen schema [command] [--pretty]    # full command reference (no API key neede
 
 **Research categories:** `smart-money` (`sm`), `token` (`tgm`), `profiler` (`prof`), `portfolio` (`port`), `prediction-market` (`pm`), `search`, `perp`, `points`
 
+**Direct research subcommand:** `chain-rank`
+
 **Trade:** `quote`, `execute`, `bridge-status`, `limit-order` — DEX swaps on Solana and Base, cross-chain bridges, and Solana limit orders.
 
 **Wallet:** `create`, `list`, `show`, `export`, `default`, `delete`, `send` — local or Privy server-side wallets (EVM + Solana).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ nansen schema [command] [--pretty]    # full command reference (no API key neede
 
 **Research categories:** `smart-money` (`sm`), `token` (`tgm`), `profiler` (`prof`), `portfolio` (`port`), `prediction-market` (`pm`), `search`, `perp`, `points`
 
-**Direct research subcommand:** `chain-rank`
+**Direct research subcommand:** `nansen research chain-rank [--timeframe-days 7|30|365] [--chain-type all|evm]`
 
 **Trade:** `quote`, `execute`, `bridge-status`, `limit-order` — DEX swaps on Solana and Base, cross-chain bridges, and Solana limit orders.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -950,9 +950,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -970,9 +967,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -990,9 +984,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1010,9 +1001,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1030,9 +1018,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1050,9 +1035,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2737,9 +2719,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2761,9 +2740,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2785,9 +2761,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2809,9 +2782,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -950,6 +950,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -967,6 +970,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -984,6 +990,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1001,6 +1010,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1018,6 +1030,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,6 +1050,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2719,6 +2737,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2740,6 +2761,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2761,6 +2785,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2782,6 +2809,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/__tests__/coverage.test.js
+++ b/src/__tests__/coverage.test.js
@@ -10,6 +10,9 @@ import { batchProfile, traceCounterparties, compareWallets } from '../cli.js';
 
 // All documented endpoints from Nansen API
 const DOCUMENTED_ENDPOINTS = {
+  chains: [
+    { name: 'chain-rank', method: 'chainRank', endpoint: '/api/v1/chains/chain-rank' },
+  ],
   smartMoney: [
     { name: 'netflow', method: 'smartMoneyNetflow', endpoint: '/api/v1/smart-money/netflow' },
     { name: 'holdings', method: 'smartMoneyHoldings', endpoint: '/api/v1/smart-money/holdings' },
@@ -85,6 +88,14 @@ const NOT_IMPLEMENTED = [
 describe('API Endpoint Coverage', () => {
   const api = new NansenAPI('test-key');
 
+  describe('Chain Endpoints', () => {
+    for (const ep of DOCUMENTED_ENDPOINTS.chains) {
+      it(`should have ${ep.name} method`, () => {
+        expect(typeof api[ep.method]).toBe('function');
+      });
+    }
+  });
+
   describe('Smart Money Endpoints', () => {
     for (const ep of DOCUMENTED_ENDPOINTS.smartMoney) {
       it(`should have ${ep.name} method`, () => {
@@ -144,6 +155,7 @@ describe('API Endpoint Coverage', () => {
   describe('Coverage Summary', () => {
     it('should report implemented endpoints', () => {
       const implemented = [
+        ...DOCUMENTED_ENDPOINTS.chains,
         ...DOCUMENTED_ENDPOINTS.smartMoney,
         ...DOCUMENTED_ENDPOINTS.profiler,
         ...DOCUMENTED_ENDPOINTS.tokenGodMode,

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -294,6 +294,20 @@ describe('buildResearchCommands handler', () => {
     expect(mockApi.chainRank).toHaveBeenCalledWith({ timeFrame: 30, chainType: 'evm' });
   });
 
+  it('rejects chain-rank with a timeframe outside 7/30/365', async () => {
+    mockApi = makeMockApi();
+    await expect(cmds.research(['chain-rank'], mockApi, {}, { 'timeframe-days': '99' }))
+      .rejects.toThrow('--timeframe-days must be one of: 7, 30, 365');
+    expect(mockApi.chainRank).not.toHaveBeenCalled();
+  });
+
+  it('rejects chain-rank with an unknown chain type', async () => {
+    mockApi = makeMockApi();
+    await expect(cmds.research(['chain-rank'], mockApi, {}, { 'chain-type': 'solana' }))
+      .rejects.toThrow('--chain-type must be one of: all, evm');
+    expect(mockApi.chainRank).not.toHaveBeenCalled();
+  });
+
   it('rejects unknown subcommand', async () => {
     mockApi = makeMockApi();
     await expect(cmds.research(['not-a-real-sub'], mockApi, {}, {}))

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest';
 import { NansenAPI, NansenError } from '../api.js';
-import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from '../commands/research.js';
+import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS, RESEARCH_SUBCOMMANDS } from '../commands/research.js';
 
 const FROM = '2025-01-01';
 const TO = '2025-01-31';
@@ -54,6 +54,13 @@ describe('NansenAPI research (historical) methods', () => {
     expect(options.headers['Content-Type']).toBe('application/json');
     return JSON.parse(options.body);
   }
+
+  it('uses the chain-rank endpoint and request shape', async () => {
+    setupMock();
+    await api.chainRank({ timeFrame: 30, chainType: 'evm' });
+    const body = lastCall('/api/v1/chains/chain-rank');
+    expect(body).toEqual({ time_frame: 30, chain_type: 'evm' });
+  });
 
   describe('researchDexTrades', () => {
     it('hits historical-dex-trades with token_address, chain, and date_range {from,to}', async () => {
@@ -270,11 +277,21 @@ describe('buildResearchCommands handler', () => {
       researchWalletBalances: vi.fn().mockResolvedValue({ data: [] }),
       researchTxLookup: vi.fn().mockResolvedValue({ data: [] }),
       researchWalletTransactions: vi.fn().mockResolvedValue({ data: [] }),
+      chainRank: vi.fn().mockResolvedValue({ data: [] }),
     };
   }
 
-  it('exports all 11 subcommands', () => {
+  it('exports historical and direct subcommands', () => {
     expect(RESEARCH_HISTORICAL_SUBCOMMANDS.size).toBe(11);
+    expect(RESEARCH_SUBCOMMANDS.size).toBe(12);
+  });
+
+  it('dispatches chain-rank', async () => {
+    mockApi = makeMockApi();
+    await cmds.research(['chain-rank'], mockApi, {}, {
+      'timeframe-days': '30', 'chain-type': 'evm',
+    });
+    expect(mockApi.chainRank).toHaveBeenCalledWith({ timeFrame: 30, chainType: 'evm' });
   });
 
   it('rejects unknown subcommand', async () => {

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -301,6 +301,15 @@ describe('buildResearchCommands handler', () => {
     expect(mockApi.chainRank).not.toHaveBeenCalled();
   });
 
+  it('rejects non-integer --timeframe-days values', async () => {
+    mockApi = makeMockApi();
+    for (const value of ['30.5', '30abc', '-7', '0']) {
+      await expect(cmds.research(['chain-rank'], mockApi, {}, { 'timeframe-days': value }))
+        .rejects.toThrow('--timeframe-days must be a positive integer');
+    }
+    expect(mockApi.chainRank).not.toHaveBeenCalled();
+  });
+
   it('rejects chain-rank with an unknown chain type', async () => {
     mockApi = makeMockApi();
     await expect(cmds.research(['chain-rank'], mockApi, {}, { 'chain-type': 'solana' }))

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -310,6 +310,23 @@ describe('buildResearchCommands handler', () => {
     expect(mockApi.chainRank).not.toHaveBeenCalled();
   });
 
+  it('rejects --timeframe-days 0 on historical-token-screener (API requires at least 1)', async () => {
+    mockApi = makeMockApi();
+    await expect(cmds.research(['historical-token-screener'], mockApi, {}, {
+      'timeframe-days': '0', 'to-date': TO,
+    })).rejects.toThrow('--timeframe-days must be a positive integer');
+    expect(mockApi.researchTokenScreener).not.toHaveBeenCalled();
+  });
+
+  it('prints chain-rank help without calling the API', async () => {
+    mockApi = makeMockApi();
+    const logged = [];
+    const helpCmds = buildResearchCommands({ log: line => logged.push(line) });
+    await helpCmds.research(['chain-rank', 'help'], mockApi, {}, {});
+    expect(logged.join('\n')).toContain('nansen research chain-rank');
+    expect(mockApi.chainRank).not.toHaveBeenCalled();
+  });
+
   it('rejects chain-rank with an unknown chain type', async () => {
     mockApi = makeMockApi();
     await expect(cmds.research(['chain-rank'], mockApi, {}, { 'chain-type': 'solana' }))

--- a/src/api.js
+++ b/src/api.js
@@ -834,6 +834,16 @@ export class NansenAPI {
     return this.request('/api/v1/account', {}, { method: 'GET', cache: false });
   }
 
+  // ============= Chain Endpoints =============
+
+  async chainRank(params = {}) {
+    const { timeFrame = 7, chainType = 'all' } = params;
+    return this.request('/api/v1/chains/chain-rank', {
+      time_frame: timeFrame,
+      chain_type: chainType
+    });
+  }
+
   // ============= Smart Money Endpoints =============
   
   async smartMoneyNetflow(params = {}) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,7 +12,7 @@ import { buildLimitOrderCommands } from './limit-order.js';
 import { formatAlertsTable, buildAlertsCommands } from './commands/alerts.js';
 import { buildAgentCommands } from './commands/agent.js';
 import { buildMcpCommands } from './commands/mcp.js';
-import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from './commands/research.js';
+import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS, RESEARCH_SUBCOMMANDS } from './commands/research.js';
 import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
@@ -1638,18 +1638,19 @@ export function buildCommands(deps = {}) {
     if (!rawCategory || rawCategory === 'help') {
       return {
         categories: [...RESEARCH_CATEGORIES],
+        subcommands: [...RESEARCH_SUBCOMMANDS],
         historical: [...RESEARCH_HISTORICAL_SUBCOMMANDS],
         aliases: RESEARCH_CATEGORY_ALIASES,
         description: 'Research and analytics commands',
         example: 'nansen research smart-money netflow --chain solana'
       };
     }
-    if (RESEARCH_HISTORICAL_SUBCOMMANDS.has(rawCategory)) {
+    if (RESEARCH_SUBCOMMANDS.has(rawCategory)) {
       return researchHistorical(args, apiInstance, flags, options);
     }
     const category = RESEARCH_CATEGORY_ALIASES[rawCategory] || rawCategory;
     if (!RESEARCH_CATEGORIES.has(category)) {
-      throw new NansenError(`Unknown research category: ${rawCategory}. Available: ${[...RESEARCH_CATEGORIES, ...RESEARCH_HISTORICAL_SUBCOMMANDS].join(', ')}`, ErrorCode.UNKNOWN);
+      throw new NansenError(`Unknown research category: ${rawCategory}. Available: ${[...RESEARCH_CATEGORIES, ...RESEARCH_SUBCOMMANDS].join(', ')}`, ErrorCode.UNKNOWN);
     }
     // `research perp` reaches only the analytics half (screener/leaderboard) —
     // the trading subcommands live at the top level. Routing its help through

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -41,6 +41,9 @@ const SUBCOMMANDS = [
 export const RESEARCH_HISTORICAL_SUBCOMMANDS = new Set(SUBCOMMANDS);
 export const RESEARCH_SUBCOMMANDS = new Set(['chain-rank', ...SUBCOMMANDS]);
 
+const CHAIN_RANK_TIMEFRAMES = new Set([7, 30, 365]);
+const CHAIN_RANK_CHAIN_TYPES = new Set(['all', 'evm']);
+
 function requireOptions(options, required) {
   const missing = required.filter(name => !options[name]);
   if (missing.length > 0) {
@@ -189,10 +192,21 @@ export function buildResearchCommands(deps = {}) {
       const asOfDate = options['as-of-date'];
 
       if (sub === 'chain-rank') {
-        return apiInstance.chainRank({
-          timeFrame: parseTimeframeDays(options['timeframe-days']) ?? 7,
-          chainType: options['chain-type'] || 'all',
-        });
+        const timeFrame = parseTimeframeDays(options['timeframe-days']) ?? 7;
+        if (!CHAIN_RANK_TIMEFRAMES.has(timeFrame)) {
+          throw new NansenError(
+            `--timeframe-days must be one of: ${[...CHAIN_RANK_TIMEFRAMES].join(', ')}`,
+            ErrorCode.INVALID_PARAMS,
+          );
+        }
+        const chainType = options['chain-type'] || 'all';
+        if (!CHAIN_RANK_CHAIN_TYPES.has(chainType)) {
+          throw new NansenError(
+            `--chain-type must be one of: ${[...CHAIN_RANK_CHAIN_TYPES].join(', ')}`,
+            ErrorCode.INVALID_PARAMS,
+          );
+        }
+        return apiInstance.chainRank({ timeFrame, chainType });
       }
 
       // Range-based token endpoints (require --from-date + --to-date)

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -1,9 +1,7 @@
 /**
  * Nansen CLI - Research command
  *
- * Historical/point-in-time analytics. Each subcommand resolves labels and
- * metrics at the requested date rather than current state — useful for
- * backtesting and historical research.
+ * Direct API analytics, including historical/point-in-time research.
  */
 
 import { NansenError, ErrorCode } from '../api.js';
@@ -41,6 +39,7 @@ const SUBCOMMANDS = [
 ];
 
 export const RESEARCH_HISTORICAL_SUBCOMMANDS = new Set(SUBCOMMANDS);
+export const RESEARCH_SUBCOMMANDS = new Set(['chain-rank', ...SUBCOMMANDS]);
 
 function requireOptions(options, required) {
   const missing = required.filter(name => !options[name]);
@@ -75,9 +74,10 @@ function parseChains(options) {
   return undefined;
 }
 
-const HELP_TOP = `nansen research — Historical/point-in-time analytics
+const HELP_TOP = `nansen research — Direct API analytics
 
 SUBCOMMANDS:
+  chain-rank                       Rank chains by growth metrics
   historical-dex-trades             Historical DEX trades for a token
   historical-pnl-leaderboard        Historical PnL leaderboard for a token
   historical-token-flow-summary     Historical token flow summary
@@ -102,6 +102,10 @@ COMMON OPTIONS:
 Run: nansen research <subcommand> --help`;
 
 const SUB_HELP = {
+  'chain-rank': `nansen research chain-rank — Rank chains by growth metrics
+
+USAGE:
+  nansen research chain-rank [--timeframe-days 7|30|365] [--chain-type all|evm]`,
   'historical-dex-trades': `nansen research historical-dex-trades — Historical DEX trades for a token
 
 USAGE:
@@ -166,9 +170,9 @@ export function buildResearchCommands(deps = {}) {
         return;
       }
 
-      if (!RESEARCH_HISTORICAL_SUBCOMMANDS.has(sub)) {
+      if (!RESEARCH_SUBCOMMANDS.has(sub)) {
         throw new NansenError(
-          `Unknown research subcommand: ${sub}. Available: ${SUBCOMMANDS.join(', ')}`,
+          `Unknown research subcommand: ${sub}. Available: ${[...RESEARCH_SUBCOMMANDS].join(', ')}`,
           ErrorCode.UNKNOWN,
         );
       }
@@ -183,6 +187,13 @@ export function buildResearchCommands(deps = {}) {
       const filters = options.filters || {};
       const { fromDate, toDate } = resolveDateRange(options);
       const asOfDate = options['as-of-date'];
+
+      if (sub === 'chain-rank') {
+        return apiInstance.chainRank({
+          timeFrame: parseTimeframeDays(options['timeframe-days']) ?? 7,
+          chainType: options['chain-type'] || 'all',
+        });
+      }
 
       // Range-based token endpoints (require --from-date + --to-date)
       const rangeTokenHandlers = {

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -60,11 +60,11 @@ function resolveDateRange(options) {
 
 function parseTimeframeDays(value) {
   if (value === undefined || value === null || value === '') return undefined;
-  const n = parseInt(value, 10);
-  if (Number.isNaN(n)) {
-    throw new NansenError('--timeframe-days must be an integer', ErrorCode.INVALID_PARAMS);
+  const trimmed = String(value).trim();
+  if (!/^[1-9]\d*$/.test(trimmed)) {
+    throw new NansenError('--timeframe-days must be a positive integer', ErrorCode.INVALID_PARAMS);
   }
-  return n;
+  return parseInt(trimmed, 10);
 }
 
 function parseChains(options) {

--- a/src/schema.json
+++ b/src/schema.json
@@ -1162,6 +1162,21 @@
             }
           }
         },
+        "chain-rank": {
+          "endpoint": "/api/v1/chains/chain-rank",
+          "description": "Rank chains by growth metrics",
+          "options": {
+            "timeframe-days": {
+              "type": "number",
+              "enum": [7, 30, 365],
+              "default": 7
+            },
+            "chain-type": {
+              "enum": ["all", "evm"],
+              "default": "all"
+            }
+          }
+        },
         "historical-dex-trades": {
           "endpoint": "/api/v1beta1/tgm/historical-dex-trades",
           "description": "Historical DEX trades for a token at a point in time",


### PR DESCRIPTION
## Summary

- add `nansen research chain-rank`
- map timeframe and chain-type options to the public API request
- document the command and add focused API, dispatch, and coverage tests

## Validation

- `npm test -- src/__tests__/research.test.js src/__tests__/coverage.test.js` — 87 passed
- `npm test` — 2,547 passed, 2 skipped
- `npm run lint`
- `git diff --check main...HEAD`