### PR TITLE
Add position-intelligence research command

### DIFF
--- a/.changeset/research-position-intelligence.md
+++ b/.changeset/research-position-intelligence.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add the `nansen research position-intelligence` command.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ nansen schema [command] [--pretty]    # full command reference (no API key neede
 
 **Research categories:** `smart-money` (`sm`), `token` (`tgm`), `profiler` (`prof`), `portfolio` (`port`), `prediction-market` (`pm`), `search`, `perp`, `points`
 
+**Direct research subcommand:** `position-intelligence`
+
 **Trade:** `quote`, `execute`, `bridge-status`, `limit-order` — DEX swaps on Solana and Base, cross-chain bridges, and Solana limit orders.
 
 **Wallet:** `create`, `list`, `show`, `export`, `default`, `delete`, `send` — local or Privy server-side wallets (EVM + Solana).

--- a/src/__tests__/coverage.test.js
+++ b/src/__tests__/coverage.test.js
@@ -46,6 +46,7 @@ const DOCUMENTED_ENDPOINTS = {
     { name: 'jup-dca', method: 'tokenJupDca', endpoint: '/api/v1/tgm/jup-dca' },
     { name: 'perp-trades', method: 'tokenPerpTrades', endpoint: '/api/v1/tgm/perp-trades' },
     { name: 'perp-positions', method: 'tokenPerpPositions', endpoint: '/api/v1/tgm/perp-positions' },
+    { name: 'position-intelligence', method: 'tokenPositionIntelligence', endpoint: '/api/v1/tgm/position-intelligence' },
     { name: 'perp-pnl-leaderboard', method: 'tokenPerpPnlLeaderboard', endpoint: '/api/v1/tgm/perp-pnl-leaderboard' },
     { name: 'top-tokens', method: 'topTokens', endpoint: '/api/v1/nansen-score/top-tokens' },
   ],

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -301,7 +301,14 @@ describe('buildResearchCommands handler', () => {
   it('requires a position-intelligence symbol', async () => {
     mockApi = makeMockApi();
     await expect(cmds.research(['position-intelligence'], mockApi, {}, {}))
-      .rejects.toThrow(/symbol/);
+      .rejects.toThrow(/--symbol \(or --token-address\)/);
+  });
+
+  it('rejects an empty position-intelligence symbol', async () => {
+    mockApi = makeMockApi();
+    await expect(cmds.research(['position-intelligence'], mockApi, {}, { symbol: '' }))
+      .rejects.toThrow(/--symbol/);
+    expect(mockApi.tokenPositionIntelligence).not.toHaveBeenCalled();
   });
 
   it('rejects unknown subcommand', async () => {

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -292,6 +292,12 @@ describe('buildResearchCommands handler', () => {
     expect(mockApi.tokenPositionIntelligence).toHaveBeenCalledWith({ tokenAddress: 'BTC' });
   });
 
+  it('dispatches position-intelligence via the --token-address alias', async () => {
+    mockApi = makeMockApi();
+    await cmds.research(['position-intelligence'], mockApi, {}, { 'token-address': 'BTC' });
+    expect(mockApi.tokenPositionIntelligence).toHaveBeenCalledWith({ tokenAddress: 'BTC' });
+  });
+
   it('requires a position-intelligence symbol', async () => {
     mockApi = makeMockApi();
     await expect(cmds.research(['position-intelligence'], mockApi, {}, {}))

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -304,9 +304,11 @@ describe('buildResearchCommands handler', () => {
       .rejects.toThrow(/--symbol \(or --token-address\)/);
   });
 
-  it('rejects an empty position-intelligence symbol', async () => {
+  it('rejects an empty or whitespace-only position-intelligence symbol', async () => {
     mockApi = makeMockApi();
     await expect(cmds.research(['position-intelligence'], mockApi, {}, { symbol: '' }))
+      .rejects.toThrow(/--symbol/);
+    await expect(cmds.research(['position-intelligence'], mockApi, {}, { symbol: '   ' }))
       .rejects.toThrow(/--symbol/);
     expect(mockApi.tokenPositionIntelligence).not.toHaveBeenCalled();
   });

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest';
 import { NansenAPI, NansenError } from '../api.js';
-import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from '../commands/research.js';
+import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS, RESEARCH_SUBCOMMANDS } from '../commands/research.js';
 
 const FROM = '2025-01-01';
 const TO = '2025-01-31';
@@ -54,6 +54,13 @@ describe('NansenAPI research (historical) methods', () => {
     expect(options.headers['Content-Type']).toBe('application/json');
     return JSON.parse(options.body);
   }
+
+  it('uses the position-intelligence endpoint and request shape', async () => {
+    setupMock();
+    await api.tokenPositionIntelligence({ tokenAddress: 'BTC' });
+    const body = lastCall('/api/v1/tgm/position-intelligence');
+    expect(body).toEqual({ token_address: 'BTC' });
+  });
 
   describe('researchDexTrades', () => {
     it('hits historical-dex-trades with token_address, chain, and date_range {from,to}', async () => {
@@ -270,11 +277,25 @@ describe('buildResearchCommands handler', () => {
       researchWalletBalances: vi.fn().mockResolvedValue({ data: [] }),
       researchTxLookup: vi.fn().mockResolvedValue({ data: [] }),
       researchWalletTransactions: vi.fn().mockResolvedValue({ data: [] }),
+      tokenPositionIntelligence: vi.fn().mockResolvedValue({ data: [] }),
     };
   }
 
-  it('exports all 11 subcommands', () => {
+  it('exports historical and direct subcommands', () => {
     expect(RESEARCH_HISTORICAL_SUBCOMMANDS.size).toBe(11);
+    expect(RESEARCH_SUBCOMMANDS.size).toBe(12);
+  });
+
+  it('dispatches position-intelligence', async () => {
+    mockApi = makeMockApi();
+    await cmds.research(['position-intelligence'], mockApi, {}, { symbol: 'BTC' });
+    expect(mockApi.tokenPositionIntelligence).toHaveBeenCalledWith({ tokenAddress: 'BTC' });
+  });
+
+  it('requires a position-intelligence symbol', async () => {
+    mockApi = makeMockApi();
+    await expect(cmds.research(['position-intelligence'], mockApi, {}, {}))
+      .rejects.toThrow(/symbol/);
   });
 
   it('rejects unknown subcommand', async () => {

--- a/src/api.js
+++ b/src/api.js
@@ -1240,6 +1240,13 @@ export class NansenAPI {
     });
   }
 
+  async tokenPositionIntelligence(params = {}) {
+    const { tokenAddress } = params;
+    return this.request('/api/v1/tgm/position-intelligence', {
+      token_address: tokenAddress
+    });
+  }
+
   async tokenPerpPnlLeaderboard(params = {}) {
     const { tokenSymbol, filters = {}, orderBy, pagination, days = 30, withLabels } = params;
     const body = {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1631,7 +1631,7 @@ export function buildCommands(deps = {}) {
   // it, so it has to be taken exactly once, here.
   const perpAnalytics = cmds['perp'];
 
-  const researchHistorical = buildResearchCommands(deps).research;
+  const researchSub = buildResearchCommands(deps).research;
 
   cmds['research'] = async (args, apiInstance, flags, options) => {
     const rawCategory = args[0];
@@ -1646,7 +1646,7 @@ export function buildCommands(deps = {}) {
       };
     }
     if (RESEARCH_SUBCOMMANDS.has(rawCategory)) {
-      return researchHistorical(args, apiInstance, flags, options);
+      return researchSub(args, apiInstance, flags, options);
     }
     const category = RESEARCH_CATEGORY_ALIASES[rawCategory] || rawCategory;
     if (!RESEARCH_CATEGORIES.has(category)) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,7 +12,7 @@ import { buildLimitOrderCommands } from './limit-order.js';
 import { formatAlertsTable, buildAlertsCommands } from './commands/alerts.js';
 import { buildAgentCommands } from './commands/agent.js';
 import { buildMcpCommands } from './commands/mcp.js';
-import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from './commands/research.js';
+import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS, RESEARCH_SUBCOMMANDS } from './commands/research.js';
 import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
@@ -1638,18 +1638,19 @@ export function buildCommands(deps = {}) {
     if (!rawCategory || rawCategory === 'help') {
       return {
         categories: [...RESEARCH_CATEGORIES],
+        subcommands: [...RESEARCH_SUBCOMMANDS],
         historical: [...RESEARCH_HISTORICAL_SUBCOMMANDS],
         aliases: RESEARCH_CATEGORY_ALIASES,
         description: 'Research and analytics commands',
         example: 'nansen research smart-money netflow --chain solana'
       };
     }
-    if (RESEARCH_HISTORICAL_SUBCOMMANDS.has(rawCategory)) {
+    if (RESEARCH_SUBCOMMANDS.has(rawCategory)) {
       return researchHistorical(args, apiInstance, flags, options);
     }
     const category = RESEARCH_CATEGORY_ALIASES[rawCategory] || rawCategory;
     if (!RESEARCH_CATEGORIES.has(category)) {
-      throw new NansenError(`Unknown research category: ${rawCategory}. Available: ${[...RESEARCH_CATEGORIES, ...RESEARCH_HISTORICAL_SUBCOMMANDS].join(', ')}`, ErrorCode.UNKNOWN);
+      throw new NansenError(`Unknown research category: ${rawCategory}. Available: ${[...RESEARCH_CATEGORIES, ...RESEARCH_SUBCOMMANDS].join(', ')}`, ErrorCode.UNKNOWN);
     }
     // `research perp` reaches only the analytics half (screener/leaderboard) —
     // the trading subcommands live at the top level. Routing its help through

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -77,7 +77,7 @@ function parseChains(options) {
 const HELP_TOP = `nansen research — Direct API analytics
 
 SUBCOMMANDS:
-  position-intelligence            Aggregate Hyperliquid positions by trader cohort
+  position-intelligence             Aggregate Hyperliquid positions by trader cohort
   historical-dex-trades             Historical DEX trades for a token
   historical-pnl-leaderboard        Historical PnL leaderboard for a token
   historical-token-flow-summary     Historical token flow summary
@@ -105,7 +105,9 @@ const SUB_HELP = {
   'position-intelligence': `nansen research position-intelligence — Aggregate Hyperliquid positions by trader cohort
 
 USAGE:
-  nansen research position-intelligence --symbol <symbol>`,
+  nansen research position-intelligence --symbol <symbol>
+
+NOTE: --token-address is accepted as an alias for --symbol (the API request field is token_address).`,
   'historical-dex-trades': `nansen research historical-dex-trades — Historical DEX trades for a token
 
 USAGE:

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -1,9 +1,7 @@
 /**
  * Nansen CLI - Research command
  *
- * Historical/point-in-time analytics. Each subcommand resolves labels and
- * metrics at the requested date rather than current state — useful for
- * backtesting and historical research.
+ * Direct API analytics, including historical/point-in-time research.
  */
 
 import { NansenError, ErrorCode } from '../api.js';
@@ -41,6 +39,7 @@ const SUBCOMMANDS = [
 ];
 
 export const RESEARCH_HISTORICAL_SUBCOMMANDS = new Set(SUBCOMMANDS);
+export const RESEARCH_SUBCOMMANDS = new Set(['position-intelligence', ...SUBCOMMANDS]);
 
 function requireOptions(options, required) {
   const missing = required.filter(name => !options[name]);
@@ -75,9 +74,10 @@ function parseChains(options) {
   return undefined;
 }
 
-const HELP_TOP = `nansen research — Historical/point-in-time analytics
+const HELP_TOP = `nansen research — Direct API analytics
 
 SUBCOMMANDS:
+  position-intelligence            Aggregate Hyperliquid positions by trader cohort
   historical-dex-trades             Historical DEX trades for a token
   historical-pnl-leaderboard        Historical PnL leaderboard for a token
   historical-token-flow-summary     Historical token flow summary
@@ -102,6 +102,10 @@ COMMON OPTIONS:
 Run: nansen research <subcommand> --help`;
 
 const SUB_HELP = {
+  'position-intelligence': `nansen research position-intelligence — Aggregate Hyperliquid positions by trader cohort
+
+USAGE:
+  nansen research position-intelligence --symbol <symbol>`,
   'historical-dex-trades': `nansen research historical-dex-trades — Historical DEX trades for a token
 
 USAGE:
@@ -166,9 +170,9 @@ export function buildResearchCommands(deps = {}) {
         return;
       }
 
-      if (!RESEARCH_HISTORICAL_SUBCOMMANDS.has(sub)) {
+      if (!RESEARCH_SUBCOMMANDS.has(sub)) {
         throw new NansenError(
-          `Unknown research subcommand: ${sub}. Available: ${SUBCOMMANDS.join(', ')}`,
+          `Unknown research subcommand: ${sub}. Available: ${[...RESEARCH_SUBCOMMANDS].join(', ')}`,
           ErrorCode.UNKNOWN,
         );
       }
@@ -183,6 +187,12 @@ export function buildResearchCommands(deps = {}) {
       const filters = options.filters || {};
       const { fromDate, toDate } = resolveDateRange(options);
       const asOfDate = options['as-of-date'];
+
+      if (sub === 'position-intelligence') {
+        const symbol = options.symbol || options['token-address'] || options.token;
+        requireOptions({ symbol }, ['symbol']);
+        return apiInstance.tokenPositionIntelligence({ tokenAddress: symbol });
+      }
 
       // Range-based token endpoints (require --from-date + --to-date)
       const rangeTokenHandlers = {

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -192,7 +192,12 @@ export function buildResearchCommands(deps = {}) {
 
       if (sub === 'position-intelligence') {
         const symbol = options.symbol || options['token-address'] || options.token;
-        requireOptions({ symbol }, ['symbol']);
+        if (!symbol) {
+          throw new NansenError(
+            'Required: --symbol (or --token-address)',
+            ErrorCode.MISSING_PARAM,
+          );
+        }
         return apiInstance.tokenPositionIntelligence({ tokenAddress: symbol });
       }
 

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -191,7 +191,7 @@ export function buildResearchCommands(deps = {}) {
       const asOfDate = options['as-of-date'];
 
       if (sub === 'position-intelligence') {
-        const symbol = options.symbol || options['token-address'] || options.token;
+        const symbol = String(options.symbol || options['token-address'] || options.token || '').trim();
         if (!symbol) {
           throw new NansenError(
             'Required: --symbol (or --token-address)',

--- a/src/schema.json
+++ b/src/schema.json
@@ -1162,6 +1162,16 @@
             }
           }
         },
+        "position-intelligence": {
+          "endpoint": "/api/v1/tgm/position-intelligence",
+          "description": "Aggregate Hyperliquid positions by trader cohort",
+          "options": {
+            "symbol": {
+              "required": true,
+              "description": "Hyperliquid asset symbol"
+            }
+          }
+        },
         "historical-dex-trades": {
           "endpoint": "/api/v1beta1/tgm/historical-dex-trades",
           "description": "Historical DEX trades for a token at a point in time",

--- a/src/schema.json
+++ b/src/schema.json
@@ -1168,7 +1168,7 @@
           "options": {
             "symbol": {
               "required": true,
-              "description": "Hyperliquid asset symbol"
+              "description": "Hyperliquid asset symbol (--token-address is accepted as an alias)"
             }
           }
         },


### PR DESCRIPTION
## Summary

- add `nansen research position-intelligence`
- require an asset symbol and map it to the public API request
- document the command and add focused API, dispatch, validation, and coverage tests

## Validation

- `npm test -- src/__tests__/research.test.js src/__tests__/coverage.test.js` — 88 passed
- `npm test` — 2,548 passed, 2 skipped
- `npm run lint`
- `git diff --check main...HEAD`