### PR TITLE
fix: reject non-numeric --*-min/--*-max alert flags instead of silently dropping them

### DIFF
--- a/.changeset/fix-alerts-numeric-range-validation.md
+++ b/.changeset/fix-alerts-numeric-range-validation.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix `nansen alerts create`/`update` silently dropping numeric range filters (`--usd-min/max`, `--market-cap-min/max`, `--fdv-min/max`, `--token-amount-min/max`, `--token-age-min/max`, and the `--inflow/outflow/netflow-*-min/max` flags) instead of rejecting bad input. These flags were converted with plain `Number(val)`, so a typo or garbage value (e.g. `--usd-min abc`) became `NaN`, which `JSON.stringify` silently turns into `null` in the request body — the alert would get created without the filter the user thought they'd set, with no error at any point. `--*-min`/`--*-max` now reject non-numeric input with a clear `Invalid --<flag> "<value>": must be a number` error; valid negative values (e.g. `--netflow-1h-min -5000` for a net-outflow filter) are unaffected.

--- a/src/__tests__/alerts.test.js
+++ b/src/__tests__/alerts.test.js
@@ -1,0 +1,57 @@
+/**
+ * Alerts command - numeric range validation
+ *
+ * buildRange() / parseFiniteNumber() feed --*-min/--*-max flags into the
+ * alert payload sent to the API. Before this fix, a non-numeric value
+ * (typo, empty string, etc.) silently became NaN, which JSON.stringify
+ * then turns into `null` — so the filter the user asked for would vanish
+ * from the request instead of failing loudly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildSmTokenFlowsData,
+  buildCommonTokenTransferData,
+  buildSmartContractCallData,
+} from '../commands/alerts.js';
+
+describe('alerts numeric range validation', () => {
+  it('builds a valid range for sm-token-flows', () => {
+    const data = buildSmTokenFlowsData({ 'inflow-1h-min': '1000000', 'inflow-1h-max': '5000000' });
+    expect(data.inflow_1h).toEqual({ min: 1000000, max: 5000000 });
+  });
+
+  it('allows negative values (net outflow) instead of rejecting all negatives', () => {
+    const data = buildSmTokenFlowsData({ 'netflow-1h-min': '-5000', 'netflow-1h-max': '10000' });
+    expect(data.netflow_1h).toEqual({ min: -5000, max: 10000 });
+  });
+
+  it('rejects non-numeric --usd-min instead of silently sending null', () => {
+    expect(() => buildCommonTokenTransferData({ 'usd-min': 'abc' })).toThrow(/--usd-min/);
+  });
+
+  it('rejects non-numeric --token-amount-max', () => {
+    expect(() => buildCommonTokenTransferData({ 'token-amount-max': 'lots' })).toThrow(/--token-amount-max/);
+  });
+
+  it('rejects non-numeric --market-cap-min on sm-token-flows', () => {
+    expect(() => buildSmTokenFlowsData({ 'market-cap-min': 'n/a' })).toThrow(/--market-cap-min/);
+  });
+
+  it('rejects non-numeric --token-age-max', () => {
+    expect(() => buildSmTokenFlowsData({ 'token-age-max': 'seven' })).toThrow(/--token-age-max/);
+  });
+
+  it('rejects non-numeric --token-age-min/--token-age-max on common-token-transfer', () => {
+    expect(() => buildCommonTokenTransferData({ 'token-age-min': 'x' })).toThrow(/--token-age-min/);
+    expect(() => buildCommonTokenTransferData({ 'token-age-max': 'y' })).toThrow(/--token-age-max/);
+  });
+
+  it('rejects non-numeric --usd-max on smart-contract-call', () => {
+    expect(() => buildSmartContractCallData({ 'usd-max': 'not-a-number' })).toThrow(/--usd-max/);
+  });
+
+  it('leaves ranges undefined when no min/max flags are given', () => {
+    expect(buildSmTokenFlowsData({}).inflow_1h).toBeUndefined();
+  });
+});

--- a/src/commands/alerts.js
+++ b/src/commands/alerts.js
@@ -108,14 +108,31 @@ function parseChains(chainsOpt) {
 }
 
 /**
+ * Parse a CLI option value as a finite number, or throw a clear error.
+ *
+ * Plain `Number(val)` turns garbage input ("abc") into NaN, and
+ * `JSON.stringify` silently turns NaN into `null` — so a typo'd
+ * --usd-min/--market-cap-max/etc. would vanish from the request instead of
+ * failing loudly, and the alert would ship without the filter the user
+ * asked for.
+ */
+function parseFiniteNumber(raw, name) {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    throw new NansenError(`Invalid --${name} "${raw}": must be a number`, ErrorCode.INVALID_PARAMS);
+  }
+  return n;
+}
+
+/**
  * Build a { min, max } range object from two option values.
  * Returns undefined if neither is provided.
  */
