### PR TITLE
fix: route wallet list summary to stderr, emit JSON on stdout

### DIFF
--- a/.changeset/fix-wallet-list-stdout-json.md
+++ b/.changeset/fix-wallet-list-stdout-json.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix `nansen wallet list` polluting stdout with its human-readable summary, which made the output impossible for an agent to `JSON.parse`. The decorated summary (wallet names, EVM/Solana addresses, default marker) now goes to stderr, and the command returns a structured `{ wallets }` value so stdout carries only clean JSON — matching how research commands emit their data. The empty case (`No wallets found`) likewise prints its hint to stderr and still emits `{ "wallets": [] }` on stdout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Entry point is `src/index.js`.
 - **ESM only** — `import`/`export`, no TypeScript, no transpilation
 - **BigInt for token amounts** — never floating point
 - **Research commands** — return data objects, CLI layer formats via `formatOutput()` to stdout
-- **Operational commands** (trade, wallet, login) — print human-readable text via `log()` to stdout, return `undefined`
+- **Operational commands** (trade, wallet, login) — print human-readable text via `log()` to stdout, return `undefined`. **Exception:** `wallet list` routes its human-readable summary to stderr and returns `{ wallets }` so agents can `JSON.parse` stdout; follow this pattern for any wallet subcommand that returns queryable data.
 - **No interactive prompts in core** — use env vars (`NANSEN_WALLET_PASSWORD`, `NANSEN_API_KEY`)
 - **Actionable errors** — `"Not logged in. Run: nansen login"` not `"Authentication failed"`
 

--- a/src/__tests__/wallet.test.js
+++ b/src/__tests__/wallet.test.js
@@ -684,6 +684,7 @@ describe('Privy wallet create does not emit PASSWORD_REQUIRED', () => {
 describe('Wallet list/show CLI output for provider', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it('list output shows provider for Privy wallets', async () => {
@@ -700,12 +701,62 @@ describe('Wallet list/show CLI output for provider', () => {
       }));
 
     const { buildWalletCommands } = await import('../wallet.js');
-    const output = [];
-    const cmds = buildWalletCommands({ log: (m) => output.push(m), exit: () => {} });
+    let stderr = '';
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr += chunk;
+      return true;
+    });
+    const cmds = buildWalletCommands({ log: () => {}, exit: () => {} });
     await cmds.wallet(['list'], null, {}, {});
 
-    const joined = output.join('\n');
-    expect(joined).toContain('privy');
+    // The provider tag lives in the human-readable summary, now on stderr.
+    expect(stderr).toContain('privy');
+  });
+});
+
+describe('wallet list stdout/stderr separation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('emits only JSON.parse-able output to stdout and the human summary to stderr', async () => {
+    const walletsDir = path.join(tempDir, '.nansen', 'wallets');
+    fs.mkdirSync(walletsDir, { recursive: true });
+    fs.writeFileSync(path.join(walletsDir, 'config.json'),
+      JSON.stringify({ defaultWallet: 'main', passwordHash: null }));
+    fs.writeFileSync(path.join(walletsDir, 'main.json'),
+      JSON.stringify({
+        name: 'main', provider: 'local',
+        evm: { address: '0xEvmAddr' },
+        solana: { address: 'SolAddr' },
+        createdAt: '2026-01-01T00:00:00Z',
+      }));
+
+    const { runCLI } = await import('../cli.js');
+
+    const stdout = [];
+    let stderr = '';
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr += chunk;
+      return true;
+    });
+
+    await runCLI(['wallet', 'list'], {
+      output: (msg) => stdout.push(msg),
+      errorOutput: () => {},
+      exit: () => {},
+    });
+
+    // stdout carries a single clean JSON document an agent can parse
+    const joined = stdout.join('\n');
+    const parsed = JSON.parse(joined);
+    expect(parsed.data.wallets).toHaveLength(1);
+    expect(parsed.data.wallets[0].name).toBe('main');
+
+    // the human-readable summary belongs on stderr, never stdout
+    expect(stderr).toContain('main');
+    expect(stderr).toContain('EVM:');
+    expect(joined).not.toContain('EVM:');
   });
 });
 

