### PR TITLE
fix: keep research perp analytics-only

### DIFF
--- a/.changeset/restrict-research-perp-routing.md
+++ b/.changeset/restrict-research-perp-routing.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Keep `research perp` analytics-only instead of routing trading subcommands through the top-level perp dispatcher.

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -4381,6 +4381,48 @@ describe('research command routing', () => {
     expect(result.commands).toContain('screener');
   });
 
+  it('should keep research perp help analytics-only', async () => {
+    const commands = buildCommands({});
+    const result = await commands.research(['perp', 'help'], null, {}, {});
+    expect(result.commands).toEqual(['screener', 'leaderboard']);
+  });
+
+  it.each([
+    ['screener', 'perpScreener'],
+    ['leaderboard', 'perpLeaderboard'],
+  ])('should delegate research perp %s to the analytics handler', async (subcommand, method) => {
+    const mockApi = { [method]: vi.fn().mockResolvedValue({ data: [] }) };
+    const commands = buildCommands({});
+
+    await commands.research(['perp', subcommand], mockApi, {}, {});
+
+    expect(mockApi[method]).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    'order',
+    'cancel',
+    'close',
+    'leverage',
+    'transfer',
+    'approve-builder-fee',
+    'positions',
+    'orders',
+    'account',
+    'meta',
+  ])(
+    'should not route research perp %s to the top-level perp handler',
+    async (subcommand) => {
+      const commands = buildCommands({});
+
+      await expect(commands.research(['perp', subcommand], null, {}, {}))
+        .rejects.toMatchObject({
+          code: 'UNKNOWN',
+          message: `Unknown perp analytics subcommand: ${subcommand}. Available: screener, leaderboard`,
+        });
+    },
+  );
+
   it('should error on unknown category', async () => {
     const commands = buildCommands({});
     await expect(commands.research(['unknown'], null, {}, {}))

--- a/src/cli.js
+++ b/src/cli.js
@@ -1530,7 +1530,7 @@ export function buildCommands(deps = {}) {
       };
 
       if (!handlers[subcommand]) {
-        return { error: `Unknown subcommand: ${subcommand}`, available: Object.keys(handlers) };
+        throw new NansenError(`Unknown perp analytics subcommand: ${subcommand}. Available: screener, leaderboard`, ErrorCode.UNKNOWN);
       }
 
       return handlers[subcommand]();
@@ -1652,11 +1652,11 @@ export function buildCommands(deps = {}) {
       throw new NansenError(`Unknown research category: ${rawCategory}. Available: ${[...RESEARCH_CATEGORIES, ...RESEARCH_HISTORICAL_SUBCOMMANDS].join(', ')}`, ErrorCode.UNKNOWN);
     }
     // `research perp` reaches only the analytics half (screener/leaderboard) —
-    // the trading subcommands live at the top level. Routing its help through
-    // cmds['perp'] printed the trading help, advertising order/close/leverage
-    // from a command that can't run them.
-    if (category === 'perp' && (!args[1] || args[1] === 'help')) {
-      return perpAnalytics(['help'], apiInstance, flags, options);
+    // the trading subcommands live at the top level. Use the captured handler
+    // for every subcommand because cmds['perp'] is replaced below by the
+    // combined top-level trading dispatcher.
+    if (category === 'perp') {
+      return perpAnalytics(args.slice(1), apiInstance, flags, options);
     }
     return cmds[category](args.slice(1), apiInstance, flags, options);
   };


### PR DESCRIPTION
## Summary

Fixes #565.

research perp is intended to expose only the perpetual-futures analytics commands, while trading and account operations belong to the top-level perp namespace.

The research dispatcher previously looked up cmds[category] dynamically. Because the top-level perp trading dispatcher later replaced cmds.perp, commands such as research perp order were incorrectly routed to trading handlers.

## Changes

- routes every research perp invocation through the captured analytics-only handler
- preserves research perp screener, research perp leaderboard, and research perp help
- rejects unsupported analytics subcommands with a structured UNKNOWN error and a non-zero exit code
- prevents order, cancel, close, leverage, transfer, approve-builder-fee, positions, orders, account, and meta from reaching trading handlers through the research namespace
- preserves the behavior of the top-level perp trading dispatcher
- adds a patch changeset for the user-facing routing fix

## How to Test

The regression tests failed against the previous behavior because research perp reached the top-level trading handlers. They pass with this fix.

Verification:
- npx vitest run src/tests/cli.internal.test.js -t "research command routing" — 18 passed
- npx vitest run src/tests/cli.internal.test.js — 466 passed
- npx vitest run src/tests/perp.test.js — 79 passed
- npm test — 62 test files passed; 2,559 tests passed and 2 skipped
- npm run lint — passed
- git diff --check — passed
- real CLI verification confirmed that all tested top-level perp-only subcommands return UNKNOWN with exit code 1 under research perp
- independent code review found no logic errors, security concerns, or test gaps

## Checklist

- [x] Tests pass (npm test)
- [x] src/schema.json updated if new commands or flags were added — no new commands or flags were added, so no schema change is required
- [x] README.md updated if new top-level commands or categories were added — no new top-level commands or categories were added
- [x] Changeset added (.changeset/) — .changeset/restrict-research-perp-routing.md

## Risk & Impact

- preserves the behavior of the top-level perp trading dispatcher
- adds a patch changeset for the user-facing routing fix
- independent code review found no logic errors, security concerns, or test gaps