### PR TITLE
fix: fail closed on ambiguous broadcast failures in swap and bridge execute

### DIFF
--- a/.changeset/broadcast-failed-fail-closed.md
+++ b/.changeset/broadcast-failed-fail-closed.md
@@ -3,13 +3,17 @@
 ---
 
 Fail closed on an ambiguous broadcast failure in swap and bridge execute. When
-`/execute` (swap) returns a 502/503 (regardless of body shape) or any other
+`/execute` (swap) returns any 5xx (regardless of body shape — a structured 504
+`UPSTREAM_TIMEOUT` is treated the same as a bare 502) or any other
 uninterpretable response — or the POST, or reading its body, throws a network
 error — after the signed tx was sent, or a bridge broadcast fails ambiguously,
 the tx may already be live. The quote is now marked spent and the
 run aborts — rather than trying the next candidate quote or leaving the quote
-reusable — so a re-execute (or agent auto-retry) can't double-broadcast. A
-bridge send is kept reusable only when the node's error proves the tx never
+reusable — so a re-execute (or agent auto-retry) can't double-broadcast. Gasless
+(Relay solver-paid) swaps additionally do not retry the `/execute` POST: the
+signed authorization is broadcast by Relay's own wrapping tx, so a re-POST can't
+be node-deduped and could trigger a second solve — a single attempt fails closed
+instead. A bridge send is kept reusable only when the node's error proves the tx never
 entered the mempool (a pre-broadcast validation rejection such as insufficient
 funds); in-flight txpool states like "already known" or "nonce too low" fail
 closed.

--- a/.changeset/broadcast-failed-fail-closed.md
+++ b/.changeset/broadcast-failed-fail-closed.md
@@ -1,0 +1,11 @@
+---
+"nansen-cli": patch
+---
+
+Fail closed on an ambiguous broadcast failure in swap and bridge execute. When
+`/execute` (swap) returns a non-JSON/502 response after the signed tx was
+POSTed, or a bridge broadcast fails with a gateway/network error, the tx may
+already be live on the backend. The quote is now marked spent and the run
+aborts — rather than trying the next candidate quote or leaving the quote
+reusable — so a re-execute (or agent auto-retry) can't double-broadcast. A
+definitive node rejection (a JSON-RPC error) still leaves the quote reusable.

--- a/.changeset/broadcast-failed-fail-closed.md
+++ b/.changeset/broadcast-failed-fail-closed.md
@@ -3,9 +3,10 @@
 ---
 
 Fail closed on an ambiguous broadcast failure in swap and bridge execute. When
-`/execute` (swap) returns a non-JSON/502 response (or the POST itself throws a
-network error) after the signed tx was sent, or a bridge broadcast fails
-ambiguously, the tx may already be live. The quote is now marked spent and the
+`/execute` (swap) returns a 502/503 (regardless of body shape) or any other
+uninterpretable response — or the POST, or reading its body, throws a network
+error — after the signed tx was sent, or a bridge broadcast fails ambiguously,
+the tx may already be live. The quote is now marked spent and the
 run aborts — rather than trying the next candidate quote or leaving the quote
 reusable — so a re-execute (or agent auto-retry) can't double-broadcast. A
 bridge send is kept reusable only when the node's error proves the tx never

--- a/.changeset/broadcast-failed-fail-closed.md
+++ b/.changeset/broadcast-failed-fail-closed.md
@@ -3,9 +3,12 @@
 ---
 
 Fail closed on an ambiguous broadcast failure in swap and bridge execute. When
-`/execute` (swap) returns a non-JSON/502 response after the signed tx was
-POSTed, or a bridge broadcast fails with a gateway/network error, the tx may
-already be live on the backend. The quote is now marked spent and the run
-aborts — rather than trying the next candidate quote or leaving the quote
+`/execute` (swap) returns a non-JSON/502 response (or the POST itself throws a
+network error) after the signed tx was sent, or a bridge broadcast fails
+ambiguously, the tx may already be live. The quote is now marked spent and the
+run aborts — rather than trying the next candidate quote or leaving the quote
 reusable — so a re-execute (or agent auto-retry) can't double-broadcast. A
-definitive node rejection (a JSON-RPC error) still leaves the quote reusable.
+bridge send is kept reusable only when the node's error proves the tx never
+entered the mempool (a pre-broadcast validation rejection such as insufficient
+funds); in-flight txpool states like "already known" or "nonce too low" fail
+closed.

--- a/src/__tests__/bridge-broadcast-failclosed.test.js
+++ b/src/__tests__/bridge-broadcast-failclosed.test.js
@@ -161,22 +161,48 @@ describe('bridge EVM broadcast fail-closed', () => {
     expect(readQuote('bridge-net').executedAt).toBeTypeOf('number');
   });
 