--- a/src/schema.json
+++ b/src/schema.json
@@ -1903,7 +1903,15 @@
           "description": "Create a new wallet"
         },
         "list": {
-          "description": "List all wallets"
+          "description": "List all wallets",
+          "returns": [
+            "wallets[].name",
+            "wallets[].evm",
+            "wallets[].solana",
+            "wallets[].isDefault",
+            "wallets[].provider",
+            "wallets[].createdAt"
+          ]
         },
         "show": {
           "description": "Show wallet details",

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -720,19 +720,23 @@ export function buildWalletCommands(deps = {}) {
 
         'list': async () => {
           const result = listWallets();
+          // Human-readable summary goes to stderr so stdout carries only the
+          // structured JSON that agents parse; the return value drives runCLI's
+          // stdout path (matching how research commands emit their data).
           if (result.wallets.length === 0) {
-            log('No wallets found. Create one with: nansen wallet create');
-            return;
+            process.stderr.write('No wallets found. Create one with: nansen wallet create\n');
+            return { wallets: result.wallets };
           }
-          log('');
+          process.stderr.write('\n');
           for (const w of result.wallets) {
             const star = w.isDefault ? ' ★' : '';
             const providerTag = w.provider === 'privy' ? ' (privy)' : '';
-            log(`  ${w.name}${star}${providerTag}`);
-            log(`    EVM:    ${w.evm}`);
-            log(`    Solana: ${w.solana}`);
-            log('');
+            process.stderr.write(`  ${w.name}${star}${providerTag}\n`);
+            process.stderr.write(`    EVM:    ${w.evm}\n`);
+            process.stderr.write(`    Solana: ${w.solana}\n`);
+            process.stderr.write('\n');
           }
+          return { wallets: result.wallets };
         },
 
         'show': async () => {


### PR DESCRIPTION
## The bug

`nansen wallet list` writes its human-readable summary (wallet names, EVM/Solana addresses, the `★` default marker) to **stdout** via `log()`, and returns `undefined` so no structured JSON is emitted. That mixes prose and data on the same stream, so agent pipelines that expect parseable output break:

```console
$ nansen wallet list | jq .
parse error: Invalid numeric literal at line 1, column 5
```

Every other data-returning command emits clean JSON on stdout; `wallet list` is the odd one out, which makes it unusable in `| jq`-style automation.

## Prior history — why this keeps coming back

This was reported before in #289 and #406, and both were closed on the belief that the fix had already landed via #397. That belief is incorrect, and I verified it two ways before writing this:

- **#397's actual diff** only extracted a `requireWalletFile()` helper for the file-existence checks in `showWallet`, `exportWallet`, `setDefaultWallet`, and `deleteWallet` (plus a `deriveEvmAddress()` helper in `transfer.js`). It is a self-described "no behavior changes" refactor and **never touches `listWallets` or the `list` handler**.
- A full `git log -L :listWallets:src/wallet.js` trace shows `listWallets` was only ever touched by two commits: its original creation, and one Privy PR that added a `provider` field. **No commit in its history ever introduced stderr/stdout separation.**

So this is a **fresh fix**, not a rebase or reopen of the older PRs — the output path they were meant to fix was never actually modified.

## The fix

In the `list` handler (`src/wallet.js`):
- Route the human-readable summary to **stderr** via `process.stderr.write` (the file's existing convention).
- Return a structured `{ wallets }` value so `runCLI`'s normal success path renders clean JSON to **stdout** — mirroring how research/data commands emit their output.
- The empty case prints its `No wallets found` hint to stderr and still returns `{ wallets: [] }`, so **stdout is always valid JSON**.

After the fix:
```console
$ nansen wallet list | jq '.data.wallets[].name'
"main"
```
(the summary still renders for humans — it's just on stderr now.)

## Testing & verification

- **Failing-first test** added driving the real `runCLI`: before the fix it fails with `SyntaxError: Unexpected end of JSON input` (the summary went to real stdout, the JSON sink was empty) — reproducing the exact bug.
- After the fix, the wallet-list tests pass (**4 passing**), including an updated Privy test that now asserts the provider tag lands on stderr.
- **Full suite: 2623 passed, 2 skipped, 0 failed** (64 files).
- **`npm run lint`: clean.**
- Changeset added (`patch`), user-facing.
