### PR TITLE
fix: reject non-finite limit order values

### DIFF
--- a/.changeset/reject-non-finite-limit-order-values.md
+++ b/.changeset/reject-non-finite-limit-order-values.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Reject non-finite limit-order trigger prices and expiry values before wallet or API activity.

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -189,6 +189,18 @@ describe('parseExpiry', () => {
     const past = Date.now() - 3600000;
     expect(() => parseExpiry(String(past))).toThrow(/in the past/);
   });
+
+  it.each([
+    'Infinity',
+    '-Infinity',
+    '1e309',
+  ])('rejects non-finite raw expiry value %s', (value) => {
+    expect(() => parseExpiry(value)).toThrow(/Invalid expiry/);
+  });
+
+  it('rejects an expiry duration that overflows to Infinity', () => {
+    expect(() => parseExpiry(`${'9'.repeat(400)}h`)).toThrow(/Invalid expiry/);
+  });
 });
 
 // ============= API Client Functions =============
@@ -498,6 +510,46 @@ describe('buildLimitOrderCommands', () => {
       expect(exit).toHaveBeenCalledWith(1);
       expect(logs.some(l => l.includes('positive number'))).toBe(true);
     });
+
+    it.each(['Infinity', '-Infinity', '1e309'])(
+      'rejects non-finite trigger price %s before wallet or API activity',
+      async (triggerPrice) => {
+        const wallet = `lo-create-price-${triggerPrice.replace('-', 'negative-')}`;
+        createTestWallet(wallet);
+        const logs = [];
+        const exit = vi.fn();
+        const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+        await cmds.create([], null, {}, {
+          from: '11111111111111111111111111111111', to: 'USDC', amount: '1', 'trigger-mint': 'SOL',
+          'trigger-condition': 'below', 'trigger-price': triggerPrice, wallet,
+        });
+
+        expect(exit).toHaveBeenCalledWith(1);
+        expect(logs).toContain('Error: --trigger-price must be a finite positive number.');
+        expect(global.fetch).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each(['Infinity', '-Infinity', '1e309'])(
+      'rejects non-finite expiry %s before wallet or API activity',
+      async (expires) => {
+        const wallet = `lo-create-expiry-${expires.replace('-', 'negative-')}`;
+        createTestWallet(wallet);
+        const logs = [];
+        const exit = vi.fn();
+        const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+        await cmds.create([], null, {}, {
+          from: '11111111111111111111111111111111', to: 'USDC', amount: '1', 'trigger-mint': 'SOL',
+          'trigger-condition': 'below', 'trigger-price': '80', expires, wallet,
+        });
+
+        expect(exit).toHaveBeenCalledWith(1);
+        expect(logs.some(l => l.includes(`Invalid expiry "${expires}"`))).toBe(true);
+        expect(global.fetch).not.toHaveBeenCalled();
+      },
+    );
 
     it('validates trigger-condition', async () => {
       const logs = [];
@@ -1009,6 +1061,25 @@ describe('buildLimitOrderCommands', () => {
       expect(patchBody.triggerPriceUsd).toBe(85);
       expect(patchBody.orderType).toBe('single');
     });
+
+    it.each(['Infinity', '-Infinity', '1e309'])(
+      'rejects non-finite trigger price %s before wallet or API activity',
+      async (triggerPrice) => {
+        const wallet = `lo-update-price-${triggerPrice.replace('-', 'negative-')}`;
+        createTestWallet(wallet);
+        const logs = [];
+        const exit = vi.fn();
+        const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+        await cmds.update([], null, {}, {
+          order: 'order-1', 'trigger-price': triggerPrice, wallet,
+        });
+
+        expect(exit).toHaveBeenCalledWith(1);
+        expect(logs).toContain('Error: --trigger-price must be a finite positive number.');
+        expect(global.fetch).not.toHaveBeenCalled();
+      },
+    );
 
     it('updates slippage', async () => {
       createTestWallet('lo-update-slip');

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -396,21 +396,32 @@ export function parseExpiry(expiryStr) {
   const match = expiryStr.match(/^(\d+)(h|d)$/i);
   if (match) {
     const value = parseInt(match[1], 10);
+    if (!Number.isFinite(value)) {
+      throw new Error(`Invalid expiry "${expiryStr}". Duration must be finite.`);
+    }
     if (value <= 0) {
       throw new Error(`Invalid expiry "${expiryStr}". Duration must be greater than 0.`);
     }
     const unit = match[2].toLowerCase();
     const ms = unit === 'h' ? value * 3600 * 1000 : value * 24 * 3600 * 1000;
-    return Date.now() + ms;
+    const expiresAt = Date.now() + ms;
+    if (!Number.isFinite(expiresAt)) {
+      throw new Error(`Invalid expiry "${expiryStr}". Duration is too large.`);
+    }
+    return expiresAt;
   }
 
   // Try as raw epoch ms — must be in the future, or the order expires on arrival.
   const num = Number(expiryStr);
-  if (!isNaN(num)) {
+  if (Number.isFinite(num)) {
     if (num <= Date.now()) {
       throw new Error(`Expiry "${expiryStr}" is in the past. Provide a future time (e.g. "24h", "7d", or a future epoch in ms).`);
     }
     return num;
+  }
+
+  if (!Number.isNaN(num)) {
+    throw new Error(`Invalid expiry "${expiryStr}". Provide a finite future epoch in milliseconds or a duration such as "24h" or "7d".`);
   }
 
   throw new Error(`Invalid expiry format: "${expiryStr}". Use "24h", "7d", "30d", or epoch ms.`);
@@ -569,6 +580,22 @@ EXAMPLES:
         return;
       }
 
+      const price = Number(triggerPrice);
+      if (!Number.isFinite(price) || price <= 0) {
+        log('Error: --trigger-price must be a finite positive number.');
+        exit(1);
+        return;
+      }
+
+      let expiresAt;
+      try {
+        expiresAt = parseExpiry(expiresStr);
+      } catch (err) {
+        log(`Error: ${err.message}`);
+        exit(1);
+        return;
+      }
+
       // Amount is always in human-readable token units (e.g. 1.5 = 1.5 SOL)
       // Converted to base units (lamports) internally
       let amountBaseUnits;
@@ -594,13 +621,6 @@ EXAMPLES:
         return;
       }
 
-      const price = Number(triggerPrice);
-      if (isNaN(price) || price <= 0) {
-        log('Error: --trigger-price must be a positive number (USD price).');
-        exit(1);
-        return;
-      }
-
       if (triggerCondition !== 'above' && triggerCondition !== 'below') {
         log('Error: --trigger-condition must be "above" or "below".');
         exit(1);
@@ -617,15 +637,6 @@ EXAMPLES:
           exit(1);
           return;
         }
-      }
-
-      let expiresAt;
-      try {
-        expiresAt = parseExpiry(expiresStr);
-      } catch (err) {
-        log(`Error: ${err.message}`);
-        exit(1);
-        return;
       }
 
       const triggerMint = resolveTokenAddress(triggerMintRaw, 'solana');
@@ -899,8 +910,8 @@ EXAMPLES:
       const updateBody = { orderType: 'single' };
       if (triggerPrice != null) {
         const price = Number(triggerPrice);
-        if (isNaN(price) || price <= 0) {
-          log('Error: --trigger-price must be a positive number.');
+        if (!Number.isFinite(price) || price <= 0) {
+          log('Error: --trigger-price must be a finite positive number.');
           exit(1);
           return;
         }


### PR DESCRIPTION
## Summary

Fixes #566.

Limit-order create and update accepted non-finite trigger prices such as Infinity and values such as 1e309 that overflow to Infinity.

The expiry parser had the same validation gap for raw epoch values. Extremely large duration values could also overflow while being converted to milliseconds.

These values passed local validation as JavaScript numbers, but JSON.stringify() serialized them as JSON null, allowing invalid CLI input to reach wallet, authentication, RPC, and API operations.

**Root cause**

The trigger-price validators used:

```js
const price = Number(triggerPrice);

if (isNaN(price) || price <= 0) {
  // reject
}
```

Infinity is not NaN and is greater than zero, so it passed this condition.

The raw expiry parser similarly used `!isNaN(num)` without requiring the converted value to be finite.

Additionally, the create path resolved token decimals through `getTokenInfo()` before validating the trigger price and expiry. For unknown but valid Solana mints, this could cause an outbound RPC request before the invalid value was rejected.

## Changes

- require create trigger prices to satisfy `Number.isFinite(price) && price > 0`
- apply the same finite-positive rule to update trigger prices
- reject Infinity, -Infinity, and numeric overflow values such as 1e309
- require raw expiry timestamps to be finite
- reject duration values that overflow while being parsed or converted to milliseconds
- move create trigger-price and expiry validation ahead of token decimal resolution
- ensure invalid trigger prices and expiries are rejected before:
  - token metadata RPC requests
  - wallet resolution
  - authentication
  - transaction construction or signing
  - limit-order API requests
- return actionable CLI errors:
  - `Error: --trigger-price must be a finite positive number.`
  - `Error: Invalid expiry "Infinity". Provide a finite future epoch in milliseconds or a duration such as "24h" or "7d".`
- add a patch changeset for the user-facing validation fix

## How to Test

**Regression coverage**

The added tests cover 13 cases:

- raw expiry:
  - Infinity
  - -Infinity
  - 1e309
  - a duration large enough to overflow to Infinity
- create trigger price:
  - Infinity
  - -Infinity
  - 1e309
- create expiry:
  - Infinity
  - -Infinity
  - 1e309
- update trigger price:
  - Infinity
  - -Infinity
  - 1e309

The create regression tests use a valid but unknown Solana mint. Resolving its decimals would require an RPC request if validation occurred too late. The tests assert that `global.fetch` is never called, proving rejection happens before RPC or API activity.

Before the fix, the new regression matrix produced:

Test Files 1 failed
Tests 13 failed | 76 skipped


After the fix:

$ npx vitest run src/tests/limit-order.test.js

Test Files 1 passed (1)
Tests 89 passed (89)


**Real CLI verification**

Create with a non-finite trigger price:

Error: --trigger-price must be a finite positive number.
exit=1


Create with a non-finite expiry:

Error: Invalid expiry "Infinity". Provide a finite future epoch in milliseconds or a duration such as "24h" or "7d".
exit=1


Update with a non-finite trigger price:

Error: --trigger-price must be a finite positive number.
exit=1


All three commands were rejected before wallet or network activity.

**Full test output**

$ npm test

Test Files 62 passed (62)
Tests 2559 passed | 2 skipped (2561)
Duration 164.57s


Additional checks:

$ npm run lint

nansen-cli@1.43.1 lint
eslint .

$ git diff origin/main --check
exit 0


## Checklist

- [x] Tests pass (npm test)
- [x] src/schema.json updated if new commands or flags were added — no commands or flags were added, so no schema change is required
- [x] README.md updated if new top-level commands or categories were added — no top-level commands or categories were added
- [x] Changeset added (.changeset/) — .changeset/reject-non-finite-limit-order-values.md

## Risk & Impact

A final independent review of the updated diff found no security concerns, logic errors, test gaps, or additional required changes.