### PR TITLE
Add transaction-with-token-transfer-lookup research command

### DIFF
--- a/.changeset/research-transaction-token-transfer-lookup.md
+++ b/.changeset/research-transaction-token-transfer-lookup.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add the `nansen research transaction-with-token-transfer-lookup` command.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ nansen schema [command] [--pretty]    # full command reference (no API key neede
 
 **Research categories:** `smart-money` (`sm`), `token` (`tgm`), `profiler` (`prof`), `portfolio` (`port`), `prediction-market` (`pm`), `search`, `perp`, `points`
 
+**Direct research subcommand:** `transaction-with-token-transfer-lookup`
+
 **Trade:** `quote`, `execute`, `bridge-status`, `limit-order` — DEX swaps on Solana and Base, cross-chain bridges, and Solana limit orders.
 
 **Wallet:** `create`, `list`, `show`, `export`, `default`, `delete`, `send` — local or Privy server-side wallets (EVM + Solana).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ nansen schema [command] [--pretty]    # full command reference (no API key neede
 
 **Research categories:** `smart-money` (`sm`), `token` (`tgm`), `profiler` (`prof`), `portfolio` (`port`), `prediction-market` (`pm`), `search`, `perp`, `points`
 
-**Direct research subcommand:** `transaction-with-token-transfer-lookup`
+**Direct research subcommands:** `transaction-with-token-transfer-lookup`
 
 **Trade:** `quote`, `execute`, `bridge-status`, `limit-order` — DEX swaps on Solana and Base, cross-chain bridges, and Solana limit orders.
 

