### PR TITLE
fix: changelog --since matches nothing for partial version input

### DIFF
--- a/.changeset/fix-changelog-since-partial-version.md
+++ b/.changeset/fix-changelog-since-partial-version.md
@@ -1,0 +1,7 @@
+---
+"nansen-cli": patch
+---
+
+Fix `nansen changelog --since <version>` silently returning "No changelog entries found" for a version missing its patch number (e.g. `--since 1.43` instead of `--since 1.43.0`), even when matching entries exist. The comparison compared the missing component against `undefined`, and `>` is always `false` against `undefined` in both directions, so a version that matched on major.minor always came out "less than" the since-value. A missing component is now treated as `0`, and a `--since` value that isn't a valid version (e.g. `--since abc`) now prints a clear error instead of silently matching nothing.
+
+The version-comparison logic is now shared (`src/semver.js`) between `nansen changelog --since` and the update-notifier's `isNewer` check, which had the identical bug in its own separate parser. `isNewer` couldn't misfire in practice (both versions it compares are always fully-qualified x.y.z today), but it's the same defect class, so it's fixed the same way rather than left in place.

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -3333,6 +3333,57 @@ describe('Response Caching', () => {
   });
 });
 
+// compareSemver's own unit tests live in src/__tests__/semver.test.js
+// (its canonical home, src/semver.js). What belongs here is the CLI
+// command's behavior — that --since is validated and filters correctly —
+// not a re-test of the comparison function's arithmetic.
+describe('changelog command --since', () => {
+  function runChangelog(options) {
+    const logs = [];
+    const commands = buildCommands({ log: (m) => logs.push(m), exit: vi.fn() });
+    return commands.changelog([], null, {}, options).then(() => logs.join('\n'));
+  }
+
+  it('rejects a non-numeric --since value with a clear error instead of silently matching nothing', async () => {
+    const out = await runChangelog({ since: 'abc' });
+    expect(out).toBe('Invalid --since value "abc": expected a version like 1.43 or 1.43.0.');
+  });
+
+  it('rejects a malformed --since value like "1.2.3.4"', async () => {
+    const out = await runChangelog({ since: '1.2.3.4' });
+    expect(out).toContain('Invalid --since value "1.2.3.4"');
+  });
+
+  it('a --since value missing the patch component reads as .0, not as always-less-than-everything (regression for the "1.43 vs 1.43.1" bug)', async () => {
+    // Read the real CHANGELOG.md the command itself reads, and use whatever
+    // its current newest version's major.minor happens to be, so this
+    // doesn't hardcode a version number that goes stale as new releases
+    // land. The exact patch number doesn't matter here — only that a
+    // major.minor-only --since behaves like its explicit ".0" form.
+    const changelogPath = new URL('../../CHANGELOG.md', import.meta.url).pathname;
+    const content = fs.readFileSync(changelogPath, 'utf8');
+    const headingMatch = content.match(/^## \[?(\d+\.\d+)\.\d+\]?/m);
+    expect(headingMatch).not.toBeNull();
+    const [, majorMinor] = headingMatch;
+
+    const explicitZeroForm = await runChangelog({ since: `${majorMinor}.0` });
+    const partialForm = await runChangelog({ since: majorMinor });
+
+    // Before the fix this always fell through to "No changelog entries
+    // found", because compareSemver compared the real patch number against
+    // `undefined` and that is never >= 0 in either direction — so a
+    // major.minor-only --since matched nothing, even entries for that exact
+    // major.minor.
+    expect(partialForm).not.toContain('No changelog entries found');
+    expect(partialForm).toBe(explicitZeroForm);
+  });
+
+  it('a --since value far in the future still reports the no-match message clearly (not an error)', async () => {
+    const out = await runChangelog({ since: '9999.0.0' });
+    expect(out).toBe('No changelog entries found for versions >= 9999.0.0');
+  });
+});
+
 describe('cache command', () => {
   it('should clear cache with clear subcommand', async () => {
     const logs = [];

--- a/src/__tests__/semver.test.js
+++ b/src/__tests__/semver.test.js
@@ -1,0 +1,52 @@
+/**
+ * Tests for compareSemver (src/semver.js) — the shared version-comparison
+ * implementation used by `nansen changelog --since` (src/cli.js) and the
+ * update-notifier's `isNewer` (src/update-check.js).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compareSemver } from '../semver.js';
+
+describe('compareSemver', () => {
+  it('compares full x.y.z versions numerically, not lexically', () => {
+    expect(compareSemver('1.43.1', '1.43.0')).toBe(1);
+    expect(compareSemver('1.43.0', '1.43.1')).toBe(-1);
+    expect(compareSemver('1.43.0', '1.43.0')).toBe(0);
+    expect(compareSemver('1.9.0', '1.10.0')).toBe(-1); // numeric, not string, comparison
+    expect(compareSemver('2.0.0', '1.99.99')).toBe(1);
+  });
+
+  it('treats a missing patch component as .0, not as always-less-than', () => {
+    // Regression: comparing a real patch number against `undefined` (from a
+    // "1.43"-shaped input with no third component) made every `>` check
+    // false in both directions, so a version that matched on major.minor
+    // always came out "less than" — even 1.43.1 vs "1.43".
+    expect(compareSemver('1.43.1', '1.43')).toBe(1);
+    expect(compareSemver('1.43.0', '1.43')).toBe(0);
+    expect(compareSemver('1.42.9', '1.43')).toBe(-1);
+  });
+
+  it('treats a missing minor and patch component as .0.0', () => {
+    expect(compareSemver('2.0.0', '2')).toBe(0);
+    expect(compareSemver('2.1.0', '2')).toBe(1);
+    expect(compareSemver('1.9.0', '2')).toBe(-1);
+  });
+
+  it('ignores a leading "v"', () => {
+    expect(compareSemver('v1.43.1', 'v1.43.0')).toBe(1);
+  });
+
+  it('is symmetric: swapping arguments negates the result', () => {
+    expect(compareSemver('1.43.1', '1.43.0')).toBe(-compareSemver('1.43.0', '1.43.1'));
+    // Equal-after-normalization case: both directions must be exactly 0
+    // (not +0 vs -0 — `toBe` uses Object.is, so assert each side directly
+    // rather than negating one into the other).
+    expect(compareSemver('1.43', '1.43.0')).toBe(0);
+    expect(compareSemver('1.43.0', '1.43')).toBe(0);
+  });
+
+  it('treats both sides missing components consistently (e.g. "2" vs "2.0")', () => {
+    expect(compareSemver('2', '2.0')).toBe(0);
+    expect(compareSemver('2', '2.0.0')).toBe(0);
+  });
+});

--- a/src/__tests__/update-check.test.js
+++ b/src/__tests__/update-check.test.js
@@ -15,6 +15,7 @@ import path from 'path';
 import os from 'os';
 import http from 'http';
 import childProcess from 'child_process';
+import { isNewer } from '../update-check.js';
 
 // We need to test with a controlled cache file, so we'll write to
 // the real ~/.nansen/update-check.json and clean up after.
@@ -52,6 +53,32 @@ function writeCache(data) {
 function removeCache() {
   try { fs.unlinkSync(CACHE_FILE); } catch { /* ignore */ }
 }
+
+// =================== isNewer ===================
+
+describe('isNewer', () => {
+  it('detects a newer full x.y.z version', () => {
+    expect(isNewer('1.44.0', '1.43.9')).toBe(true);
+    expect(isNewer('1.43.9', '1.44.0')).toBe(false);
+    expect(isNewer('1.43.0', '1.43.0')).toBe(false);
+  });
+
+  it('treats a version missing a component as reading .0 for it, not as unreachable (regression)', () => {
+    // Before delegating to the shared compareSemver, isNewer had its own
+    // parser with the identical undefined-vs-number bug that
+    // `nansen changelog --since` had: a version string with fewer than 3
+    // components parsed its missing part as `undefined`, and `>` is always
+    // `false` against `undefined` in both directions — so a partial "latest"
+    // could never register as newer, no matter how new it actually was.
+    expect(isNewer('1.44', '1.43.9')).toBe(true);
+    expect(isNewer('2', '1.99.99')).toBe(true);
+    expect(isNewer('1.43', '1.43.0')).toBe(false);
+  });
+
+  it('ignores a leading "v"', () => {
+    expect(isNewer('v1.44.0', 'v1.43.0')).toBe(true);
+  });
+});
 
 // =================== getUpdateNotification ===================
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -169,12 +169,6 @@ export function compactSchema(schema) {
   };
 }
 
-// compareSemver is imported above (from src/semver.js, shared with
-// update-check.js) and re-exported here so this module's tests can import it
-// from '../cli.js' alongside the other CLI internals they already pull from
-// this file.
-export { compareSemver };
-
 export function parseArgs(args) {
   const result = { _: [], flags: {}, options: {} };
   

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,6 +14,7 @@ import { buildAgentCommands } from './commands/agent.js';
 import { buildMcpCommands } from './commands/mcp.js';
 import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS } from './commands/research.js';
 import { resolveAddress, isEnsName } from './ens.js';
+import { compareSemver } from './semver.js';
 import fs from 'fs';
 import { getUpdateNotification, getUpgradeNotice, scheduleUpdateCheck } from './update-check.js';
 import { getAuthStatus, runDoctorChecks, runConnectivityChecks, formatDoctorReport } from './doctor.js';
@@ -168,18 +169,11 @@ export function compactSchema(schema) {
   };
 }
 
-/**
- * Compare two semver strings. Returns 1 if a > b, -1 if a < b, 0 if equal.
- */
-function compareSemver(a, b) {
-  const parse = v => v.replace(/^v/, '').split('.').map(Number);
-  const [aM, am, ap] = parse(a);
-  const [bM, bm, bp] = parse(b);
-  if (aM !== bM) return aM > bM ? 1 : -1;
-  if (am !== bm) return am > bm ? 1 : -1;
-  if (ap !== bp) return ap > bp ? 1 : -1;
-  return 0;
-}
+// compareSemver is imported above (from src/semver.js, shared with
+// update-check.js) and re-exported here so this module's tests can import it
+// from '../cli.js' alongside the other CLI internals they already pull from
+// this file.
+export { compareSemver };
 
 export function parseArgs(args) {
   const result = { _: [], flags: {}, options: {} };
@@ -1132,6 +1126,15 @@ export function buildCommands(deps = {}) {
       }
       const since = _options.since;
       if (since) {
+        // compareSemver treats a missing trailing component as 0, so accept
+        // "1", "1.43", and "1.43.0" alike here — but anything that isn't
+        // digits-and-dots (e.g. "abc") needs a clear error instead of
+        // silently comparing as if it were version 0.0.0, which would show
+        // every entry rather than flag the typo.
+        if (!/^v?\d+(\.\d+){0,2}$/.test(String(since))) {
+          log(`Invalid --since value "${since}": expected a version like 1.43 or 1.43.0.`);
+          return;
+        }
         // Show only entries from the given version onwards
         const lines = content.split('\n');
         const filtered = [];

--- a/src/semver.js
+++ b/src/semver.js
@@ -1,0 +1,26 @@
+/**
+ * Compare two semver strings. Returns 1 if a > b, -1 if a < b, 0 if equal.
+ *
+ * A missing trailing component is treated as 0 ("1.43" reads as "1.43.0"),
+ * not as `undefined` — `undefined` would make every `>` comparison against it
+ * false in both directions, so a version that matches on major.minor always
+ * came out "less than" a value that only specified major.minor (e.g.
+ * `compareSemver('1.43.1', '1.43')` fell through to comparing `1 > undefined`,
+ * which is false, so it returned -1 instead of 1).
+ *
+ * Shared by `nansen changelog --since` (src/cli.js) and the update-notifier's
+ * version check (src/update-check.js) so both compare versions the same,
+ * correct way instead of each hand-rolling its own parser.
+ */
+export function compareSemver(a, b) {
+  const parse = v => {
+    const parts = String(v).replace(/^v/, '').split('.').map(Number);
+    return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
+  };
+  const [aM, am, ap] = parse(a);
+  const [bM, bm, bp] = parse(b);
+  if (aM !== bM) return aM > bM ? 1 : -1;
+  if (am !== bm) return am > bm ? 1 : -1;
+  if (ap !== bp) return ap > bp ? 1 : -1;
+  return 0;
+}

--- a/src/update-check.js
+++ b/src/update-check.js
@@ -9,6 +9,7 @@ import fs from 'fs';
 import path from 'path';
 import childProcess from 'child_process';
 import { fileURLToPath } from 'url';
+import { compareSemver } from './semver.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const CONFIG_DIR = path.join(process.env.HOME || process.env.USERPROFILE || '', '.nansen');
@@ -19,14 +20,20 @@ const PACKAGE_NAME = 'nansen-cli';
 /**
  * Compare two semver strings. Returns true if latest > current.
  * Exported so `nansen doctor` reports upgrade state with identical semantics.
+ *
+ * Delegates to the shared compareSemver (src/semver.js, also used by `nansen
+ * changelog --since`) instead of hand-rolling its own parser. The previous
+ * inline parser here had the same bug compareSemver used to have: a version
+ * string with fewer than 3 components (e.g. a hand-edited or truncated cache
+ * file) parsed its missing component as `undefined`, and `>` is always
+ * `false` against `undefined` in both directions — so a partial version
+ * always read as "not newer", never "newer". In practice both `latest` (from
+ * the npm registry) and `current` (from this package's own version) are
+ * always full x.y.z today, so this couldn't misfire yet — but it's the same
+ * defect class, so it's fixed the same way rather than left as a landmine.
  */
 export function isNewer(latest, current) {
-  const parse = v => v.replace(/^v/, '').split('.').map(Number);
-  const [lM, lm, lp] = parse(latest);
-  const [cM, cm, cp] = parse(current);
-  if (lM !== cM) return lM > cM;
-  if (lm !== cm) return lm > cm;
-  return lp > cp;
+  return compareSemver(latest, current) > 0;
 }
 
 const LAST_VERSION_FILE = path.join(CONFIG_DIR, 'last-version.json');


### PR DESCRIPTION
## Summary

- Fixes `nansen changelog --since <version>` silently matching nothing when `<version>` is missing its patch component (e.g. `--since 1.43`), even though matching entries exist. The comparison compared the missing component against `undefined`, and `>` is always `false` against `undefined` in both directions.
- A missing version component is now treated as `0` (`1.43` reads as `1.43.0`), and a `--since` value that isn't a valid version (e.g. `--since abc`) now prints a clear error instead of silently matching nothing.
- The comparison logic is now shared (`src/semver.js`) between `nansen changelog --since` and the update-notifier's `isNewer` check (`src/update-check.js`), which had the identical bug in its own separate parser. `isNewer` couldn't misfire in practice (both versions it compares are always fully-qualified `x.y.z` today), but it's the same defect class, so it's fixed the same way rather than left in place.

Fixes #571

## Test plan

    $ npm test
    ...
     Test Files  63 passed (63)
          Tests  2559 passed | 2 skipped (2561)
       Duration  254.63s

    $ npm run lint
    (no output -- clean)

- [x] `npm test` passes (output above)
- [x] `npm run lint` passes
- [x] New code paths have tests (new `src/__tests__/semver.test.js`; new `changelog command --since` describe block in `src/__tests__/cli.internal.test.js`; new `isNewer` describe block in `src/__tests__/update-check.test.js`)
- [x] No `console.log` in core, no hardcoded secrets
- [x] Error messages are actionable (e.g. `Invalid --since value "abc": expected a version like 1.43 or 1.43.0.`)
- [x] Changeset added (`.changeset/fix-changelog-since-partial-version.md`)
- [ ] `src/schema.json` -- not applicable, no new commands or options were added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141eH4NcQy4GXgusCGbG1pm
