### PR TITLE
test: stop changelog --since test colliding with entry prose

### DIFF
--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -3369,12 +3369,20 @@ describe('changelog command --since', () => {
     const explicitZeroForm = await runChangelog({ since: `${majorMinor}.0` });
     const partialForm = await runChangelog({ since: majorMinor });
 
-    // Before the fix this always fell through to "No changelog entries
-    // found", because compareSemver compared the real patch number against
-    // `undefined` and that is never >= 0 in either direction — so a
+    // Before the fix this always fell through to the "No changelog entries
+    // found" message, because compareSemver compared the real patch number
+    // against `undefined` and that is never >= 0 in either direction — so a
     // major.minor-only --since matched nothing, even entries for that exact
     // major.minor.
-    expect(partialForm).not.toContain('No changelog entries found');
+    //
+    // Assert on structure (the newest version's heading is present) rather
+    // than on the absence of the no-match sentinel string: a real changelog
+    // entry's prose can legitimately quote "No changelog entries found"
+    // (e.g. the entry that documents this very fix), so checking for that
+    // substring is a false positive waiting to happen. The heading only
+    // appears when entries were actually included, and the no-match message
+    // is a single line with no "## " heading.
+    expect(partialForm).toContain(`## ${majorMinor}.`);
     expect(partialForm).toBe(explicitZeroForm);
   });
 


### PR DESCRIPTION
## Problem

The Version Packages release PR (#554) is failing CI on the `changelog command --since` regression test, even though the source change that added it (#572) passed. The failure is a self-collision, not a code regression:

```
AssertionError: expected '## 1.43.2\n\n### Patch Changes\n\n- […' not to contain 'No changelog entries found'
```

The test asserts that `nansen changelog --since <major.minor>` output does **not** contain the literal string `"No changelog entries found"` — using the command's no-match sentinel as proof that entries were matched. But #572's own changelog entry documents the fix with the prose *…silently returning "No changelog entries found" for a version missing its patch number…*.

#572 passed because `CHANGELOG.md` on its branch didn't yet contain that entry — the changesets bot only rolls it into the `1.43.2` section when it generates the Version Packages PR. Once it did, `--since 1.43` legitimately returns the `1.43.2` section, whose prose contains the sentinel, and the test trips. **This also breaks `main` the moment #554 merges.**

## Fix

Assert on structure instead: the newest version's `## x.y.` heading must be present in the filtered output. The heading appears only when entries were actually included, and the single-line no-match message has no heading — so it proves the same thing without colliding with entry prose. The `toBe(explicitZeroForm)` equivalence check (the real regression guard) is unchanged.

## Verification

- Reproduced the exact CI failure locally by swapping in the release-branch `CHANGELOG.md`; confirmed the old assertion fails and the new one passes against it.
- Full suite: 2596 passed / 2 skipped. Lint clean.

Test-only change → no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)