-  it('leaves the quote REUSABLE on a DEFINITIVE JSON-RPC rejection (nonce too low)', async () => {
-    // The node explicitly refused the tx — nothing is in flight — so a burned
-    // quote here would be a needless re-quote for a plainly retryable error.
-    stubSend(Object.assign(new Error('RPC error (eth_sendRawTransaction): nonce too low'), { code: 'RPC_JSON_ERROR' }));
+  it('leaves the quote REUSABLE on a PRE-BROADCAST JSON-RPC rejection (insufficient funds)', async () => {
+    // The node rejected the tx during validation — it never entered the mempool
+    // — so a burned quote here would be a needless re-quote for a plainly
+    // retryable error (fund the wallet and re-run the same quote).
+    stubSend(Object.assign(new Error('RPC error (eth_sendRawTransaction): insufficient funds for gas * price + value'), { code: 'RPC_JSON_ERROR' }));
     const cmds = buildBridgeCommands({ log: () => {} });
-    writeQuote('bridge-nonce');
+    writeQuote('bridge-funds');
 
-    await expect(cmds.execute([], api, {}, { quote: 'bridge-nonce', wallet: 'w' }))
-      .rejects.toThrow(/nonce too low/i);
+    await expect(cmds.execute([], api, {}, { quote: 'bridge-funds', wallet: 'w' }))
+      .rejects.toThrow(/insufficient funds/i);
 
     // Not consumed: no executedAt, and a second attempt actually re-signs
     // (it is NOT blocked by the single-use guard).
-    expect(readQuote('bridge-nonce').executedAt).toBeUndefined();
+    expect(readQuote('bridge-funds').executedAt).toBeUndefined();
     signEvmTransaction.mockClear();
-    await expect(cmds.execute([], api, {}, { quote: 'bridge-nonce', wallet: 'w' }))
-      .rejects.toThrow(/nonce too low/i);
+    await expect(cmds.execute([], api, {}, { quote: 'bridge-funds', wallet: 'w' }))
+      .rejects.toThrow(/insufficient funds/i);
     expect(signEvmTransaction).toHaveBeenCalled();
+  });
+
+  // In-flight txpool states come back as JSON-RPC errors too, but the tx is
+  // ALREADY broadcasting — these MUST fail closed, not stay reusable.
+  it.each([
+    ['already known', 'already known'],
+    ['known transaction', 'known transaction: 0xabc'],
+    ['nonce too low', 'nonce too low'],
+    ['replacement underpriced', 'replacement transaction underpriced'],
+  ])('marks the quote spent on an in-flight txpool JSON-RPC error (%s)', async (label, message) => {
+    stubSend(Object.assign(new Error(`RPC error (eth_sendRawTransaction): ${message}`), { code: 'RPC_JSON_ERROR' }));
+    const cmds = buildBridgeCommands({ log: () => {} });
+    const qid = `bridge-inflight-${label.replace(/\s+/g, '-')}`;
+    writeQuote(qid);
+
+    await expect(cmds.execute([], api, {}, { quote: qid, wallet: 'w' }))
+      .rejects.toThrow(new RegExp(message.split(':')[0], 'i'));
+
+    // The tx may already be in the mempool — the quote is consumed, and a retry
+    // is refused before it re-signs.
+    expect(readQuote(qid).executedAt).toBeTypeOf('number');
+    signEvmTransaction.mockClear();
+    await expect(cmds.execute([], api, {}, { quote: qid, wallet: 'w' }))
+      .rejects.toThrow(/partially executed|already executed/i);
+    expect(signEvmTransaction).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/bridge-broadcast-failclosed.test.js
+++ b/src/__tests__/bridge-broadcast-failclosed.test.js
@@ -184,14 +184,18 @@ describe('bridge EVM broadcast fail-closed', () => {
     expect(signEvmTransaction).toHaveBeenCalled();
   });
 
-  // In-flight txpool states come back as JSON-RPC errors too, but the tx is
-  // ALREADY broadcasting — these MUST fail closed, not stay reusable.
+  // In-flight (or not-provably-pre-broadcast) states come back as JSON-RPC
+  // errors too, but the tx may ALREADY be broadcasting — these MUST fail closed,
+  // not stay reusable. The bare "transaction underpriced" is here deliberately:
+  // some non-geth nodes reuse it for a failed replacement (a nonce collision),
+  // so it is NOT on the pre-broadcast allowlist.
   it.each([
     ['already known', 'already known'],
     ['known transaction', 'known transaction: 0xabc'],
     ['nonce too low', 'nonce too low'],
     ['replacement underpriced', 'replacement transaction underpriced'],
-  ])('marks the quote spent on an in-flight txpool JSON-RPC error (%s)', async (label, message) => {
+    ['bare underpriced', 'transaction underpriced'],
+  ])('marks the quote spent on a not-provably-pre-broadcast JSON-RPC error (%s)', async (label, message) => {
     stubSend(Object.assign(new Error(`RPC error (eth_sendRawTransaction): ${message}`), { code: 'RPC_JSON_ERROR' }));
     const cmds = buildBridgeCommands({ log: () => {} });
     const qid = `bridge-inflight-${label.replace(/\s+/g, '-')}`;

--- a/src/__tests__/bridge-broadcast-failclosed.test.js
+++ b/src/__tests__/bridge-broadcast-failclosed.test.js
@@ -5,14 +5,17 @@
  * (or an agent auto-retry) re-signs the step at a fresh nonce and double-sends.
  *
  * The client cannot distinguish "502, tx never sent" from "502, tx sent, ack
- * lost", so it fails closed: any send failure EXCEPT a definitive JSON-RPC
- * rejection (RPC_JSON_ERROR — the node explicitly refused the tx, nothing is in
- * flight) marks the quote spent. A definitive rejection instead leaves the
- * quote reusable, so a genuine pre-broadcast error (nonce too low, insufficient
- * funds) doesn't needlessly burn it.
+ * lost", so it fails closed by default: a send failure marks the quote spent
+ * UNLESS the node's error proves the tx never entered the mempool. Only a
+ * pre-broadcast validation rejection (insufficient funds, intrinsic gas too
+ * low, underpriced, malformed, …) — or a missing-RPC config error — keeps the
+ * quote reusable. Crucially, in-flight txpool states ("already known", "known
+ * transaction", "nonce too low", "replacement transaction underpriced") also
+ * come back as JSON-RPC errors, but the tx is already broadcasting, so those
+ * fail closed too.
  *
- * See src/bridge.js processEvmStep + isDefinitiveRpcRejection, and evmRpcCall's
- * error codes in src/trading.js.
+ * See src/bridge.js processEvmStep + isPreBroadcastSendRejection, and
+ * evmRpcCall's error codes in src/trading.js.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 

--- a/src/__tests__/bridge-broadcast-failclosed.test.js
+++ b/src/__tests__/bridge-broadcast-failclosed.test.js
@@ -1,0 +1,182 @@
+/**
+ * A bridge broadcast that FAILS AMBIGUOUSLY (a non-JSON gateway page,
+ * a dropped connection) after the node may already have accepted the tx must
+ * consume the quote — otherwise a later `nansen bridge execute --quote <id>`
+ * (or an agent auto-retry) re-signs the step at a fresh nonce and double-sends.
+ *
+ * The client cannot distinguish "502, tx never sent" from "502, tx sent, ack
+ * lost", so it fails closed: any send failure EXCEPT a definitive JSON-RPC
+ * rejection (RPC_JSON_ERROR — the node explicitly refused the tx, nothing is in
+ * flight) marks the quote spent. A definitive rejection instead leaves the
+ * quote reusable, so a genuine pre-broadcast error (nonce too low, insufficient
+ * funds) doesn't needlessly burn it.
+ *
+ * See src/bridge.js processEvmStep + isDefinitiveRpcRejection, and evmRpcCall's
+ * error codes in src/trading.js.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../wallet.js', () => ({
+  showWallet: vi.fn(),
+  getWalletConfig: vi.fn(() => ({})),
+  exportWallet: vi.fn(),
+}));
+
+vi.mock('../keychain.js', () => ({
+  retrievePassword: vi.fn(() => ({ password: null, source: null })),
+}));
+
+const { evmRpcCall, getEvmNonce, signEvmTransaction, waitForReceipt } = vi.hoisted(() => ({
+  evmRpcCall: vi.fn(),
+  getEvmNonce: vi.fn(async () => 7),
+  signEvmTransaction: vi.fn(() => '0xsigned'),
+  waitForReceipt: vi.fn(async () => ({ status: '0x1', blockNumber: '0x1' })),
+}));
+
+vi.mock('../trading.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, evmRpcCall, getEvmNonce, signEvmTransaction, waitForReceipt };
+});
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { exportWallet, getWalletConfig, showWallet } from '../wallet.js';
+import { buildBridgeCommands } from '../bridge.js';
+
+const ADDR = '0x' + 'ab'.repeat(20);
+// Real Base -> Hyperliquid deposit router/selector — the preflight rejects
+// anything else, so the fixture needs well-formed deposit calldata.
+const ROUTER = '0x4cd00e387622c35bddb9b4c962c136462338bc31';
+const USDC = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+const REQUESTED_AMOUNT = 2000000n;
+const word = h => h.toLowerCase().replace(/^0x/, '').padStart(64, '0');
+const depositCalldata = (depositor, amount = REQUESTED_AMOUNT) =>
+  '0xe8017952' + word(depositor) + word(USDC) + word(amount.toString(16)) + word('0x'.padEnd(66, 'a'));
+
+describe('bridge EVM broadcast fail-closed', () => {
+  let tmpHome;
+  let prevHome;
+  let quotesDir;
+
+  function writeQuote(quoteId) {
+    const data = {
+      quoteId,
+      type: 'bridge',
+      originChain: 'base',
+      destinationChain: 'hyperliquid',
+      walletProvider: 'local',
+      walletAddress: ADDR,
+      requestedAmountBaseUnits: REQUESTED_AMOUNT.toString(),
+      timestamp: Date.now(),
+      response: {
+        execution_type: 'evm_transaction',
+        request_id: 'r1',
+        steps: [{
+          id: 'deposit',
+          kind: 'transaction',
+          items: [{
+            status: 'incomplete',
+            data: { from: ADDR, to: ROUTER, data: depositCalldata(ADDR), value: '0', maxFeePerGas: '1000000' },
+          }],
+        }],
+      },
+    };
+    fs.writeFileSync(path.join(quotesDir, `${quoteId}.json`), JSON.stringify(data, null, 2));
+  }
+
+  const api = {
+    request: vi.fn(async (endpoint) => {
+      if (String(endpoint).includes('/bridge/status')) return { status: 'success', destination_tx_hashes: [] };
+      return { results: [{ address: ADDR, sanctioned: false }] };
+    }),
+  };
+
+  // Make eth_sendRawTransaction reject with `sendError`; everything else the
+  // step needs (base fee) resolves normally.
+  function stubSend(sendError) {
+    evmRpcCall.mockImplementation(async (_chain, method) => {
+      if (method === 'eth_getBlockByNumber') return { baseFeePerGas: '0x1' };
+      if (method === 'eth_sendRawTransaction') throw sendError;
+      return '0x0';
+    });
+  }
+
+  function readQuote(quoteId) {
+    return JSON.parse(fs.readFileSync(path.join(quotesDir, `${quoteId}.json`), 'utf8'));
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prevHome = process.env.HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nansen-bridge-failclosed-'));
+    process.env.HOME = tmpHome;
+    quotesDir = path.join(tmpHome, '.nansen', 'quotes');
+    fs.mkdirSync(quotesDir, { recursive: true });
+    getWalletConfig.mockReturnValue({});
+    showWallet.mockReturnValue({ name: 'w', evm: ADDR, provider: 'local' });
+    exportWallet.mockReturnValue({ evm: { privateKey: '11'.repeat(32) } });
+    getEvmNonce.mockResolvedValue(7);
+    api.request.mockImplementation(async (endpoint) => {
+      if (String(endpoint).includes('/bridge/status')) return { status: 'success', destination_tx_hashes: [] };
+      return { results: [{ address: ADDR, sanctioned: false }] };
+    });
+  });
+
+  afterEach(() => {
+    process.env.HOME = prevHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('marks the quote spent on an AMBIGUOUS send failure (non-JSON 502) and refuses a re-execute', async () => {
+    stubSend(Object.assign(new Error('RPC endpoint returned non-JSON response (HTTP 502)'), { code: 'RPC_HTTP_ERROR', status: 502 }));
+    const cmds = buildBridgeCommands({ log: () => {} });
+    writeQuote('bridge-502');
+
+    await expect(cmds.execute([], api, {}, { quote: 'bridge-502', wallet: 'w' }))
+      .rejects.toThrow(/non-JSON|502/i);
+
+    // The tx may be live — the quote is consumed even though onBroadcast never
+    // ran with a real hash.
+    const q = readQuote('bridge-502');
+    expect(q.executedAt).toBeTypeOf('number');
+
+    // A retry is refused before it re-signs anything.
+    signEvmTransaction.mockClear();
+    await expect(cmds.execute([], api, {}, { quote: 'bridge-502', wallet: 'w' }))
+      .rejects.toThrow(/partially executed|already executed/i);
+    expect(signEvmTransaction).not.toHaveBeenCalled();
+  });
+
+  it('marks the quote spent when the send throws a bare NETWORK error (dropped connection)', async () => {
+    // evmRpcCall wraps a fetch rejection as RPC_NETWORK_ERROR — also ambiguous.
+    stubSend(Object.assign(new Error('RPC request to base failed for eth_sendRawTransaction: socket hang up'), { code: 'RPC_NETWORK_ERROR' }));
+    const cmds = buildBridgeCommands({ log: () => {} });
+    writeQuote('bridge-net');
+
+    await expect(cmds.execute([], api, {}, { quote: 'bridge-net', wallet: 'w' }))
+      .rejects.toThrow(/socket hang up|failed for/i);
+
+    expect(readQuote('bridge-net').executedAt).toBeTypeOf('number');
+  });
+
+  it('leaves the quote REUSABLE on a DEFINITIVE JSON-RPC rejection (nonce too low)', async () => {
+    // The node explicitly refused the tx — nothing is in flight — so a burned
+    // quote here would be a needless re-quote for a plainly retryable error.
+    stubSend(Object.assign(new Error('RPC error (eth_sendRawTransaction): nonce too low'), { code: 'RPC_JSON_ERROR' }));
+    const cmds = buildBridgeCommands({ log: () => {} });
+    writeQuote('bridge-nonce');
+
+    await expect(cmds.execute([], api, {}, { quote: 'bridge-nonce', wallet: 'w' }))
+      .rejects.toThrow(/nonce too low/i);
+
+    // Not consumed: no executedAt, and a second attempt actually re-signs
+    // (it is NOT blocked by the single-use guard).
+    expect(readQuote('bridge-nonce').executedAt).toBeUndefined();
+    signEvmTransaction.mockClear();
+    await expect(cmds.execute([], api, {}, { quote: 'bridge-nonce', wallet: 'w' }))
+      .rejects.toThrow(/nonce too low/i);
+    expect(signEvmTransaction).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/trading-quote-reuse.test.js
+++ b/src/__tests__/trading-quote-reuse.test.js
@@ -339,4 +339,63 @@ describe('swap quote reuse guard (mirrors bridge quotes)', () => {
       .rejects.toThrow(/already executed/i);
     expect(executeBodies.length).toBe(postCount);
   });
+
+  it('fails closed when the /execute POST throws a raw network error (dropped ack)', async () => {
+    // A TCP drop after the request body flushes but before a response is every
+    // bit as ambiguous as a 502 — the backend may already have broadcast. The
+    // fetch rejects with a plain Error (no .code); executeTransaction must still
+    // classify it BROADCAST_FAILED so the quote is marked spent and the loop
+    // aborts, rather than falling through to the next candidate.
+    const SECOND_ROUTER = '0x1111111254eeb25477b68fb85ed929f73a960582';
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+
+    let executeAttempts = 0;
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? JSON.parse(opts.body) : {};
+
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeAttempts += 1;
+        // fetch itself rejects — no HTTP response object at all.
+        return Promise.reject(new Error('socket hang up'));
+      }
+      if (body.method === 'eth_getCode') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+      }
+      if (body.method === 'eth_getTransactionCount') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    // Two candidates, so a regression would fall through and broadcast the 2nd.
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [
+        { aggregator: 'lifi', inputMint: BASE_ETH, outputMint: BASE_USDC, inAmount: '1000000000000000000', outAmount: '3000000000',
+          transaction: { to: LIFI_ROUTER, data: '0x12345678', value: '1000000000000000000', gas: '210000', maxFeePerGas: '1000000', maxPriorityFeePerGas: '1000000' } },
+        { aggregator: 'odos', inputMint: BASE_ETH, outputMint: BASE_USDC, inAmount: '1000000000000000000', outAmount: '2999000000',
+          transaction: { to: SECOND_ROUTER, data: '0xabcdef01', value: '1000000000000000000', gas: '210000', maxFeePerGas: '1000000', maxPriorityFeePerGas: '1000000' } },
+      ],
+    }, 'base', 'local', null, null, {
+      swapMode: 'exactIn',
+      request: evmIntent({ walletAddress, fromToken: BASE_ETH, toToken: BASE_USDC, amount: '1000000000000000000' }),
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    const flags = { 'no-simulate': true, 'no-verify-outcome': true };
+
+    await expect(cmds.execute([], null, flags, { quote: quoteId }))
+      .rejects.toThrow(/socket hang up|failed/i);
+
+    // The quote is marked spent, and a re-execute is refused.
+    const quoteFile = JSON.parse(fs.readFileSync(path.join(getQuotesDir(), `${quoteId}.json`), 'utf8'));
+    expect(quoteFile.executedAt).toBeTypeOf('number');
+    const attemptsAfterFirst = executeAttempts;
+    await expect(cmds.execute([], null, flags, { quote: quoteId }))
+      .rejects.toThrow(/already executed/i);
+    expect(executeAttempts).toBe(attemptsAfterFirst);
+  });
 });

--- a/src/__tests__/trading-quote-reuse.test.js
+++ b/src/__tests__/trading-quote-reuse.test.js
@@ -398,4 +398,115 @@ describe('swap quote reuse guard (mirrors bridge quotes)', () => {
       .rejects.toThrow(/already executed/i);
     expect(executeAttempts).toBe(attemptsAfterFirst);
   });
+
+  it('fails closed on a JSON 502/503 — a parseable error body does not make it definitive', async () => {
+    // A JSON 502 like { code: "UPSTREAM_TIMEOUT" } is exactly the "gateway
+    // forwarded the tx upstream, then timed out on the ack" case. It must be
+    // classified BROADCAST_FAILED regardless of body shape — NOT surfaced with
+    // its own (nonfatal) code, which would let the loop try the next candidate.
+    const SECOND_ROUTER = '0x1111111254eeb25477b68fb85ed929f73a960582';
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? JSON.parse(opts.body) : {};
+
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(body);
+        // A well-formed JSON error body, but a 502 status.
+        return Promise.resolve({ ok: false, status: 502, text: () => Promise.resolve(JSON.stringify({ code: 'UPSTREAM_TIMEOUT', message: 'upstream timed out' })) });
+      }
+      if (body.method === 'eth_getCode') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+      }
+      if (body.method === 'eth_getTransactionCount') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [
+        { aggregator: 'lifi', inputMint: BASE_ETH, outputMint: BASE_USDC, inAmount: '1000000000000000000', outAmount: '3000000000',
+          transaction: { to: LIFI_ROUTER, data: '0x12345678', value: '1000000000000000000', gas: '210000', maxFeePerGas: '1000000', maxPriorityFeePerGas: '1000000' } },
+        { aggregator: 'odos', inputMint: BASE_ETH, outputMint: BASE_USDC, inAmount: '1000000000000000000', outAmount: '2999000000',
+          transaction: { to: SECOND_ROUTER, data: '0xabcdef01', value: '1000000000000000000', gas: '210000', maxFeePerGas: '1000000', maxPriorityFeePerGas: '1000000' } },
+      ],
+    }, 'base', 'local', null, null, {
+      swapMode: 'exactIn',
+      request: evmIntent({ walletAddress, fromToken: BASE_ETH, toToken: BASE_USDC, amount: '1000000000000000000' }),
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    const flags = { 'no-simulate': true, 'no-verify-outcome': true };
+
+    await expect(cmds.execute([], null, flags, { quote: quoteId }))
+      .rejects.toThrow(/502|broadcast/i);
+
+    // Only the first candidate was posted (its retries) — same signed tx every time.
+    expect(new Set(executeBodies.map(b => b.signedTransaction)).size).toBe(1);
+    const quoteFile = JSON.parse(fs.readFileSync(path.join(getQuotesDir(), `${quoteId}.json`), 'utf8'));
+    expect(quoteFile.executedAt).toBeTypeOf('number');
+    await expect(cmds.execute([], null, flags, { quote: quoteId }))
+      .rejects.toThrow(/already executed/i);
+  });
+
+  it('fails closed when reading the /execute response BODY fails (truncated/reset)', async () => {
+    // fetch() can resolve on headers and then reject while reading the body. That
+    // error has no code; executeTransaction must still classify it BROADCAST_FAILED
+    // so the quote is marked spent and the loop aborts instead of continuing.
+    const SECOND_ROUTER = '0x1111111254eeb25477b68fb85ed929f73a960582';
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? JSON.parse(opts.body) : {};
+
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(body);
+        // Headers received (200), but the body stream errors mid-read.
+        return Promise.resolve({ ok: true, status: 200, text: () => Promise.reject(new Error('aborted: incomplete chunked read')) });
+      }
+      if (body.method === 'eth_getCode') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+      }
+      if (body.method === 'eth_getTransactionCount') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [
+        { aggregator: 'lifi', inputMint: BASE_ETH, outputMint: BASE_USDC, inAmount: '1000000000000000000', outAmount: '3000000000',
+          transaction: { to: LIFI_ROUTER, data: '0x12345678', value: '1000000000000000000', gas: '210000', maxFeePerGas: '1000000', maxPriorityFeePerGas: '1000000' } },
+        { aggregator: 'odos', inputMint: BASE_ETH, outputMint: BASE_USDC, inAmount: '1000000000000000000', outAmount: '2999000000',
+          transaction: { to: SECOND_ROUTER, data: '0xabcdef01', value: '1000000000000000000', gas: '210000', maxFeePerGas: '1000000', maxPriorityFeePerGas: '1000000' } },
+      ],
+    }, 'base', 'local', null, null, {
+      swapMode: 'exactIn',
+      request: evmIntent({ walletAddress, fromToken: BASE_ETH, toToken: BASE_USDC, amount: '1000000000000000000' }),
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    const flags = { 'no-simulate': true, 'no-verify-outcome': true };
+
+    await expect(cmds.execute([], null, flags, { quote: quoteId }))
+      .rejects.toThrow(/body read failed|aborted/i);
+
+    // Second candidate never signed/posted; quote marked spent; re-execute refused.
+    expect(new Set(executeBodies.map(b => b.signedTransaction)).size).toBe(1);
+    const quoteFile = JSON.parse(fs.readFileSync(path.join(getQuotesDir(), `${quoteId}.json`), 'utf8'));
+    expect(quoteFile.executedAt).toBeTypeOf('number');
+    await expect(cmds.execute([], null, flags, { quote: quoteId }))
+      .rejects.toThrow(/already executed/i);
+  });
 });

--- a/src/__tests__/trading-quote-reuse.test.js
+++ b/src/__tests__/trading-quote-reuse.test.js
@@ -268,4 +268,75 @@ describe('swap quote reuse guard (mirrors bridge quotes)', () => {
       .rejects.toThrow(/already executed/i);
     expect(executeBodies).toHaveLength(1);
   });
+
+  it('fails closed on BROADCAST_FAILED: marks the quote spent and never tries the next candidate', async () => {
+    // The gap this locks in: /execute retries a 502 and, if all attempts fail,
+    // throws BROADCAST_FAILED — but a 502 on the ACK (not the send) means the tx
+    // may already be live. The old code left the quote unmarked and fell through
+    // to the next candidate, double-broadcasting both in-run and via a later
+    // re-execute. isFatalBroadcastError now covers BROADCAST_FAILED, and the
+    // candidate catch marks the quote spent before aborting.
+    const SECOND_ROUTER = '0x1111111254eeb25477b68fb85ed929f73a960582';
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+    const walletAddress = showWallet('default').evm;
+
+    const executeBodies = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const body = opts?.body ? JSON.parse(opts.body) : {};
+
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executeBodies.push(body);
+        // A 502 gateway page — NON-JSON — on every attempt: executeTransaction
+        // exhausts its 502 retries and throws BROADCAST_FAILED.
+        return Promise.resolve({ ok: false, status: 502, text: () => Promise.resolve('<html>502 Bad Gateway</html>') });
+      }
+      if (body.method === 'eth_getCode') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x6080604052' })) });
+      }
+      if (body.method === 'eth_getTransactionCount') {
+        return Promise.resolve({ text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: '0x5' })) });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: body.id || 1, result: null })) });
+    }));
+
+    // TWO candidates: if the fix regressed, the loop would fall through and sign
+    // + broadcast the SECOND on top of a possibly-live first tx.
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [
+        { aggregator: 'lifi', inputMint: BASE_ETH, outputMint: BASE_USDC, inAmount: '1000000000000000000', outAmount: '3000000000',
+          transaction: { to: LIFI_ROUTER, data: '0x12345678', value: '1000000000000000000', gas: '210000', maxFeePerGas: '1000000', maxPriorityFeePerGas: '1000000' } },
+        { aggregator: 'odos', inputMint: BASE_ETH, outputMint: BASE_USDC, inAmount: '1000000000000000000', outAmount: '2999000000',
+          transaction: { to: SECOND_ROUTER, data: '0xabcdef01', value: '1000000000000000000', gas: '210000', maxFeePerGas: '1000000', maxPriorityFeePerGas: '1000000' } },
+      ],
+    }, 'base', 'local', null, null, {
+      swapMode: 'exactIn',
+      request: evmIntent({ walletAddress, fromToken: BASE_ETH, toToken: BASE_USDC, amount: '1000000000000000000' }),
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    const flags = { 'no-simulate': true, 'no-verify-outcome': true };
+
+    await expect(cmds.execute([], null, flags, { quote: quoteId }))
+      .rejects.toThrow(/502|bad gateway/i);
+
+    // Only the FIRST candidate was ever posted (its retries) — every /execute
+    // body carries the same signed tx, so the second candidate never went out.
+    expect(executeBodies.length).toBeGreaterThan(0);
+    expect(new Set(executeBodies.map(b => b.signedTransaction)).size).toBe(1);
+
+    // The quote is marked spent even though executeTransaction threw before the
+    // normal markQuoteExecuted could run. No broadcast hash is recorded (we hold
+    // none), so loadQuote falls back to its generic "already executed" refusal.
+    const quoteFile = JSON.parse(fs.readFileSync(path.join(getQuotesDir(), `${quoteId}.json`), 'utf8'));
+    expect(quoteFile.executedAt).toBeTypeOf('number');
+
+    // A cross-process retry (or an agent auto-retry) is refused before re-signing.
+    const postCount = executeBodies.length;
+    await expect(cmds.execute([], null, flags, { quote: quoteId }))
+      .rejects.toThrow(/already executed/i);
+    expect(executeBodies.length).toBe(postCount);
+  });
 });

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -3521,6 +3521,37 @@ describe('API error handling', () => {
     global.fetch = origFetch;
   });
 
+  it('fails closed on a parseable 504 from execute API (every 5xx is ambiguous)', async () => {
+    // A 504 with a structured body — { code: "UPSTREAM_TIMEOUT" } — is NOT a
+    // definitive "never sent": the gateway may have forwarded the signed tx
+    // upstream and then lost the ack on the timeout. Classifying it by its own
+    // (nonfatal) code would let the candidate loop broadcast the next quote on
+    // top of a live tx, so executeTransaction folds it into BROADCAST_FAILED
+    // like a 502/503, preserving the upstream body as `details`.
+    const origFetch = global.fetch;
+    const errorBody = JSON.stringify({
+      code: 'UPSTREAM_TIMEOUT',
+      message: 'Upstream request timed out',
+    });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 504,
+      text: async () => errorBody,
+    });
+
+    const { executeTransaction } = await import('../trading.js');
+    await expect(executeTransaction({
+      signedTransaction: 'test',
+      chain: 'base',
+    }, { retries: 0 })).rejects.toMatchObject({
+      code: 'BROADCAST_FAILED',
+      status: 504,
+      details: { code: 'UPSTREAM_TIMEOUT', message: 'Upstream request timed out' },
+    });
+
+    global.fetch = origFetch;
+  });
+
   it('should surface NO_QUOTES_AVAILABLE errors', async () => {
     const origFetch = global.fetch;
     const errorBody = JSON.stringify({
@@ -5420,6 +5451,75 @@ describe('Relay aggregator: --gasless flag dispatch', () => {
     expect(body.steps).toEqual([{ kind: 'transaction', items: [{ data: 'opaque-step-blob' }] }]);
     expect(body.simulate).toBe(false); // gasless skips simulation
     expect(body.quoteId).toBe('backend-relay-quote-id');
+
+    delete process.env.NANSEN_WALLET_PASSWORD;
+    vi.unstubAllGlobals();
+  });
+
+  it('does NOT retry the /execute POST on an ambiguous 5xx for a gasless swap (no double-solve)', async () => {
+    // A --gasless Relay swap POSTs a signed authorization; Relay's solver
+    // broadcasts its own wrapping tx from it, so a re-POST after the solver
+    // already picked it up can't be deduped at the node level and risks a second
+    // solve. executeTransaction must therefore be called with retries:0 for
+    // gasless — a single POST that fails closed — unlike a normal swap where the
+    // byte-identical replay is safe to retry. Regression guard: exactly ONE POST
+    // to /execute even though the response is a retryable-looking 502.
+    createWallet('default', 'testpass');
+    process.env.NANSEN_WALLET_PASSWORD = 'testpass';
+
+    let executePosts = 0;
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('trading-api') && urlStr.endsWith('/execute')) {
+        executePosts += 1;
+        return Promise.resolve({
+          ok: false,
+          status: 502,
+          text: () => Promise.resolve('<!DOCTYPE html><html>502 Bad Gateway</html>'),
+        });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null })) });
+    }));
+
+    const sigCount = Buffer.from([0x01]);
+    const emptySig = Buffer.alloc(64);
+    const message = Buffer.from([0x01, 0x00, 0x01, 0x02, ...Buffer.alloc(32), ...Buffer.alloc(32), ...Buffer.alloc(32), 0x01, 0x01, 0x01, 0x00, 0x04, 0x02, 0x00, 0x00, 0x00]);
+    const txBase64 = Buffer.concat([sigCount, emptySig, message]).toString('base64');
+
+    const quoteId = saveQuote({
+      success: true,
+      metadata: { quoteId: 'backend-relay-quote-id' },
+      quotes: [{
+        aggregator: 'relay',
+        inputMint: '11111111111111111111111111111111',
+        outputMint: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        inAmount: '1000000000',
+        outAmount: '180000000',
+        approvalAddress: '',
+        transaction: txBase64,
+        metadata: {
+          requestId: 'relay-req-gas',
+          isCrossChain: true,
+          bridgeTool: 'relay',
+          steps: [{ kind: 'transaction', items: [{ data: 'opaque-step-blob' }] }],
+        },
+      }],
+    }, 'solana', 'local', null, 'base', {
+      swapMode: 'exactIn',
+      request: solanaIntent({
+        walletAddress: showWallet('default').solana,
+        fromToken: '11111111111111111111111111111111',
+        toToken: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        toChain: 'base',
+        amount: '1000000000',
+        maxInputAmount: '1000000000',
+      }),
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    await expect(cmds.execute([], null, { gasless: true }, { quote: quoteId })).rejects.toThrow();
+
+    expect(executePosts).toBe(1); // no retry — the gasless authorization is not re-POSTed
 
     delete process.env.NANSEN_WALLET_PASSWORD;
     vi.unstubAllGlobals();

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -3489,7 +3489,13 @@ describe('API error handling', () => {
     global.fetch = origFetch;
   });
 
-  it('should surface UPSTREAM_BROADCAST_ERROR from execute API', async () => {
+  it('fails closed on a 502 from execute API, preserving the upstream body as details', async () => {
+    // A 502 is ambiguous no matter the body: the gateway may have forwarded the
+    // signed tx upstream before failing, so we can't trust a JSON error code
+    // (even "simulation failed") to prove the tx never went out. executeTransaction
+    // classifies it BROADCAST_FAILED — the fail-closed class that marks the quote
+    // spent and aborts — rather than surfacing the upstream code as nonfatal. The
+    // original code/message is preserved as `details` so nothing is lost.
     const origFetch = global.fetch;
     const errorBody = JSON.stringify({
       code: 'UPSTREAM_BROADCAST_ERROR',
@@ -3502,10 +3508,15 @@ describe('API error handling', () => {
     });
 
     const { executeTransaction } = await import('../trading.js');
+    // retries default to 2 with a 1.5s delay; drop both so the test doesn't wait.
     await expect(executeTransaction({
       signedTransaction: 'test',
       chain: 'solana',
-    })).rejects.toThrow('simulation failed');
+    }, { retries: 0 })).rejects.toMatchObject({
+      code: 'BROADCAST_FAILED',
+      status: 502,
+      details: { code: 'UPSTREAM_BROADCAST_ERROR', message: 'Jupiter Ultra execute failed: transaction simulation failed' },
+    });
 
     global.fetch = origFetch;
   });

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1077,6 +1077,17 @@ export async function resolveEvmStepFees(chain, txData, overrides = {}) {
   return { gasPrice: await evmRpcCall(chain, 'eth_gasPrice') };
 }
 
+// A send failure is DEFINITIVE when the node itself refused the transaction (a
+// JSON-RPC error) or the request never left this process (no RPC configured):
+// nothing is in flight, so the quote stays reusable. Every other failure — a
+// non-JSON gateway page, a dropped connection — is AMBIGUOUS: the node may have
+// accepted the tx before the ack was lost, so callers must fail closed and
+// consume the quote rather than let a re-execute re-sign at a fresh nonce.
+// See evmRpcCall (trading.js) for the error codes.
+function isDefinitiveRpcRejection(err) {
+  return err?.code === 'RPC_JSON_ERROR' || err?.code === 'RPC_UNCONFIGURED';
+}
+
 async function processEvmStep(step, { chain, privateKeyHex, signerAddress, log, onBroadcast, feeOverrides, nonceSequence, intent }) {
   for (const item of step.items || []) {
     if (item.status === 'complete') continue;
@@ -1114,7 +1125,18 @@ async function processEvmStep(step, { chain, privateKeyHex, signerAddress, log, 
     );
 
     log(`  Broadcasting ${step.id} on ${chain}...`);
-    const txHash = await evmRpcCall(chain, 'eth_sendRawTransaction', [signedTx]);
+    let txHash;
+    try {
+      txHash = await evmRpcCall(chain, 'eth_sendRawTransaction', [signedTx]);
+    } catch (sendErr) {
+      // A definitive rejection (the node refused this tx) leaves nothing in
+      // flight, so let it propagate WITHOUT consuming the quote. Any other
+      // failure is indistinguishable from "sent, ack lost": fail closed — mark
+      // the quote spent so a later re-execute can't re-sign this step at a fresh
+      // nonce and double-broadcast — then rethrow to abort the bridge.
+      if (!isDefinitiveRpcRejection(sendErr)) onBroadcast?.(step.id, null);
+      throw sendErr;
+    }
     // In flight now: record it before waiting on the receipt, because a receipt
     // timeout must not leave the quote reusable.
     onBroadcast?.(step.id, txHash);
@@ -1158,7 +1180,16 @@ async function processSignatureStepLocal(step, { privateKeyHex, log, apiInstance
       }
 
       log(`  Signing ${step.id} (EIP-712)...`);
-      await postBridgeExecute(apiInstance, targetUrl, postBody);
+      // Fail closed on ANY submit failure: the proxy may have forwarded the
+      // authorization before the error surfaced, and we can't tell that from a
+      // clean pre-forward rejection. Consume the quote before rethrowing so a
+      // re-execute can't resubmit this leg.
+      try {
+        await postBridgeExecute(apiInstance, targetUrl, postBody);
+      } catch (sendErr) {
+        onBroadcast?.(step.id, null);
+        throw sendErr;
+      }
       onBroadcast?.(step.id, null);
       log(`  Submitted to ${new URL(targetUrl).hostname}`);
     } else if (signData.action) {
@@ -1196,7 +1227,17 @@ async function processSignatureStepLocal(step, { privateKeyHex, log, apiInstance
       };
 
       log(`  Signing ${step.id} (Hyperliquid deposit)...`);
-      const result = await postBridgeExecute(apiInstance, 'https://api.hyperliquid.xyz/exchange', hlBody);
+      // Fail closed if the SUBMIT itself throws (transport/proxy error — HL may
+      // still have received the action). A clean HL rejection instead returns
+      // 200 and is caught by assertHyperliquidStepAccepted below, OUTSIDE this
+      // try: that is a definitive no-op, so it must NOT consume the quote.
+      let result;
+      try {
+        result = await postBridgeExecute(apiInstance, 'https://api.hyperliquid.xyz/exchange', hlBody);
+      } catch (sendErr) {
+        onBroadcast?.(step.id, null);
+        throw sendErr;
+      }
       assertHyperliquidStepAccepted(result, step.id);
       onBroadcast?.(step.id, null);
       log(`  Submitted to api.hyperliquid.xyz`);
@@ -1270,7 +1311,14 @@ async function processSignatureStepPrivy(step, { privyClient, walletId, log, api
       } else {
         postBody.signature = signature;
       }
-      await postBridgeExecute(apiInstance, targetUrl, postBody);
+      // Fail closed on any submit failure — see the local path for the rationale
+      // (an ambiguous forward must not leave the quote reusable).
+      try {
+        await postBridgeExecute(apiInstance, targetUrl, postBody);
+      } catch (sendErr) {
+        onBroadcast?.(step.id, null);
+        throw sendErr;
+      }
       onBroadcast?.(step.id, null);
     } else {
       const [rHex, sHex, vHex] = [signature.slice(2, 66), signature.slice(66, 130), signature.slice(130, 132)];
@@ -1279,7 +1327,16 @@ async function processSignatureStepPrivy(step, { privyClient, walletId, log, api
         nonce: signData.nonce,
         signature: { r: '0x' + rHex, s: '0x' + sHex, v: parseInt(vHex, 16) },
       };
-      const result = await postBridgeExecute(apiInstance, 'https://api.hyperliquid.xyz/exchange', hlBody);
+      // Submit-throw = ambiguous → fail closed; a clean HL rejection returns 200
+      // and is caught by assertHyperliquidStepAccepted (outside the try) as a
+      // definitive no-op that must NOT consume the quote.
+      let result;
+      try {
+        result = await postBridgeExecute(apiInstance, 'https://api.hyperliquid.xyz/exchange', hlBody);
+      } catch (sendErr) {
+        onBroadcast?.(step.id, null);
+        throw sendErr;
+      }
       assertHyperliquidStepAccepted(result, step.id);
       onBroadcast?.(step.id, null);
     }

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1107,7 +1107,8 @@ const PRE_BROADCAST_SEND_ERRORS = [
   'invalid sender',
   'invalid signature',
   'could not decode',
-  'rlp',
+  'rlp: ', // geth's RLP decode errors ("rlp: input string too long", …); the
+           // trailing space avoids matching "rlp" embedded in an unrelated message
   'negative value',
 ];
 

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1077,15 +1077,45 @@ export async function resolveEvmStepFees(chain, txData, overrides = {}) {
   return { gasPrice: await evmRpcCall(chain, 'eth_gasPrice') };
 }
 
-// A send failure is DEFINITIVE when the node itself refused the transaction (a
-// JSON-RPC error) or the request never left this process (no RPC configured):
-// nothing is in flight, so the quote stays reusable. Every other failure — a
-// non-JSON gateway page, a dropped connection — is AMBIGUOUS: the node may have
-// accepted the tx before the ack was lost, so callers must fail closed and
-// consume the quote rather than let a re-execute re-sign at a fresh nonce.
-// See evmRpcCall (trading.js) for the error codes.
-function isDefinitiveRpcRejection(err) {
-  return err?.code === 'RPC_JSON_ERROR' || err?.code === 'RPC_UNCONFIGURED';
+// eth_sendRawTransaction JSON-RPC error messages that PROVE the tx never
+// entered the mempool: the node rejected it during validation, so nothing is in
+// flight and the quote stays reusable. Matched case-insensitively as substrings
+// of the node's error text. Everything NOT listed here fails closed — crucially
+// the txpool states ("already known", "known transaction", "already imported",
+// "nonce too low", "replacement transaction underpriced") that mean a tx is
+// ALREADY in flight; treating those as safe rejections would let a re-execute
+// sign a fresh nonce and broadcast a second bridge tx.
+const PRE_BROADCAST_SEND_ERRORS = [
+  'insufficient funds',
+  'intrinsic gas too low',
+  'gas too low',
+  'exceeds block gas limit',
+  'exceeds the block gas limit',
+  'max fee per gas less than block base fee',
+  'fee cap less than block base fee',
+  'max priority fee per gas higher than max fee per gas',
+  'transaction underpriced', // NB: "replacement transaction underpriced" is excluded below
+  'invalid sender',
+  'invalid signature',
+  'could not decode',
+  'rlp',
+  'negative value',
+];
+
+// True when we are CONFIDENT a failed send never put the tx into the mempool, so
+// the bridge quote may be retried. This is deliberately NARROW: a definitive
+// answer requires a JSON-RPC rejection (RPC_JSON_ERROR) whose message is on the
+// pre-broadcast allowlist, or a missing-RPC config error (the request never
+// left this process). A transport/HTTP failure, or ANY other JSON-RPC error
+// (including in-flight txpool states), is ambiguous and must fail closed — see
+// evmRpcCall (trading.js) for the error codes.
+function isPreBroadcastSendRejection(err) {
+  if (err?.code === 'RPC_UNCONFIGURED') return true;
+  if (err?.code !== 'RPC_JSON_ERROR') return false;
+  const msg = (err.message || '').toLowerCase();
+  // A tx at this nonce is already pending — the EXISTING one is in flight.
+  if (msg.includes('replacement transaction underpriced')) return false;
+  return PRE_BROADCAST_SEND_ERRORS.some(pattern => msg.includes(pattern));
 }
 
 async function processEvmStep(step, { chain, privateKeyHex, signerAddress, log, onBroadcast, feeOverrides, nonceSequence, intent }) {
@@ -1129,12 +1159,14 @@ async function processEvmStep(step, { chain, privateKeyHex, signerAddress, log, 
     try {
       txHash = await evmRpcCall(chain, 'eth_sendRawTransaction', [signedTx]);
     } catch (sendErr) {
-      // A definitive rejection (the node refused this tx) leaves nothing in
-      // flight, so let it propagate WITHOUT consuming the quote. Any other
-      // failure is indistinguishable from "sent, ack lost": fail closed — mark
-      // the quote spent so a later re-execute can't re-sign this step at a fresh
-      // nonce and double-broadcast — then rethrow to abort the bridge.
-      if (!isDefinitiveRpcRejection(sendErr)) onBroadcast?.(step.id, null);
+      // Fail closed UNLESS we're confident the tx never entered the mempool (a
+      // pre-broadcast validation rejection, or no RPC configured). Everything
+      // else — a lost ack, a gateway error, OR an in-flight txpool state like
+      // "already known" / "nonce too low" that a node reports as a JSON-RPC
+      // error — may already be broadcasting, so mark the quote spent before
+      // rethrowing to abort, so a later re-execute can't re-sign this step at a
+      // fresh nonce and double-broadcast.
+      if (!isPreBroadcastSendRejection(sendErr)) onBroadcast?.(step.id, null);
       throw sendErr;
     }
     // In flight now: record it before waiting on the receipt, because a receipt

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1080,11 +1080,21 @@ export async function resolveEvmStepFees(chain, txData, overrides = {}) {
 // eth_sendRawTransaction JSON-RPC error messages that PROVE the tx never
 // entered the mempool: the node rejected it during validation, so nothing is in
 // flight and the quote stays reusable. Matched case-insensitively as substrings
-// of the node's error text. Everything NOT listed here fails closed — crucially
+// of the node's error text. Every entry here must be UNAMBIGUOUSLY pre-broadcast
+// across EVM node implementations. Everything NOT listed fails closed — crucially
 // the txpool states ("already known", "known transaction", "already imported",
 // "nonce too low", "replacement transaction underpriced") that mean a tx is
 // ALREADY in flight; treating those as safe rejections would let a re-execute
 // sign a fresh nonce and broadcast a second bridge tx.
+//
+// Deliberately EXCLUDED: the bare "transaction underpriced". On go-ethereum /
+// op-geth (which is what Base — today's only EVM bridge chain — runs) it means a
+// fresh too-low-fee tx that was never accepted, i.e. safe. But some other nodes
+// (certain Besu / Nethermind versions) reuse that same bare message for a failed
+// REPLACEMENT (a nonce collision with an in-flight tx). Since the allowlist is
+// not chain-scoped and processEvmStep runs for whatever CHAIN_RPCS resolves, we
+// fail closed on it rather than risk a future non-geth chain misclassifying an
+// in-flight tx as safe. Cost is at most a needless re-quote.
 const PRE_BROADCAST_SEND_ERRORS = [
   'insufficient funds',
   'intrinsic gas too low',
@@ -1094,7 +1104,6 @@ const PRE_BROADCAST_SEND_ERRORS = [
   'max fee per gas less than block base fee',
   'fee cap less than block base fee',
   'max priority fee per gas higher than max fee per gas',
-  'transaction underpriced', // NB: "replacement transaction underpriced" is excluded below
   'invalid sender',
   'invalid signature',
   'could not decode',
@@ -1107,14 +1116,13 @@ const PRE_BROADCAST_SEND_ERRORS = [
 // answer requires a JSON-RPC rejection (RPC_JSON_ERROR) whose message is on the
 // pre-broadcast allowlist, or a missing-RPC config error (the request never
 // left this process). A transport/HTTP failure, or ANY other JSON-RPC error
-// (including in-flight txpool states), is ambiguous and must fail closed — see
+// (including in-flight txpool states and the cross-node-ambiguous bare
+// "transaction underpriced"), is treated as unsafe and must fail closed — see
 // evmRpcCall (trading.js) for the error codes.
 function isPreBroadcastSendRejection(err) {
   if (err?.code === 'RPC_UNCONFIGURED') return true;
   if (err?.code !== 'RPC_JSON_ERROR') return false;
   const msg = (err.message || '').toLowerCase();
-  // A tx at this nonce is already pending — the EXISTING one is in flight.
-  if (msg.includes('replacement transaction underpriced')) return false;
   return PRE_BROADCAST_SEND_ERRORS.some(pattern => msg.includes(pattern));
 }
 

--- a/src/trading.js
+++ b/src/trading.js
@@ -205,11 +205,28 @@ export async function executeTransaction(params, { retries = 2, retryDelayMs = 1
       await new Promise(r => setTimeout(r, retryDelayMs));
     }
 
-    const res = await fetch(`${TRADING_API_URL}/execute`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(params),
-    });
+    let res;
+    try {
+      res = await fetch(`${TRADING_API_URL}/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(params),
+      });
+    } catch (netErr) {
+      // The POST left this process but no response came back (a reset/timeout).
+      // That may have struck AFTER the backend received the signed tx and
+      // broadcast it — indistinguishable from "never sent" — so treat it as
+      // BROADCAST_FAILED, the same fail-closed class as a 502. Retrying re-sends
+      // the SAME signed bytes (a byte-identical replay a node dedupes), so a
+      // retry here can't itself double-broadcast; only exhausting them fails
+      // closed at the caller (isFatalBroadcastError → mark the quote spent).
+      lastError = Object.assign(
+        new Error(`Execute POST to /execute failed: ${netErr.message}`),
+        { code: 'BROADCAST_FAILED' }
+      );
+      if (attempt < retries) continue;
+      throw lastError;
+    }
 
     const text = await res.text();
     let body;

--- a/src/trading.js
+++ b/src/trading.js
@@ -263,12 +263,18 @@ export async function executeTransaction(params, { retries = 2, retryDelayMs = 1
     // to the !res.ok branch below, which would surface a nonfatal upstream code
     // and let the candidate loop broadcast the next quote on top of a live tx.
     if (res.status === 502 || res.status === 503) {
+      // Only append the simulation fee hint for a NON-JSON body. A structured
+      // JSON error (e.g. { code: "UPSTREAM_TIMEOUT" }) already explains itself
+      // via `details`; tacking "you may be out of SOL" onto a gateway timeout
+      // would misdirect the user.
       const chainType = params.chain && CHAIN_MAP[params.chain]?.type;
-      const feeHint = chainType === 'solana'
-        ? ' This often means the transaction failed simulation — check that you have enough SOL for fees (~0.005 SOL minimum).'
-        : chainType === 'evm'
-          ? ' This often means the transaction failed simulation — check that you have enough ETH for gas fees.'
-          : '';
+      const feeHint = !parsed
+        ? chainType === 'solana'
+          ? ' This often means the transaction failed simulation — check that you have enough SOL for fees (~0.005 SOL minimum).'
+          : chainType === 'evm'
+            ? ' This often means the transaction failed simulation — check that you have enough ETH for gas fees.'
+            : ''
+        : '';
       lastError = Object.assign(
         new Error(`Execute API returned ${res.status} — treating as an ambiguous broadcast failure; the transaction may already be live.${feeHint}`),
         { code: 'BROADCAST_FAILED', status: res.status, details: parsed ? body : text.slice(0, 200) }

--- a/src/trading.js
+++ b/src/trading.js
@@ -87,22 +87,41 @@ export function resolveTokenAddress(symbolOrAddress, chainName) {
  * @returns {Promise<*>} Parsed result value
  * @throws {Error} If chain has no configured RPC or the RPC returns an error
  */
+// Error codes let a broadcasting caller (bridge.js) tell a DEFINITIVE rejection
+// (the node refused the tx — nothing is in flight, safe to retry) apart from an
+// AMBIGUOUS failure (a gateway/transport error that may have dropped the ack
+// AFTER the node accepted the tx), so it can fail closed only on the latter:
+//   - RPC_UNCONFIGURED — no URL; thrown before any request leaves the process
+//   - RPC_NETWORK_ERROR — request left but no response (reset/timeout): ambiguous
+//   - RPC_HTTP_ERROR    — non-JSON HTTP response (e.g. a 502 gateway page): ambiguous
+//   - RPC_JSON_ERROR    — a JSON-RPC { error }: the node definitively rejected it
 export async function evmRpcCall(chain, method, params = []) {
   const rpcUrl = CHAIN_RPCS[chain];
-  if (!rpcUrl) throw new Error(`No RPC URL configured for chain: ${chain}`);
-  const res = await fetch(rpcUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
-  });
+  if (!rpcUrl) throw Object.assign(new Error(`No RPC URL configured for chain: ${chain}`), { code: 'RPC_UNCONFIGURED' });
+  let res;
+  try {
+    res = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+    });
+  } catch (netErr) {
+    // The request left this process but no response came back. A reset or
+    // timeout can strike AFTER the node accepted the payload, so a caller that
+    // just broadcast a tx cannot assume it was never sent.
+    throw Object.assign(new Error(`RPC request to ${chain} failed for ${method}: ${netErr.message}`), { code: 'RPC_NETWORK_ERROR' });
+  }
   const text = await res.text();
   let body;
   try {
     body = JSON.parse(text);
   } catch {
-    throw new Error(`RPC endpoint returned non-JSON response (HTTP ${res.status}) for ${method}: ${text.slice(0, 100)}`);
+    throw Object.assign(
+      new Error(`RPC endpoint returned non-JSON response (HTTP ${res.status}) for ${method}: ${text.slice(0, 100)}`),
+      { code: 'RPC_HTTP_ERROR', status: res.status },
+    );
   }
-  if (body.error) throw new Error(`RPC error (${method}): ${body.error.message}`);
+  if (body.error) throw Object.assign(new Error(`RPC error (${method}): ${body.error.message}`), { code: 'RPC_JSON_ERROR' });
   return body.result;
 }
 
@@ -845,6 +864,12 @@ export async function waitForReceipt(chain, txHash, timeoutMs = 180000, pollMs =
  *   - RECEIPT_TIMEOUT  — receipt never landed; the tx may still be pending, so
  *                        retrying would race a second tx against the same nonce
  *                        (a confirmed on-chain revert is NOT this — it may retry)
+ *   - BROADCAST_FAILED — /execute returned an uninterpretable response (non-JSON,
+ *                        typically a 502/503 after all retries) AFTER we POSTed
+ *                        the signed tx. A dropped ack is indistinguishable from
+ *                        "never sent", so the backend may already have broadcast
+ *                        it; failing closed here trades a needless re-quote for
+ *                        never trying the next candidate on top of a live tx.
  *
  * @param {Error} err
  * @returns {boolean}
@@ -852,7 +877,8 @@ export async function waitForReceipt(chain, txHash, timeoutMs = 180000, pollMs =
 function isFatalBroadcastError(err) {
   return err?.code === 'TXHASH_MISMATCH'
     || err?.code === 'INVALID_SIGNED_TX'
-    || err?.code === 'RECEIPT_TIMEOUT';
+    || err?.code === 'RECEIPT_TIMEOUT'
+    || err?.code === 'BROADCAST_FAILED';
 }
 
 /**
@@ -3698,10 +3724,22 @@ EXAMPLES:
             }
 
           } catch (quoteErr) {
+            // A BROADCAST_FAILED throws out of executeTransaction — BEFORE the
+            // normal markQuoteExecuted runs — so nothing has recorded this quote
+            // as spent. The signed tx may already be live on the backend (a 502
+            // on the ack, not on the send), so fail closed: mark it here so a
+            // later "trade execute --quote <id>" (or an agent auto-retry) is
+            // refused before it re-signs under a fresh nonce. No broadcast hash
+            // is recorded — we don't have one — which yields loadQuote's generic
+            // "may still be pending, check the explorer" message.
+            if (quoteErr?.code === 'BROADCAST_FAILED') {
+              markQuoteExecuted(quoteId);
+            }
             // Post-broadcast failures abort the whole execute — never retry the
             // next quote once a transaction is already out and its outcome is
-            // unknown (mismatch, underivable local hash, or an unconfirmed
-            // receipt timeout). See isFatalBroadcastError.
+            // unknown (mismatch, underivable local hash, an unconfirmed receipt
+            // timeout, or an ambiguous broadcast failure). See
+            // isFatalBroadcastError.
             if (isFatalBroadcastError(quoteErr)) throw quoteErr;
             const msg = quoteErr.message || '';
             log(`  ❌ Quote ${quoteName} failed: ${msg}`);

--- a/src/trading.js
+++ b/src/trading.js
@@ -228,25 +228,63 @@ export async function executeTransaction(params, { retries = 2, retryDelayMs = 1
       throw lastError;
     }
 
-    const text = await res.text();
+    let text;
+    try {
+      text = await res.text();
+    } catch (bodyErr) {
+      // Headers arrived but the body read failed (a truncated/reset response).
+      // Like the network case above, the backend may already have broadcast, so
+      // fail closed as BROADCAST_FAILED rather than surface a codeless error the
+      // candidate loop would treat as nonfatal. A retry re-sends byte-identical
+      // bytes a node dedupes.
+      lastError = Object.assign(
+        new Error(`Execute response body read failed (status ${res.status}): ${bodyErr.message}`),
+        { code: 'BROADCAST_FAILED', status: res.status }
+      );
+      if ((res.status === 502 || res.status === 503) && attempt < retries) continue;
+      throw lastError;
+    }
+
+    // Parse up front so a JSON body can be preserved as structured details — but
+    // the classification below never lets a parseable body downgrade an
+    // ambiguous status to its own (nonfatal) code.
     let body;
+    let parsed = true;
     try {
       body = JSON.parse(text);
     } catch {
+      parsed = false;
+    }
+
+    // A 502/503 is ambiguous no matter the body SHAPE: the gateway may have
+    // forwarded the signed tx upstream before failing (a JSON 502 like
+    // { code: "UPSTREAM_TIMEOUT" } is exactly that case). Classify EVERY 502/503
+    // as BROADCAST_FAILED and keep the body only as details — never fall through
+    // to the !res.ok branch below, which would surface a nonfatal upstream code
+    // and let the candidate loop broadcast the next quote on top of a live tx.
+    if (res.status === 502 || res.status === 503) {
       const chainType = params.chain && CHAIN_MAP[params.chain]?.type;
-      const feeHint = res.status === 502
-        ? chainType === 'solana'
-          ? ' This often means the transaction failed simulation — check that you have enough SOL for fees (~0.005 SOL minimum).'
-          : chainType === 'evm'
-            ? ' This often means the transaction failed simulation — check that you have enough ETH for gas fees.'
-            : ''
-        : '';
+      const feeHint = chainType === 'solana'
+        ? ' This often means the transaction failed simulation — check that you have enough SOL for fees (~0.005 SOL minimum).'
+        : chainType === 'evm'
+          ? ' This often means the transaction failed simulation — check that you have enough ETH for gas fees.'
+          : '';
       lastError = Object.assign(
-        new Error(`Execute API returned non-JSON response (status ${res.status}).${feeHint || ' This may be a Cloudflare challenge or server error.'}`),
+        new Error(`Execute API returned ${res.status} — treating as an ambiguous broadcast failure; the transaction may already be live.${feeHint}`),
+        { code: 'BROADCAST_FAILED', status: res.status, details: parsed ? body : text.slice(0, 200) }
+      );
+      // Retry (re-POSTs byte-identical bytes) then fail closed at the caller.
+      if (attempt < retries) continue;
+      throw lastError;
+    }
+
+    if (!parsed) {
+      // Non-JSON on a non-502/503 status (a Cloudflare challenge or HTML error
+      // page). Still uninterpretable after the POST went out, so fail closed.
+      lastError = Object.assign(
+        new Error(`Execute API returned non-JSON response (status ${res.status}). This may be a Cloudflare challenge or server error.`),
         { code: 'BROADCAST_FAILED', status: res.status, details: text.slice(0, 200) }
       );
-      // Retry on 502/503 (likely transient Cloudflare issues)
-      if ((res.status === 502 || res.status === 503) && attempt < retries) continue;
       throw lastError;
     }
 

--- a/src/trading.js
+++ b/src/trading.js
@@ -241,7 +241,7 @@ export async function executeTransaction(params, { retries = 2, retryDelayMs = 1
         new Error(`Execute response body read failed (status ${res.status}): ${bodyErr.message}`),
         { code: 'BROADCAST_FAILED', status: res.status }
       );
-      if ((res.status === 502 || res.status === 503) && attempt < retries) continue;
+      if (res.status >= 500 && attempt < retries) continue;
       throw lastError;
     }
 
@@ -256,13 +256,15 @@ export async function executeTransaction(params, { retries = 2, retryDelayMs = 1
       parsed = false;
     }
 
-    // A 502/503 is ambiguous no matter the body SHAPE: the gateway may have
-    // forwarded the signed tx upstream before failing (a JSON 502 like
-    // { code: "UPSTREAM_TIMEOUT" } is exactly that case). Classify EVERY 502/503
-    // as BROADCAST_FAILED and keep the body only as details — never fall through
-    // to the !res.ok branch below, which would surface a nonfatal upstream code
-    // and let the candidate loop broadcast the next quote on top of a live tx.
-    if (res.status === 502 || res.status === 503) {
+    // ANY 5xx is ambiguous no matter the body SHAPE: the gateway may have
+    // forwarded the signed tx upstream before failing (a JSON 502/504 like
+    // { code: "UPSTREAM_TIMEOUT" } is exactly that case, and a 500/504 carries
+    // the same "forwarded then lost the ack" risk as a 502/503). Classify EVERY
+    // 5xx as BROADCAST_FAILED and keep the body only as details — never fall
+    // through to the !res.ok branch below, which would surface a nonfatal
+    // upstream code and let the candidate loop broadcast the next quote on top
+    // of a live tx.
+    if (res.status >= 500) {
       // Only append the simulation fee hint for a NON-JSON body. A structured
       // JSON error (e.g. { code: "UPSTREAM_TIMEOUT" }) already explains itself
       // via `details`; tacking "you may be out of SOL" onto a gateway timeout
@@ -285,7 +287,7 @@ export async function executeTransaction(params, { retries = 2, retryDelayMs = 1
     }
 
     if (!parsed) {
-      // Non-JSON on a non-502/503 status (a Cloudflare challenge or HTML error
+      // Non-JSON on a sub-500 status (a Cloudflare challenge or HTML error
       // page). Still uninterpretable after the POST went out, so fail closed.
       lastError = Object.assign(
         new Error(`Execute API returned non-JSON response (status ${res.status}). This may be a Cloudflare challenge or server error.`),
@@ -3648,7 +3650,16 @@ EXAMPLES:
               execParams.requestId = requestId; // Solana Jupiter Ultra
             }
 
-            const result = await executeTransaction(execParams);
+            // A retry re-POSTs the signed payload. For a normal swap that's a
+            // byte-identical replay the node dedupes, so retrying an ambiguous
+            // 5xx/network failure can't itself double-broadcast. But a --gasless
+            // Relay swap sends a signed AUTHORIZATION, and Relay's solver
+            // broadcasts its OWN wrapping tx from it (the returned txHash is not
+            // our bytes) — so a re-POST after the solver already picked it up
+            // can't be deduped at the node level and risks a second solve. For
+            // gasless we therefore don't retry: a single POST either succeeds or
+            // fails closed (BROADCAST_FAILED marks the quote spent and aborts).
+            const result = await executeTransaction(execParams, { retries: gasless ? 0 : undefined });
 
             if (result.status === 'Success') {
               let txId = result.signature || result.txHash;


### PR DESCRIPTION
## Problem

The single-use quote guard marks a quote spent only *after* the broadcast call returns. If the broadcast instead **throws after the tx may already be live**, the quote is left unmarked — so a swap re-broadcasts the next candidate in-run, and a later `trade execute --quote <id>` (or an agent auto-retry) re-signs under a fresh nonce and broadcasts a **second, independently valid** transaction.

The concrete trigger: `/execute` retries a 502/503 and, if all attempts fail, throws `BROADCAST_FAILED`. A 502 on the **ack** (not the send) is indistinguishable at the client from "never sent" — but the tx is live. `bridge.js` has the same post-broadcast-throw shape on its EVM and signature legs.

## Fix — fail closed on ambiguity

The client can't distinguish "502, never sent" (safe to retry) from "502, sent but ack lost" (unsafe), so this is a policy choice, not detection. We fail closed: mark the quote spent and abort, trading a needless re-quote for never double-broadcasting. A **definitive** node rejection (a JSON-RPC error — the tx was refused, nothing is in flight) still leaves the quote reusable, so ordinary pre-broadcast errors don't burn a quote.

- **`trading.js`** — `BROADCAST_FAILED` is now a fatal broadcast error (aborts the candidate loop) and marks the quote spent in the catch (it throws out of `executeTransaction` before the normal mark runs).
- **`bridge.js`** — fail closed on non-definitive send failures across the EVM leg and both signature legs; a clean Hyperliquid rejection (`assertHyperliquidStepAccepted`) stays outside the guard, so it remains reusable.
- **`evmRpcCall`** — tags thrown errors with codes (`RPC_UNCONFIGURED` / `RPC_NETWORK_ERROR` / `RPC_HTTP_ERROR` / `RPC_JSON_ERROR`) so callers can tell a definitive rejection from an ambiguous gateway/transport failure.

## Testing

- New unit coverage: swap `BROADCAST_FAILED` fail-close (aborts without touching the next candidate, marks the quote, refuses re-execute); bridge ambiguous (non-JSON 502, network drop) → quote consumed, vs definitive (JSON-RPC rejection) → quote reusable.
- Full suite green (2579 passed / 2 skipped); lint clean.
- Live happy-path broadcast round-trips (Base ETH↔USDC, cross-chain ETH↔SOL) pass through the changed execute path.

Note: the ambiguous branch itself is only reachable during a real broadcast failure (impractical to force live without deliberately broadcasting), so it's verified via the unit tests that drive the exact failure shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)