### PR TITLE
Add smart-money-pnl-leaderboard research command

### DIFF
--- a/.changeset/research-smart-money-pnl-leaderboard.md
+++ b/.changeset/research-smart-money-pnl-leaderboard.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add the `nansen research smart-money-pnl-leaderboard` command.

--- a/.changeset/strict-limit-validation.md
+++ b/.changeset/strict-limit-validation.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Reject non-integer or non-positive `--limit` values with an actionable error instead of forwarding them to the API.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ nansen schema [command] [--pretty]    # full command reference (no API key neede
 
 **Research categories:** `smart-money` (`sm`), `token` (`tgm`), `profiler` (`prof`), `portfolio` (`port`), `prediction-market` (`pm`), `search`, `perp`, `points`
 
+**Direct research subcommand:** `smart-money-pnl-leaderboard`
+
 **Trade:** `quote`, `execute`, `bridge-status`, `limit-order` — DEX swaps on Solana and Base, cross-chain bridges, and Solana limit orders.
 
 **Wallet:** `create`, `list`, `show`, `export`, `default`, `delete`, `send` — local or Privy server-side wallets (EVM + Solana).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ nansen schema [command] [--pretty]    # full command reference (no API key neede
 
 **Research categories:** `smart-money` (`sm`), `token` (`tgm`), `profiler` (`prof`), `portfolio` (`port`), `prediction-market` (`pm`), `search`, `perp`, `points`
 
-**Direct research subcommand:** `smart-money-pnl-leaderboard`
+**Direct research subcommands:** `smart-money-pnl-leaderboard`
 
 **Trade:** `quote`, `execute`, `bridge-status`, `limit-order` — DEX swaps on Solana and Base, cross-chain bridges, and Solana limit orders.
 

--- a/src/__tests__/coverage.test.js
+++ b/src/__tests__/coverage.test.js
@@ -17,6 +17,7 @@ const DOCUMENTED_ENDPOINTS = {
     { name: 'dcas', method: 'smartMoneyDcas', endpoint: '/api/v1/smart-money/dcas' },
     { name: 'perp-trades', method: 'smartMoneyPerpTrades', endpoint: '/api/v1/smart-money/perp-trades' },
     { name: 'historical-holdings', method: 'smartMoneyHistoricalHoldings', endpoint: '/api/v1/smart-money/historical-holdings' },
+    { name: 'pnl-leaderboard', method: 'smartMoneyPnlLeaderboard', endpoint: '/api/v1/smart-money/pnl-leaderboard' },
   ],
   profiler: [
     { name: 'balance', method: 'addressBalance', endpoint: '/api/v1/profiler/address/current-balance' },

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest';
 import { NansenAPI, NansenError } from '../api.js';
-import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from '../commands/research.js';
+import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS, RESEARCH_SUBCOMMANDS } from '../commands/research.js';
 
 const FROM = '2025-01-01';
 const TO = '2025-01-31';
