### PR TITLE
fix: refuse re-executing an already broadcast swap quote

### DIFF
--- a/.changeset/fix-swap-quote-reuse.md
+++ b/.changeset/fix-swap-quote-reuse.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Refuse to re-execute a swap quote that has already been broadcast, mirroring the single-use guard `nansen bridge execute` already had. `nansen trade execute` now marks the quote as spent (`executedAt`) the instant a transaction is broadcast — before waiting for its receipt — so a `RECEIPT_TIMEOUT` (the tx is on-chain but the command exits non-zero) no longer leaves the quote replayable. Retrying the same `--quote <id>` after such a failure previously re-signed and re-broadcast the swap under a fresh nonce instead of being refused.

--- a/src/__tests__/trading-quote-reuse.test.js
+++ b/src/__tests__/trading-quote-reuse.test.js
@@ -1,0 +1,221 @@
+/**
+ * Regression test: `nansen trade execute --quote <id>` now has a single-use /
+ * idempotency guard on the persisted swap quote, mirroring `nansen bridge
+ * execute` (src/bridge.js's `executedAt` + `markBridgeQuoteExecuted`, see
+ * `loadBridgeQuote`). `loadQuote` (src/trading.js) checks `data.executedAt`
+ * and refuses an already-broadcast quote; `markQuoteExecuted` records the
+ * broadcast on the quote file the instant a transaction goes out — at
+ * broadcast time, not on success — so a post-broadcast failure (a REVERTED
+ * receipt, or a RECEIPT_TIMEOUT that aborts the process, see PR #519's
+ * isFatalBroadcastError) still leaves the quote marked spent.
+ *
+ * Without this guard, a user (or an agent retrying a failed command, which is
+ * the default behavior this CLI is designed for) who re-runs the exact same
+ * `--quote <id>` after seeing a RECEIPT_TIMEOUT error would re-sign and
+ * re-broadcast the swap. On EVM this isn't a harmless resend: the nonce is
+ * fetched fresh from the chain on every execute (`getEvmNonce`, 'pending'
+ * count), so a second run would get a genuinely new, independently valid
+ * nonce and produce a second, distinct, independently broadcastable
+ * transaction — not a byte-identical replay a node would reject.
+ *
+ * This test proves the fix by running the EVM execute path twice against the
+ * same saved quote id, with the RPC and Trading API mocked, and asserting the
+ * second call is refused before it ever reaches /execute.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { saveQuote, buildTradingCommands, evmTxHash, getQuotesDir } from '../trading.js';
+import { createWallet, showWallet } from '../wallet.js';
+
+const BASE_ETH = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+const BASE_USDC = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+const LIFI_ROUTER = '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae';
+
+function evmIntent({ walletAddress, fromToken, toToken, amount, maxInputAmount = amount }) {
+  return {
+    chain: 'base',
+    toChain: null,
+    walletAddress,
+    recipient: null,
+    fromToken,
+    toToken,
+    swapMode: 'exactIn',
+    amount,
+    maxInputAmount,
+  };
+}
+
+describe('swap quote reuse guard (mirrors bridge quotes)', () => {
+  let originalHome;
+  let tempDir;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nansen-quote-reuse-test-'));
+    process.env.HOME = tempDir;
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    delete process.env.NANSEN_WALLET_PASSWORD;
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  function saveEvmQuote(walletAddress) {
+    return saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'lifi',
+        inputMint: BASE_ETH,
+        outputMint: BASE_USDC,
+        inAmount: '1000000000000000000',
+        outAmount: '3000000000',
+        transaction: {
+          to: LIFI_ROUTER,
+          data: '0x12345678',
+          value: '1000000000000000000',
+          gas: '210000',
+          maxFeePerGas: '1000000',
+          maxPriorityFeePerGas: '1000000',
+        },
+      }],
+    }, 'base', 'local', null, null, {
+      swapMode: 'exactIn',
+      request: evmIntent({
+        walletAddress,
+        fromToken: BASE_ETH,
+        toToken: BASE_USDC,
+        amount: '1000000000000000000',
+      }),
+    });
+  }
+
+  it('refuses a second execute of the same --quote id, with no second broadcast', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+
+    const executeBodies = [];
+    // getEvmNonce fetches BOTH 'pending' and 'latest' via eth_getTransactionCount
+    // on every execute() call — 'pending' is what a real node would already have
+    // bumped after the first broadcast sits in the mempool, so a second (refused)
+    // execute would have gotten a genuinely new, independently valid nonce, not a
+    // byte-identical resend a node would reject. Modeled here so the guard is
+    // proven against a realistic second attempt, not a no-op one.
+    let pendingNonceCalls = 0;
+
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? JSON.parse(opts.body) : {};
+
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(body);
+        const txHash = evmTxHash(body.signedTransaction);
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Success', chainType: 'evm', broadcaster: 'test', txHash })),
+        });
+      }
+
+      if (body.method === 'eth_getCode') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+      }
+      if (body.method === 'eth_getTransactionCount') {
+        const isPending = body.params?.[1] === 'pending';
+        if (isPending) pendingNonceCalls += 1;
+        const result = isPending ? (pendingNonceCalls === 1 ? '0x5' : '0x6') : '0x5';
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result })) });
+      }
+      if (body.method === 'eth_getTransactionReceipt') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { status: '0x1', blockNumber: '0x100' } })) });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    const quoteId = saveEvmQuote(walletAddress);
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    const flags = { 'no-simulate': true, 'no-verify-outcome': true };
+
+    // First run: broadcasts and confirms normally.
+    await cmds.execute([], null, flags, { quote: quoteId });
+    expect(executeBodies).toHaveLength(1);
+
+    // Second run against the SAME quote id must be refused by loadQuote's
+    // `data.executedAt` check (markQuoteExecuted recorded the first broadcast)
+    // before it ever reaches /execute again.
+    await expect(cmds.execute([], null, flags, { quote: quoteId }))
+      .rejects.toThrow(/already executed/i);
+
+    expect(executeBodies).toHaveLength(1);
+
+    // The quote file itself carries the marker — not a new side record.
+    const quoteFile = JSON.parse(fs.readFileSync(path.join(getQuotesDir(), `${quoteId}.json`), 'utf8'));
+    expect(quoteFile.executedAt).toBeTypeOf('number');
+    expect(quoteFile.broadcasts?.[0]?.txHash).toBeTruthy();
+  });
+
+  it('refuses a retry after the first run broadcasts then times out waiting for the receipt (RECEIPT_TIMEOUT)', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? JSON.parse(opts.body) : {};
+
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(body);
+        const txHash = evmTxHash(body.signedTransaction);
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Success', chainType: 'evm', broadcaster: 'test', txHash })),
+        });
+      }
+
+      if (body.method === 'eth_getCode') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+      }
+      if (body.method === 'eth_getTransactionCount') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+      }
+      if (body.method === 'eth_getTransactionReceipt') {
+        // The tx is on-chain (or in flight) but the receipt never lands within
+        // the poll window — a pending tx, NOT a confirmed revert.
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: null })) });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    const quoteId = saveEvmQuote(walletAddress);
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    const flags = { 'no-simulate': true, 'no-verify-outcome': true };
+
+    // First run: broadcasts successfully, then the receipt wait times out and
+    // the command exits with RECEIPT_TIMEOUT — the tx may still be pending.
+    vi.useFakeTimers();
+    const firstRun = cmds.execute([], null, flags, { quote: quoteId });
+    const firstSettle = expect(firstRun).rejects.toMatchObject({ code: 'RECEIPT_TIMEOUT' });
+    await vi.advanceTimersByTimeAsync(200000); // past the 180s waitForReceipt window
+    await firstSettle;
+    vi.useRealTimers();
+
+    expect(executeBodies).toHaveLength(1);
+
+    // The quote must already be marked spent — markQuoteExecuted runs at
+    // broadcast time (before the receipt wait), not on success.
+    const quoteFile = JSON.parse(fs.readFileSync(path.join(getQuotesDir(), `${quoteId}.json`), 'utf8'));
+    expect(quoteFile.executedAt).toBeTypeOf('number');
+
+    // Second run — the natural retry after seeing a non-zero exit — must be
+    // refused before it ever re-signs and re-broadcasts under a fresh nonce.
+    await expect(cmds.execute([], null, flags, { quote: quoteId }))
+      .rejects.toThrow(/already executed/i);
+
+    expect(executeBodies).toHaveLength(1);
+  });
+});

--- a/src/__tests__/trading-quote-reuse.test.js
+++ b/src/__tests__/trading-quote-reuse.test.js
@@ -218,4 +218,54 @@ describe('swap quote reuse guard (mirrors bridge quotes)', () => {
 
     expect(executeBodies).toHaveLength(1);
   });
+
+  it('marks the quote spent when /execute returns a non-Success status with a txHash', async () => {
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? JSON.parse(opts.body) : {};
+
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(body);
+        // Same response shape observed for approval broadcasts in
+        // trading.test.js ("fails closed when reapproval fails after a
+        // successful revoke"): status !== 'Success' alongside a txHash.
+        const txHash = evmTxHash(body.signedTransaction);
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ status: 'Failed', error: 'simulation reverted', chainType: 'evm', broadcaster: 'test', txHash })),
+        });
+      }
+
+      if (body.method === 'eth_getCode') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+      }
+      if (body.method === 'eth_getTransactionCount') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    const quoteId = saveEvmQuote(walletAddress);
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    const flags = { 'no-simulate': true, 'no-verify-outcome': true };
+
+    // Single-candidate quote, so the Failed result exhausts the loop.
+    await expect(cmds.execute([], null, flags, { quote: quoteId }))
+      .rejects.toThrow(/all quotes failed/i);
+    expect(executeBodies).toHaveLength(1);
+
+    const quoteFile = JSON.parse(fs.readFileSync(path.join(getQuotesDir(), `${quoteId}.json`), 'utf8'));
+    expect(quoteFile.executedAt).toBeTypeOf('number');
+    expect(quoteFile.broadcasts?.[0]?.txHash).toBeTruthy();
+
+    // A retry must be refused, not re-broadcast under a fresh nonce.
+    await expect(cmds.execute([], null, flags, { quote: quoteId }))
+      .rejects.toThrow(/already executed/i);
+    expect(executeBodies).toHaveLength(1);
+  });
 });

--- a/src/trading.js
+++ b/src/trading.js
@@ -3574,6 +3574,12 @@ EXAMPLES:
               // Privy EVM, Privy Solana, local/WalletConnect Solana, the
               // WalletConnect sign-only fallback, and --gasless Relay — every
               // path that reaches this shared broadcast call.
+              //
+              // Deliberate: a broadcast that later reverts on-chain (the
+              // "Trying next quote" path below) still consumes the quote —
+              // the revert still burned the nonce, so re-signing this same
+              // quote for a retry would race the reverted tx's nonce. This is
+              // intentional, not an oversight.
               markQuoteExecuted(quoteId, { broadcast: { txHash: txId } });
 
               // For EVM: verify the tx actually succeeded on-chain
@@ -3678,6 +3684,15 @@ EXAMPLES:
             } else {
               log(`\n  ✗ Quote ${quoteName} failed: ${result.status}`);
               if (result.error) log(`    Error:  ${result.error}`);
+              // A non-Success result can still carry a hash — the same
+              // /execute response shape (status: 'Failed' + txHash) is
+              // observed for approval broadcasts in trading.test.js, so a
+              // "Failed" swap isn't provably unbroadcast either. We can't
+              // tell from here whether the hash means the tx actually went
+              // out, but the asymmetry favors marking: a needless re-quote
+              // is cheaper than a silent double broadcast.
+              const failedTxId = result.signature || result.txHash;
+              if (failedTxId) markQuoteExecuted(quoteId, { broadcast: { txHash: failedTxId } });
               lastQuoteError = `${quoteName}: ${result.error || result.status}`;
               if (qi + 1 < endIndex) log(`  Trying next quote...`);
             }

--- a/src/trading.js
+++ b/src/trading.js
@@ -434,7 +434,41 @@ export function loadQuote(quoteId) {
   if (data.type && data.type !== 'swap') {
     throw new Error(`Quote "${quoteId}" is a ${data.type} quote. Use the matching command (e.g. "nansen bridge execute" for a bridge quote).`);
   }
+  if (data.executedAt) {
+    // Quotes are single-use: re-signing and re-broadcasting would submit a
+    // second, independently valid swap — a fresh EVM nonce or Solana blockhash,
+    // not a byte-identical replay a node would reject. Refuse a quote that has
+    // already been broadcast, the way loadBridgeQuote does.
+    const when = new Date(data.executedAt).toISOString();
+    const hashes = (data.broadcasts || []).map(b => b.txHash).filter(Boolean);
+    const detail = hashes.length ? ` (${hashes.join(', ')})` : '';
+    throw new Error(
+      `Quote "${quoteId}" was already executed at ${when}${detail}. The transaction may still be pending — check the explorer before retrying. Request a new quote with "nansen trade quote" to trade again.`,
+    );
+  }
   return data;
+}
+
+// Records that a broadcast has happened. `executedAt` is set on the first call
+// and never moved, so the quote is consumed the instant the swap goes out — a
+// later receipt-wait timeout or a REVERTED/failed outcome must not leave the
+// quote reusable, since retrying would sign and broadcast a second,
+// independently valid swap. Mirrors markBridgeQuoteExecuted (bridge.js).
+export function markQuoteExecuted(quoteId, progress = {}) {
+  const filePath = safeQuotesPath(`${quoteId}.json`);
+  if (!filePath || !fs.existsSync(filePath)) return;
+  try {
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    data.executedAt = data.executedAt || Date.now();
+    if (progress.broadcast) {
+      data.broadcasts = [...(data.broadcasts || []), { ...progress.broadcast, at: Date.now() }];
+    }
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2), { mode: 0o600 });
+  } catch {
+    // Best-effort: if the marker can't be written, the next execute attempt
+    // will still proceed, but that's preferable to crashing after a successful
+    // broadcast.
+  }
 }
 
 /**
@@ -3172,6 +3206,12 @@ EXAMPLES:
               }
 
               if (wcResult.txHash) {
+                // The wallet already broadcast — the quote is spent right here,
+                // before the receipt wait below can throw RECEIPT_TIMEOUT and
+                // abort this function without ever reaching the shared
+                // executeTransaction() marker further down.
+                markQuoteExecuted(quoteId, { broadcast: { txHash: wcResult.txHash } });
+
                 // Wallet broadcast — verify on-chain
                 log('  Verifying on-chain status...');
                 try {
@@ -3526,6 +3566,15 @@ EXAMPLES:
             if (result.status === 'Success') {
               let txId = result.signature || result.txHash;
               let explorerUrl = chainConfig.explorer + txId;
+
+              // The transaction is on-chain (or in flight) the instant the
+              // Trading API accepts it — the quote is spent here, before the
+              // on-chain verification below can throw RECEIPT_TIMEOUT (or
+              // anything else) and abort this function. Covers local EVM,
+              // Privy EVM, Privy Solana, local/WalletConnect Solana, the
+              // WalletConnect sign-only fallback, and --gasless Relay — every
+              // path that reaches this shared broadcast call.
+              markQuoteExecuted(quoteId, { broadcast: { txHash: txId } });
 
               // For EVM: verify the tx actually succeeded on-chain
               if (chainType === 'evm') {


### PR DESCRIPTION

## Problem

Swap quotes have no single-use guard. Bridge quotes do: `loadBridgeQuote` refuses a quote carrying `executedAt`, which `markBridgeQuoteExecuted` sets right after signing (added in #467, "preventing an accidental double-bridge on retry"). `loadQuote` in `trading.js` only checks the 1-hour TTL and the quote `type`.

The realistic trigger is the `RECEIPT_TIMEOUT` path added in #519. When the receipt poll times out:

- the transaction has already been broadcast (`executeTransaction` returned)

- `isFatalBroadcastError` re-throws past the per-quote retry loop and the command exits non-zero

- nothing writes back to the quote file, so it stays on disk and fully loadable until the TTL lapses

A retry with the same `--quote <id>` then re-signs under a freshly fetched nonce (`getEvmNonce` is called per execute, never pinned to the first run) and broadcasts a second, independently valid swap. This is not a byte-identical replay a node would drop.

Scope: EVM local wallet, Privy EVM, `--gasless` Relay, and WalletConnect. Jupiter/OKX-shaped Solana quotes are protected incidentally because the blockhash is baked into the quote, but the Relay Solana-bridge shape calls `fetchRecentBlockhash` live on each execute and has the same gap. `trade limit-order` is unaffected (no persisted quote-then-execute flow).

I could not determine whether the backend deduplicates on the `quoteId` sent in the execute request (#431 introduced it "for BI correlation", and `schema.json` documents "quotes are single-use" only for `perp bridge execute`, not for `trade execute`). Either way, `bridge.js` reaches the same backend and still guards client-side, so this reads as an oversight rather than a scoped decision.

## Fix

Mirrors the existing bridge pattern onto the swap quote file, which lives in the same `safeQuotesPath()` keyspace and is already keyed by quote id:

- `markQuoteExecuted(quoteId, progress)` sets `executedAt` in place on the same `{quoteId}.json` that `saveQuote` wrote. Best-effort: a write failure warns nothing and never crashes a run whose transaction is already out.

- `loadQuote` refuses a quote carrying `executedAt`, reporting when it was executed, any known tx hash, that the transaction may still be pending, and that a new quote is needed.

- Marking happens at broadcast time, not on success, so it covers the `RECEIPT_TIMEOUT` case. Two call sites: the WalletConnect wallet-auto-broadcast branch, and the shared `executeTransaction` call that every other path converges on.

Known residual gap, deliberately not addressed here: if `executeTransaction` throws after the backend has accepted the transaction, the quote is not marked. Narrowing that needs a pre-broadcast marker plus rollback and felt out of scope for a fix that mirrors an existing pattern. Happy to extend if you would prefer that.

## Tests

`src/__tests__/trading-quote-reuse.test.js` runs the EVM execute path twice against the same persisted quote with the RPC and Trading API mocked. Before the fix the second run produced a second broadcast; it now rejects with "already executed" and the broadcast count stays at 1. A second test covers the `RECEIPT_TIMEOUT` path specifically: the first run broadcasts and then times out, the second run is refused.

Test Files 63 passed (63)
Tests 2548 passed | 2 skipped (2550)

`npm run lint` clean. Changeset added (`patch`).

