### PR TITLE
test: give the npm-pack integration test a longer timeout

### DIFF
--- a/src/__tests__/package.test.js
+++ b/src/__tests__/package.test.js
@@ -53,7 +53,7 @@ describe('Package Integrity', () => {
 
     // Cleanup tarball
     rmSync(tgzPath, { force: true });
-  });
+  }, 180000); // `npm install` of a local tarball is fully synchronous and can be slow on a cold CI runner
 
   it('should not include test files in package', () => {
     const packOutput = execSync('npm pack --dry-run --json', {


### PR DESCRIPTION
## Summary
- `Package Integrity > should run after npm pack` runs `npm pack` + a real `npm install` of the local tarball fully synchronously, with no per-test timeout override, against the global 30s `testTimeout`.
- Because the test body is one blocking synchronous chain, Vitest can't preempt it — on a cold CI runner where `npm install` takes longer than 30s, the test only reports "Test timed out in 30000ms" after the sync work finally finishes (seen at 421s and 138s of real wall time on PR #569's CI, on two different Node versions).
- Bumped this single test's timeout to 180s so a slow-but-successful install doesn't get reported as a failure.

## Test plan
- [x] `npx vitest run src/__tests__/package.test.js` passes locally
- [x] `npm run lint` passes
- [x] `npm test` (full suite) passes: 63/63 files, 2549/2551 tests (2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)