@@ -54,6 +54,25 @@ describe('NansenAPI research (historical) methods', () => {
     expect(options.headers['Content-Type']).toBe('application/json');
     return JSON.parse(options.body);
   }
+
+  it('uses the smart money PnL leaderboard endpoint and request shape', async () => {
+    setupMock();
+    await api.smartMoneyPnlLeaderboard({
+      chains: ['ethereum'],
+      timeframe: 30,
+      filters: { include_smart_money_labels: ['Fund'] },
+      orderBy: [{ field: 'total_pnl_usd', direction: 'DESC' }],
+      pagination: { page: 1, per_page: 10 },
+    });
+    const body = lastCall('/api/v1/smart-money/pnl-leaderboard');
+    expect(body).toEqual({
+      chains: ['ethereum'],
+      timeframe: 30,
+      filters: { include_smart_money_labels: ['Fund'] },
+      order_by: [{ field: 'total_pnl_usd', direction: 'DESC' }],
+      pagination: { page: 1, per_page: 10 },
+    });
+  });
 
   describe('researchDexTrades', () => {
     it('hits historical-dex-trades with token_address, chain, and date_range {from,to}', async () => {
@@ -270,11 +289,32 @@ describe('buildResearchCommands handler', () => {
       researchWalletBalances: vi.fn().mockResolvedValue({ data: [] }),
       researchTxLookup: vi.fn().mockResolvedValue({ data: [] }),
       researchWalletTransactions: vi.fn().mockResolvedValue({ data: [] }),
+      smartMoneyPnlLeaderboard: vi.fn().mockResolvedValue({ data: [] }),
     };
   }
 
-  it('exports all 11 subcommands', () => {
+  it('exports historical and direct subcommands', () => {
     expect(RESEARCH_HISTORICAL_SUBCOMMANDS.size).toBe(11);
+    expect(RESEARCH_SUBCOMMANDS.size).toBe(12);
+  });
+
+  it('dispatches smart-money-pnl-leaderboard', async () => {
+    mockApi = makeMockApi();
+    await cmds.research(['smart-money-pnl-leaderboard'], mockApi, {}, {
+      chains: 'ethereum,solana', 'timeframe-days': '30', page: '2', limit: '5',
+    });
+    expect(mockApi.smartMoneyPnlLeaderboard).toHaveBeenCalledWith(expect.objectContaining({
+      chains: ['ethereum', 'solana'],
+      timeframe: 30,
+      pagination: { page: 2, per_page: 5 },
+    }));
+  });
+
+  it('rejects an invalid smart money leaderboard limit', async () => {
+    mockApi = makeMockApi();
+    await expect(cmds.research(['smart-money-pnl-leaderboard'], mockApi, {}, {
+      limit: '5x',
+    })).rejects.toThrow(/positive integer/);
   });
 
   it('rejects unknown subcommand', async () => {

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -317,6 +317,14 @@ describe('buildResearchCommands handler', () => {
     })).rejects.toThrow(/positive integer/);
   });
 
+  it('rejects an unsupported smart money leaderboard timeframe', async () => {
+    mockApi = makeMockApi();
+    await expect(cmds.research(['smart-money-pnl-leaderboard'], mockApi, {}, {
+      'timeframe-days': '14',
+    })).rejects.toThrow(/must be one of: 1, 7, 30, 90, 180/);
+    expect(mockApi.smartMoneyPnlLeaderboard).not.toHaveBeenCalled();
+  });
+
   it('rejects unknown subcommand', async () => {
     mockApi = makeMockApi();
     await expect(cmds.research(['not-a-real-sub'], mockApi, {}, {}))

--- a/src/api.js
+++ b/src/api.js
@@ -896,6 +896,17 @@ export class NansenAPI {
     });
   }
 
+  async smartMoneyPnlLeaderboard(params = {}) {
+    const { chains = ['solana'], timeframe = 7, filters = {}, orderBy, pagination } = params;
+    return this.request('/api/v1/smart-money/pnl-leaderboard', {
+      chains,
+      timeframe,
+      filters,
+      order_by: orderBy,
+      pagination
+    });
+  }
+
   // ============= Profiler Endpoints =============
 
   async addressBalance(params = {}) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,6 +13,8 @@ import { formatAlertsTable, buildAlertsCommands } from './commands/alerts.js';
 import { buildAgentCommands } from './commands/agent.js';
 import { buildMcpCommands } from './commands/mcp.js';
 import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS, RESEARCH_SUBCOMMANDS } from './commands/research.js';
+import { buildPagination, parseSort } from './query-options.js';
+export { buildPagination, parseSort };
 import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
@@ -52,14 +54,6 @@ export function resolveBooleanOption(options, flags, key) {
   }
   if (flags[key] !== undefined) return Boolean(flags[key]);
   return undefined;
-}
-
-export function buildPagination(options) {
-  if (!options.limit && !options.page) return undefined;
-  return {
-    page: Math.max(1, parseInt(options.page, 10) || 1),
-    per_page: options.limit,
-  };
 }
 
 // ============= Field Filtering =============
@@ -458,22 +452,6 @@ export function parseDateOption(dateOption, days = 30) {
   const to = new Date().toISOString().split('T')[0];
   const from = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
   return { from, to };
-}
-
-// Parse simple sort syntax: "field:direction" or "field" (defaults to DESC)
-export function parseSort(sortOption, orderByOption) {
-  // If --order-by is provided, use it (full JSON control)
-  if (orderByOption) return orderByOption;
-  
-  // If no --sort, return undefined
-  if (!sortOption) return undefined;
-  
-  // Parse --sort field:direction or --sort field
-  const parts = sortOption.split(':');
-  const field = parts[0];
-  const direction = (parts[1] || 'desc').toUpperCase();
-  
-  return [{ field, direction }];
 }
 
 // Enrich transfers with Nansen labels for from/to addresses

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,7 +12,7 @@ import { buildLimitOrderCommands } from './limit-order.js';
 import { formatAlertsTable, buildAlertsCommands } from './commands/alerts.js';
 import { buildAgentCommands } from './commands/agent.js';
 import { buildMcpCommands } from './commands/mcp.js';
-import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from './commands/research.js';
+import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS, RESEARCH_SUBCOMMANDS } from './commands/research.js';
 import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
@@ -1638,18 +1638,19 @@ export function buildCommands(deps = {}) {
     if (!rawCategory || rawCategory === 'help') {
       return {
         categories: [...RESEARCH_CATEGORIES],
+        subcommands: [...RESEARCH_SUBCOMMANDS],
         historical: [...RESEARCH_HISTORICAL_SUBCOMMANDS],
         aliases: RESEARCH_CATEGORY_ALIASES,
         description: 'Research and analytics commands',
         example: 'nansen research smart-money netflow --chain solana'
       };
     }
-    if (RESEARCH_HISTORICAL_SUBCOMMANDS.has(rawCategory)) {
+    if (RESEARCH_SUBCOMMANDS.has(rawCategory)) {
       return researchHistorical(args, apiInstance, flags, options);
     }
     const category = RESEARCH_CATEGORY_ALIASES[rawCategory] || rawCategory;
     if (!RESEARCH_CATEGORIES.has(category)) {
-      throw new NansenError(`Unknown research category: ${rawCategory}. Available: ${[...RESEARCH_CATEGORIES, ...RESEARCH_HISTORICAL_SUBCOMMANDS].join(', ')}`, ErrorCode.UNKNOWN);
+      throw new NansenError(`Unknown research category: ${rawCategory}. Available: ${[...RESEARCH_CATEGORIES, ...RESEARCH_SUBCOMMANDS].join(', ')}`, ErrorCode.UNKNOWN);
     }
     // `research perp` reaches only the analytics half (screener/leaderboard) —
     // the trading subcommands live at the top level. Routing its help through

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -1,19 +1,21 @@
 /**
  * Nansen CLI - Research command
  *
- * Historical/point-in-time analytics. Each subcommand resolves labels and
- * metrics at the requested date rather than current state — useful for
- * backtesting and historical research.
+ * Direct API analytics, including historical/point-in-time research.
  */
 
 import { NansenError, ErrorCode } from '../api.js';
 
 // Local copies of CLI helpers to avoid a circular import with src/cli.js.
 function buildPagination(options) {
-  if (!options.limit && !options.page) return undefined;
+  if (options.limit === undefined && options.page === undefined) return undefined;
+  const perPage = options.limit === undefined ? undefined : Number(options.limit);
+  if (perPage !== undefined && (!Number.isInteger(perPage) || perPage < 1)) {
+    throw new NansenError('--limit must be a positive integer', ErrorCode.INVALID_PARAMS);
+  }
   return {
     page: Math.max(1, parseInt(options.page, 10) || 1),
-    per_page: options.limit,
+    per_page: perPage,
   };
 }
 
@@ -41,6 +43,7 @@ const SUBCOMMANDS = [
 ];
 
 export const RESEARCH_HISTORICAL_SUBCOMMANDS = new Set(SUBCOMMANDS);
+export const RESEARCH_SUBCOMMANDS = new Set(['smart-money-pnl-leaderboard', ...SUBCOMMANDS]);
 
 function requireOptions(options, required) {
   const missing = required.filter(name => !options[name]);
@@ -75,9 +78,10 @@ function parseChains(options) {
   return undefined;
 }
 
-const HELP_TOP = `nansen research — Historical/point-in-time analytics
+const HELP_TOP = `nansen research — Direct API analytics
 
 SUBCOMMANDS:
+  smart-money-pnl-leaderboard      Rank smart money wallets by PnL
   historical-dex-trades             Historical DEX trades for a token
   historical-pnl-leaderboard        Historical PnL leaderboard for a token
   historical-token-flow-summary     Historical token flow summary
@@ -102,6 +106,10 @@ COMMON OPTIONS:
 Run: nansen research <subcommand> --help`;
 
 const SUB_HELP = {
+  'smart-money-pnl-leaderboard': `nansen research smart-money-pnl-leaderboard — Rank smart money wallets by PnL
+
+USAGE:
+  nansen research smart-money-pnl-leaderboard [--chains c1,c2] [--timeframe-days 1|7|30|90|180] [--filters '<json>'] [--sort <field[:asc|desc]>] [--page <n>] [--limit <n>]`,
   'historical-dex-trades': `nansen research historical-dex-trades — Historical DEX trades for a token
 
 USAGE:
@@ -166,9 +174,9 @@ export function buildResearchCommands(deps = {}) {
         return;
       }
 
-      if (!RESEARCH_HISTORICAL_SUBCOMMANDS.has(sub)) {
+      if (!RESEARCH_SUBCOMMANDS.has(sub)) {
         throw new NansenError(
-          `Unknown research subcommand: ${sub}. Available: ${SUBCOMMANDS.join(', ')}`,
+          `Unknown research subcommand: ${sub}. Available: ${[...RESEARCH_SUBCOMMANDS].join(', ')}`,
           ErrorCode.UNKNOWN,
         );
       }
@@ -183,6 +191,14 @@ export function buildResearchCommands(deps = {}) {
       const filters = options.filters || {};
       const { fromDate, toDate } = resolveDateRange(options);
       const asOfDate = options['as-of-date'];
+
+      if (sub === 'smart-money-pnl-leaderboard') {
+        return apiInstance.smartMoneyPnlLeaderboard({
+          chains: parseChains(options) || ['solana'],
+          timeframe: parseTimeframeDays(options['timeframe-days']) ?? 7,
+          filters, orderBy, pagination,
+        });
+      }
 
       // Range-based token endpoints (require --from-date + --to-date)
       const rangeTokenHandlers = {

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -45,6 +45,8 @@ const SUBCOMMANDS = [
 export const RESEARCH_HISTORICAL_SUBCOMMANDS = new Set(SUBCOMMANDS);
 export const RESEARCH_SUBCOMMANDS = new Set(['smart-money-pnl-leaderboard', ...SUBCOMMANDS]);
 
+const SM_PNL_TIMEFRAME_DAYS = [1, 7, 30, 90, 180];
+
 function requireOptions(options, required) {
   const missing = required.filter(name => !options[name]);
   if (missing.length > 0) {
@@ -81,7 +83,7 @@ function parseChains(options) {
 const HELP_TOP = `nansen research — Direct API analytics
 
 SUBCOMMANDS:
-  smart-money-pnl-leaderboard      Rank smart money wallets by PnL
+  smart-money-pnl-leaderboard       Rank smart money wallets by PnL
   historical-dex-trades             Historical DEX trades for a token
   historical-pnl-leaderboard        Historical PnL leaderboard for a token
   historical-token-flow-summary     Historical token flow summary
@@ -193,9 +195,16 @@ export function buildResearchCommands(deps = {}) {
       const asOfDate = options['as-of-date'];
 
       if (sub === 'smart-money-pnl-leaderboard') {
+        const timeframe = parseTimeframeDays(options['timeframe-days']) ?? 7;
+        if (!SM_PNL_TIMEFRAME_DAYS.includes(timeframe)) {
+          throw new NansenError(
+            `--timeframe-days must be one of: ${SM_PNL_TIMEFRAME_DAYS.join(', ')}`,
+            ErrorCode.INVALID_PARAMS,
+          );
+        }
         return apiInstance.smartMoneyPnlLeaderboard({
           chains: parseChains(options) || ['solana'],
-          timeframe: parseTimeframeDays(options['timeframe-days']) ?? 7,
+          timeframe,
           filters, orderBy, pagination,
         });
       }

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -5,28 +5,7 @@
  */
 
 import { NansenError, ErrorCode } from '../api.js';
-
-// Local copies of CLI helpers to avoid a circular import with src/cli.js.
-function buildPagination(options) {
-  if (options.limit === undefined && options.page === undefined) return undefined;
-  const perPage = options.limit === undefined ? undefined : Number(options.limit);
-  if (perPage !== undefined && (!Number.isInteger(perPage) || perPage < 1)) {
-    throw new NansenError('--limit must be a positive integer', ErrorCode.INVALID_PARAMS);
-  }
-  return {
-    page: Math.max(1, parseInt(options.page, 10) || 1),
-    per_page: perPage,
-  };
-}
-
-function parseSort(sortOption, orderByOption) {
-  if (orderByOption) return orderByOption;
-  if (!sortOption) return undefined;
-  const parts = String(sortOption).split(':');
-  const field = parts[0];
-  const direction = (parts[1] || 'desc').toUpperCase();
-  return [{ field, direction }];
-}
+import { buildPagination, parseSort } from '../query-options.js';
 
 const SUBCOMMANDS = [
   'historical-dex-trades',

--- a/src/query-options.js
+++ b/src/query-options.js
@@ -1,0 +1,32 @@
+/**
+ * Nansen CLI - Shared list-query helpers
+ *
+ * Builds pagination and order_by request fragments from CLI options.
+ * Lives in a leaf module so src/cli.js and src/commands/*.js share one
+ * implementation without circular imports.
+ */
+
+import { NansenError, ErrorCode } from './api.js';
+
+export function buildPagination(options) {
+  if (options.limit === undefined && options.page === undefined) return undefined;
+  const perPage = options.limit === undefined ? undefined : Number(options.limit);
+  if (perPage !== undefined && (!Number.isInteger(perPage) || perPage < 1)) {
+    throw new NansenError('--limit must be a positive integer', ErrorCode.INVALID_PARAMS);
+  }
+  return {
+    page: Math.max(1, parseInt(options.page, 10) || 1),
+    per_page: perPage,
+  };
+}
+
+// Parse simple sort syntax: "field:direction" or "field" (defaults to DESC)
+export function parseSort(sortOption, orderByOption) {
+  // If --order-by is provided, use it (full JSON control)
+  if (orderByOption) return orderByOption;
+  if (!sortOption) return undefined;
+  const parts = String(sortOption).split(':');
+  const field = parts[0];
+  const direction = (parts[1] || 'desc').toUpperCase();
+  return [{ field, direction }];
+}

--- a/src/schema.json
+++ b/src/schema.json
@@ -1162,6 +1162,21 @@
             }
           }
         },
+        "smart-money-pnl-leaderboard": {
+          "endpoint": "/api/v1/smart-money/pnl-leaderboard",
+          "description": "Rank smart money wallets by PnL",
+          "options": {
+            "chains": {
+              "default": "solana",
+              "description": "Comma-separated chains"
+            },
+            "timeframe-days": {
+              "type": "number",
+              "enum": [1, 7, 30, 90, 180],
+              "default": 7
+            }
+          }
+        },
         "historical-dex-trades": {
           "endpoint": "/api/v1beta1/tgm/historical-dex-trades",
           "description": "Historical DEX trades for a token at a point in time",

--- a/src/schema.json
+++ b/src/schema.json
@@ -1173,7 +1173,25 @@
             "timeframe-days": {
               "type": "number",
               "enum": [1, 7, 30, 90, 180],
-              "default": 7
+              "default": 7,
+              "description": "Timeframe in days"
+            },
+            "filters": {
+              "type": "string",
+              "description": "Filters as JSON object"
+            },
+            "sort": {
+              "type": "string",
+              "description": "Sort order (field[:asc|desc])"
+            },
+            "page": {
+              "type": "number",
+              "default": 1,
+              "description": "1-based page number; maps to pagination.page"
+            },
+            "limit": {
+              "type": "number",
+              "description": "Max results per page; maps to pagination.per_page"
             }
           }
         },


### PR DESCRIPTION
## Summary

- add `nansen research smart-money-pnl-leaderboard`
- map chain, timeframe, filter, sort, and pagination options to the public API request
- document the command and add focused API, dispatch, validation, and coverage tests

## Validation

- `npm test -- src/__tests__/research.test.js src/__tests__/coverage.test.js` — 88 passed
- `npm test` — 2,548 passed, 2 skipped
- `npm run lint`
- `git diff --check main...HEAD`