--- a/src/__tests__/coverage.test.js
+++ b/src/__tests__/coverage.test.js
@@ -60,6 +60,9 @@ const DOCUMENTED_ENDPOINTS = {
   search: [
     { name: 'general-search', method: 'generalSearch', endpoint: '/api/v1/search/general' },
   ],
+  transactions: [
+    { name: 'transaction-with-token-transfer-lookup', method: 'transactionWithTokenTransferLookup', endpoint: '/api/v1/transaction-with-token-transfer-lookup' },
+  ],
   predictionMarket: [
     { name: 'ohlcv', method: 'pmOhlcv', endpoint: '/api/v1/prediction-market/ohlcv' },
     { name: 'orderbook', method: 'pmOrderbook', endpoint: '/api/v1/prediction-market/orderbook' },
@@ -133,6 +136,14 @@ describe('API Endpoint Coverage', () => {
     }
   });
 
+  describe('Transaction Endpoints', () => {
+    for (const ep of DOCUMENTED_ENDPOINTS.transactions) {
+      it(`should have ${ep.name} method`, () => {
+        expect(typeof api[ep.method]).toBe('function');
+      });
+    }
+  });
+
   describe('Prediction Market Endpoints', () => {
     for (const ep of DOCUMENTED_ENDPOINTS.predictionMarket) {
       it(`should have ${ep.name} method`, () => {
@@ -150,6 +161,7 @@ describe('API Endpoint Coverage', () => {
         ...DOCUMENTED_ENDPOINTS.composite,
         ...DOCUMENTED_ENDPOINTS.portfolio,
         ...DOCUMENTED_ENDPOINTS.search,
+        ...DOCUMENTED_ENDPOINTS.transactions,
         ...DOCUMENTED_ENDPOINTS.predictionMarket,
       ];
       

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -313,6 +313,14 @@ describe('buildResearchCommands handler', () => {
     })).rejects.toThrow(/block-timestamp/);
   });
 
+  it('errors when required transaction-hash is missing', async () => {
+    mockApi = makeMockApi();
+    await expect(cmds.research(['transaction-with-token-transfer-lookup'], mockApi, {}, {
+      chain: 'ethereum',
+    })).rejects.toThrow(/transaction-hash/);
+    expect(mockApi.transactionWithTokenTransferLookup).not.toHaveBeenCalled();
+  });
+
   it('rejects unknown subcommand', async () => {
     mockApi = makeMockApi();
     await expect(cmds.research(['not-a-real-sub'], mockApi, {}, {}))

--- a/src/__tests__/research.test.js
+++ b/src/__tests__/research.test.js
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest';
 import { NansenAPI, NansenError } from '../api.js';
-import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from '../commands/research.js';
+import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS, RESEARCH_SUBCOMMANDS } from '../commands/research.js';
 
 const FROM = '2025-01-01';
 const TO = '2025-01-31';
@@ -54,6 +54,21 @@ describe('NansenAPI research (historical) methods', () => {
     expect(options.headers['Content-Type']).toBe('application/json');
     return JSON.parse(options.body);
   }
+
+  it('uses the transaction transfer lookup endpoint and request shape', async () => {
+    setupMock();
+    await api.transactionWithTokenTransferLookup({
+      transactionHash: '0xabc123',
+      chain: 'ethereum',
+      blockTimestamp: '2025-01-01 00:00:00',
+    });
+    const body = lastCall('/api/v1/transaction-with-token-transfer-lookup');
+    expect(body).toEqual({
+      transaction_hash: '0xabc123',
+      chain: 'ethereum',
+      block_timestamp: '2025-01-01 00:00:00',
+    });
+  });
 
   describe('researchDexTrades', () => {
     it('hits historical-dex-trades with token_address, chain, and date_range {from,to}', async () => {
@@ -270,11 +285,32 @@ describe('buildResearchCommands handler', () => {
       researchWalletBalances: vi.fn().mockResolvedValue({ data: [] }),
       researchTxLookup: vi.fn().mockResolvedValue({ data: [] }),
       researchWalletTransactions: vi.fn().mockResolvedValue({ data: [] }),
+      transactionWithTokenTransferLookup: vi.fn().mockResolvedValue({ data: [] }),
     };
   }
 
-  it('exports all 11 subcommands', () => {
+  it('exports historical and direct subcommands', () => {
     expect(RESEARCH_HISTORICAL_SUBCOMMANDS.size).toBe(11);
+    expect(RESEARCH_SUBCOMMANDS.size).toBe(12);
+  });
+
+  it('dispatches transaction-with-token-transfer-lookup', async () => {
+    mockApi = makeMockApi();
+    await cmds.research(['transaction-with-token-transfer-lookup'], mockApi, {}, {
+      'transaction-hash': '0xabc', chain: 'ethereum',
+    });
+    expect(mockApi.transactionWithTokenTransferLookup).toHaveBeenCalledWith({
+      transactionHash: '0xabc',
+      chain: 'ethereum',
+      blockTimestamp: undefined,
+    });
+  });
+
+  it('requires a block timestamp for non-EVM transaction lookup chains', async () => {
+    mockApi = makeMockApi();
+    await expect(cmds.research(['transaction-with-token-transfer-lookup'], mockApi, {}, {
+      'transaction-hash': 'abc', chain: 'bitcoin',
+    })).rejects.toThrow(/block-timestamp/);
   });
 
   it('rejects unknown subcommand', async () => {

--- a/src/api.js
+++ b/src/api.js
@@ -1092,6 +1092,15 @@ export class NansenAPI {
     });
   }
 
+  async transactionWithTokenTransferLookup(params = {}) {
+    const { chain = 'ethereum', transactionHash, blockTimestamp } = params;
+    return this.request('/api/v1/transaction-with-token-transfer-lookup', {
+      chain,
+      transaction_hash: transactionHash,
+      block_timestamp: blockTimestamp
+    });
+  }
+
   // ============= Token God Mode Endpoints =============
 
   async tokenScreener(params = {}) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,7 +12,7 @@ import { buildLimitOrderCommands } from './limit-order.js';
 import { formatAlertsTable, buildAlertsCommands } from './commands/alerts.js';
 import { buildAgentCommands } from './commands/agent.js';
 import { buildMcpCommands } from './commands/mcp.js';
-import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from './commands/research.js';
+import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS, RESEARCH_SUBCOMMANDS } from './commands/research.js';
 import { resolveAddress, isEnsName } from './ens.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
@@ -1638,18 +1638,19 @@ export function buildCommands(deps = {}) {
     if (!rawCategory || rawCategory === 'help') {
       return {
         categories: [...RESEARCH_CATEGORIES],
+        subcommands: [...RESEARCH_SUBCOMMANDS],
         historical: [...RESEARCH_HISTORICAL_SUBCOMMANDS],
         aliases: RESEARCH_CATEGORY_ALIASES,
         description: 'Research and analytics commands',
         example: 'nansen research smart-money netflow --chain solana'
       };
     }
-    if (RESEARCH_HISTORICAL_SUBCOMMANDS.has(rawCategory)) {
+    if (RESEARCH_SUBCOMMANDS.has(rawCategory)) {
       return researchHistorical(args, apiInstance, flags, options);
     }
     const category = RESEARCH_CATEGORY_ALIASES[rawCategory] || rawCategory;
     if (!RESEARCH_CATEGORIES.has(category)) {
-      throw new NansenError(`Unknown research category: ${rawCategory}. Available: ${[...RESEARCH_CATEGORIES, ...RESEARCH_HISTORICAL_SUBCOMMANDS].join(', ')}`, ErrorCode.UNKNOWN);
+      throw new NansenError(`Unknown research category: ${rawCategory}. Available: ${[...RESEARCH_CATEGORIES, ...RESEARCH_SUBCOMMANDS].join(', ')}`, ErrorCode.UNKNOWN);
     }
     // `research perp` reaches only the analytics half (screener/leaderboard) —
     // the trading subcommands live at the top level. Routing its help through

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -195,8 +195,8 @@ export function buildResearchCommands(deps = {}) {
         const chain = options.chain || 'ethereum';
         const blockTimestamp = options['block-timestamp'];
         requireOptions({ 'transaction-hash': options['transaction-hash'] }, ['transaction-hash']);
-        // 'all' is deliberately absent: the API resolves the hash across chains
-        // server-side and accepts it without a timestamp.
+        // Chains the API rejects without block_timestamp. Every other enum value,
+        // including 'all', near, and injective, accepts a timestamp-less lookup.
         if (['bitcoin', 'tron', 'ton', 'starknet', 'sui'].includes(chain)) {
           requireOptions({ 'block-timestamp': blockTimestamp }, ['block-timestamp']);
         }

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -1,9 +1,7 @@
 /**
  * Nansen CLI - Research command
  *
- * Historical/point-in-time analytics. Each subcommand resolves labels and
- * metrics at the requested date rather than current state — useful for
- * backtesting and historical research.
+ * Direct API analytics, including historical/point-in-time research.
  */
 
 import { NansenError, ErrorCode } from '../api.js';
@@ -41,6 +39,7 @@ const SUBCOMMANDS = [
 ];
 
 export const RESEARCH_HISTORICAL_SUBCOMMANDS = new Set(SUBCOMMANDS);
+export const RESEARCH_SUBCOMMANDS = new Set(['transaction-with-token-transfer-lookup', ...SUBCOMMANDS]);
 
 function requireOptions(options, required) {
   const missing = required.filter(name => !options[name]);
@@ -75,9 +74,11 @@ function parseChains(options) {
   return undefined;
 }
 
-const HELP_TOP = `nansen research — Historical/point-in-time analytics
+const HELP_TOP = `nansen research — Direct API analytics
 
 SUBCOMMANDS:
+  transaction-with-token-transfer-lookup
+                                   Look up a transaction and its token/NFT transfers
   historical-dex-trades             Historical DEX trades for a token
   historical-pnl-leaderboard        Historical PnL leaderboard for a token
   historical-token-flow-summary     Historical token flow summary
@@ -102,6 +103,12 @@ COMMON OPTIONS:
 Run: nansen research <subcommand> --help`;
 
 const SUB_HELP = {
+  'transaction-with-token-transfer-lookup': `nansen research transaction-with-token-transfer-lookup — Look up a transaction and its token/NFT transfers
+
+USAGE:
+  nansen research transaction-with-token-transfer-lookup --transaction-hash <hash> [--chain <chain>] [--block-timestamp "YYYY-MM-DD HH:MM:SS"]
+
+NOTE: --block-timestamp is required for bitcoin, tron, ton, starknet, and sui.`,
   'historical-dex-trades': `nansen research historical-dex-trades — Historical DEX trades for a token
 
 USAGE:
@@ -166,9 +173,9 @@ export function buildResearchCommands(deps = {}) {
         return;
       }
 
-      if (!RESEARCH_HISTORICAL_SUBCOMMANDS.has(sub)) {
+      if (!RESEARCH_SUBCOMMANDS.has(sub)) {
         throw new NansenError(
-          `Unknown research subcommand: ${sub}. Available: ${SUBCOMMANDS.join(', ')}`,
+          `Unknown research subcommand: ${sub}. Available: ${[...RESEARCH_SUBCOMMANDS].join(', ')}`,
           ErrorCode.UNKNOWN,
         );
       }
@@ -183,6 +190,20 @@ export function buildResearchCommands(deps = {}) {
       const filters = options.filters || {};
       const { fromDate, toDate } = resolveDateRange(options);
       const asOfDate = options['as-of-date'];
+
+      if (sub === 'transaction-with-token-transfer-lookup') {
+        const chain = options.chain || 'ethereum';
+        const blockTimestamp = options['block-timestamp'];
+        requireOptions({ 'transaction-hash': options['transaction-hash'] }, ['transaction-hash']);
+        if (['bitcoin', 'tron', 'ton', 'starknet', 'sui'].includes(chain)) {
+          requireOptions({ 'block-timestamp': blockTimestamp }, ['block-timestamp']);
+        }
+        return apiInstance.transactionWithTokenTransferLookup({
+          transactionHash: options['transaction-hash'],
+          chain,
+          blockTimestamp,
+        });
+      }
 
       // Range-based token endpoints (require --from-date + --to-date)
       const rangeTokenHandlers = {

--- a/src/commands/research.js
+++ b/src/commands/research.js
@@ -195,6 +195,8 @@ export function buildResearchCommands(deps = {}) {
         const chain = options.chain || 'ethereum';
         const blockTimestamp = options['block-timestamp'];
         requireOptions({ 'transaction-hash': options['transaction-hash'] }, ['transaction-hash']);
+        // 'all' is deliberately absent: the API resolves the hash across chains
+        // server-side and accepts it without a timestamp.
         if (['bitcoin', 'tron', 'ton', 'starknet', 'sui'].includes(chain)) {
           requireOptions({ 'block-timestamp': blockTimestamp }, ['block-timestamp']);
         }

--- a/src/schema.json
+++ b/src/schema.json
@@ -1162,6 +1162,22 @@
             }
           }
         },
+        "transaction-with-token-transfer-lookup": {
+          "endpoint": "/api/v1/transaction-with-token-transfer-lookup",
+          "description": "Look up a transaction and its token/NFT transfers",
+          "options": {
+            "transaction-hash": {
+              "required": true
+            },
+            "chain": {
+              "enum": ["all", "arbitrum", "avalanche", "base", "bitcoin", "bnb", "ethereum", "hyperevm", "injective", "iotaevm", "linea", "mantle", "mantra", "monad", "near", "optimism", "plasma", "robinhood", "sei", "sonic", "starknet", "sui", "ton", "tron"],
+              "default": "ethereum"
+            },
+            "block-timestamp": {
+              "description": "Block timestamp (required for bitcoin, tron, ton, starknet, and sui)"
+            }
+          }
+        },
         "historical-dex-trades": {
           "endpoint": "/api/v1beta1/tgm/historical-dex-trades",
           "description": "Historical DEX trades for a token at a point in time",


### PR DESCRIPTION
## Summary

- add `nansen research transaction-with-token-transfer-lookup`
- map transaction, chain, and timestamp options to the public API request
- enforce timestamp requirements for supported non-EVM chains and add focused documentation and tests

## Validation

- `npm test -- src/__tests__/research.test.js src/__tests__/coverage.test.js` — 88 passed
- `npm test` — 2,548 passed, 2 skipped
- `npm run lint`
- `git diff --check main...HEAD`