### PR TITLE
fix: skip npm's audit check in the package-pack integration test

### DIFF
--- a/src/__tests__/package.test.js
+++ b/src/__tests__/package.test.js
@@ -36,9 +36,12 @@ describe('Package Integrity', () => {
     const [packInfo] = JSON.parse(packOutput);
     const tgzPath = join(process.cwd(), packInfo.filename);
 
-    // Install in isolated temp directory
+    // Install in isolated temp directory. --no-audit skips npm's post-install
+    // vulnerability check: that network call has been hanging indefinitely
+    // (not just slow) rather than failing, so nothing short of avoiding it
+    // keeps this test from hanging the whole CI job.
     execSync('npm init -y', { cwd: tmpDir, stdio: 'ignore' });
-    execSync(`npm install "${tgzPath}"`, { cwd: tmpDir, stdio: 'ignore' });
+    execSync(`npm install --no-audit --no-fund "${tgzPath}"`, { cwd: tmpDir, stdio: 'ignore' });
 
     // Smoke test - if any import fails (e.g., missing src/commands/), this crashes.
     // Resolve the .cmd extension on Windows, where node_modules/.bin shims aren't extensionless.
@@ -53,7 +56,7 @@ describe('Package Integrity', () => {
 
     // Cleanup tarball
     rmSync(tgzPath, { force: true });
-  }, 180000); // `npm install` of a local tarball is fully synchronous and can be slow on a cold CI runner
+  }, 60000); // real installs take a few seconds; the margin is for a cold CI runner, not the audit hang above
 
   it('should not include test files in package', () => {
     const packOutput = execSync('npm pack --dry-run --json', {


### PR DESCRIPTION
## Summary
- Supersedes #570. That PR bumped this test's `testTimeout` to 180s, assuming the underlying `npm install` was just slow. It isn't — it hangs indefinitely. #570's own merge-commit CI run still failed, this time exceeding even the new 180s budget (234.8s and counting), and the same failure has now hit multiple unrelated open PRs.
- Root-caused locally: ran the exact `npm pack` + `npm install <tarball>` from the test with verbose logging. Every dependency resolves from the registry and `postinstall` exits 0 within milliseconds — then the process hangs with zero further output. Backgrounding it and leaving it alone, it never exited on its own; I had to `SIGKILL` it after 2m20s.
- Isolated the exact cause: `npm install --no-fund` (audit left on) still hangs; `npm install --no-audit` (fund left on) installs cleanly in <1s, every time, across many repeated runs. It's npm's own post-install vulnerability-audit network call, not the package registry — a separate endpoint from the one all the other successful installs use. This matches known npm CLI issues (npm/cli#4028 "npm install will randomly hang forever and cannot be closed", npm/cli#9386 "Exit handler never called during npm install").
- Fix: pass `--no-audit --no-fund` on the test's `npm install`, and lower `testTimeout` back down to 60s (generous margin for a cold CI runner; no longer trying to out-wait an indefinite hang).

## Test plan
- [x] Ran `npx vitest run src/__tests__/package.test.js` 3x locally — all pass in ~2s (previously this exact command reproduced the hang consistently on this same machine)
- [x] `npm run lint` passes
- [x] `npm test` (full suite) passes: 63/63 files, 2549/2551 tests (2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)