-function buildRange(minVal, maxVal) {
+function buildRange(minVal, maxVal, name) {
   if (minVal === undefined && maxVal === undefined) return undefined;
   const r = {};
-  if (minVal !== undefined) r.min = Number(minVal);
-  if (maxVal !== undefined) r.max = Number(maxVal);
+  if (minVal !== undefined) r.min = parseFiniteNumber(minVal, `${name}-min`);
+  if (maxVal !== undefined) r.max = parseFiniteNumber(maxVal, `${name}-max`);
   return r;
 }
 
@@ -138,7 +155,7 @@ export function buildSmTokenFlowsData(options) {
 
   const flowFields = ['inflow-1h', 'inflow-1d', 'inflow-7d', 'outflow-1h', 'outflow-1d', 'outflow-7d', 'netflow-1h', 'netflow-1d', 'netflow-7d'];
   for (const field of flowFields) {
-    const range = buildRange(options[`${field}-min`], options[`${field}-max`]);
+    const range = buildRange(options[`${field}-min`], options[`${field}-max`], field);
     if (range) {
       // Convert CLI key "inflow-1h" → data key "inflow_1h"
       data[field.replace(/-/g, '_')] = range;
@@ -156,13 +173,13 @@ export function buildSmTokenFlowsData(options) {
   if (excludeSectors) data.exclusion = { ...data.exclusion, tokenSectors: excludeSectors };
 
   if (options['token-age-max'] !== undefined) {
-    data.inclusion = { ...data.inclusion, tokenAge: { max: Number(options['token-age-max']) } };
+    data.inclusion = { ...data.inclusion, tokenAge: { max: parseFiniteNumber(options['token-age-max'], 'token-age-max') } };
   }
 
-  const marketCapRange = buildRange(options['market-cap-min'], options['market-cap-max']);
+  const marketCapRange = buildRange(options['market-cap-min'], options['market-cap-max'], 'market-cap');
   if (marketCapRange) data.inclusion = { ...data.inclusion, marketCap: marketCapRange };
 
-  const fdvRange = buildRange(options['fdv-min'], options['fdv-max']);
+  const fdvRange = buildRange(options['fdv-min'], options['fdv-max'], 'fdv');
   if (fdvRange) data.inclusion = { ...data.inclusion, fdvUsd: fdvRange };
 
   return data;
@@ -181,10 +198,10 @@ export function buildCommonTokenTransferData(options) {
     data.events = typeof options.events === 'string' ? options.events.split(',') : options.events;
   }
 
-  const usdRange = buildRange(options['usd-min'], options['usd-max']);
+  const usdRange = buildRange(options['usd-min'], options['usd-max'], 'usd');
   if (usdRange) data.usdValue = usdRange;
 
-  const amountRange = buildRange(options['token-amount-min'], options['token-amount-max']);
+  const amountRange = buildRange(options['token-amount-min'], options['token-amount-max'], 'token-amount');
   if (amountRange) data.tokenAmount = amountRange;
 
   const subjects = parseSubjects(options.subject);
@@ -207,12 +224,12 @@ export function buildCommonTokenTransferData(options) {
   const tokenAgeMax = options['token-age-max'];
   if (tokenAgeMin !== undefined || tokenAgeMax !== undefined) {
     const tokenAge = {};
-    if (tokenAgeMin !== undefined) tokenAge.min = Number(tokenAgeMin);
-    if (tokenAgeMax !== undefined) tokenAge.max = Number(tokenAgeMax);
+    if (tokenAgeMin !== undefined) tokenAge.min = parseFiniteNumber(tokenAgeMin, 'token-age-min');
+    if (tokenAgeMax !== undefined) tokenAge.max = parseFiniteNumber(tokenAgeMax, 'token-age-max');
     data.inclusion = { ...data.inclusion, tokenAge };
   }
 
-  const marketCapRange = buildRange(options['market-cap-min'], options['market-cap-max']);
+  const marketCapRange = buildRange(options['market-cap-min'], options['market-cap-max'], 'market-cap');
   if (marketCapRange) data.inclusion = { ...data.inclusion, marketCap: marketCapRange };
 
   const excludeFrom = parseSubjects(options['exclude-from']);
@@ -232,7 +249,7 @@ export function buildSmartContractCallData(options) {
   const chains = parseChains(options.chains);
   if (chains) data.chains = chains;
 
-  const usdRange = buildRange(options['usd-min'], options['usd-max']);
+  const usdRange = buildRange(options['usd-min'], options['usd-max'], 'usd');
   if (usdRange) data.usdValue = usdRange;
 
   if (options['signature-hash']) {


### PR DESCRIPTION
## What
`nansen alerts create`/`update` numeric range flags (`--usd-min/max`, `--market-cap-min/max`,
`--fdv-min/max`, `--token-amount-min/max`, `--token-age-min/max`, and all
`--inflow/outflow/netflow-*-min/max` flags) went through plain `Number(val)`.

A non-numeric value becomes `NaN`, and `JSON.stringify(NaN)` silently serializes to `null`:

    buildCommonTokenTransferData({ 'usd-min': 'abc', 'usd-max': '5000' })
    → JSON sent to API: {"usdValue":{"min":null,"max":5000}}

So a typo'd flag doesn't error — the alert is just created without the filter the user
asked for, and there's no signal anywhere that anything went wrong. This module had no
test coverage at all before this PR.

## Fix
Added `parseFiniteNumber(raw, name)` and wired it into `buildRange()` and the standalone
token-age fields. Non-numeric input now throws a clear `NansenError` (`Invalid --<flag>
"<value>": must be a number`) instead of silently becoming `null`. Negative values are
still allowed where they're meaningful (e.g. `--netflow-1h-min -5000` for a net-outflow
filter) — this only rejects genuinely non-numeric input, not the sign.

## Testing
`npm test` output for the new file:

     RUN  v4.1.9
     ✓ src/__tests__/alerts.test.js (9 tests) 9ms
     Test Files  1 passed (1)
          Tests  9 passed (9)

Full suite: 2626 passed / 5 failed / 2 skipped. The 5 failures (all in `doctor.test.js`,
chmod/permission-based checks) reproduce identically on a clean `main` with no changes —
confirmed by stashing this PR's changes and re-running — so they're a pre-existing
CI/sandbox artifact (running as root skips permission enforcement), not something this
PR introduces.

`npm run lint` — clean.

## Checklist
- [x] `npm test` passes for the new/changed code (full-suite failures pre-exist on main)
- [x] `npm run lint` passes
- [x] New code paths have tests
- [x] No `console.log`, no hardcoded secrets
- [x] Error messages are actionable
- [x] Changeset added
- [x] No `src/schema.json` change needed (no new commands/options, just validation)