### PR TITLE
fix: alerts numeric flags silently produce wrong results on invalid input

### DIFF
--- a/.changeset/fix-alerts-numeric-validation.md
+++ b/.changeset/fix-alerts-numeric-validation.md
@@ -1,0 +1,9 @@
+---
+"nansen-cli": patch
+---
+
+Fix `nansen alerts list --limit`/`--offset` and the numeric range flags on `nansen alerts create`/`update` (`--market-cap-min/max`, `--usd-min/max`, `--token-amount-min/max`, `--fdv-min/max`, `--inflow/outflow/netflow-*-min/max`, `--token-age-min/max`) silently accepting non-numeric input instead of erroring.
+
+`--limit abc` returned an empty alert list (`Array.prototype.slice(0, NaN)` evaluates the end index as `0`), indistinguishable from genuinely having zero alerts. `--offset -2` silently returned the *last* 2 alerts (a negative `slice()` start counts from the end of the array) instead of erroring on an invalid pagination offset. A non-numeric range flag like `--market-cap-min notanumber` passed validation (`NaN != null` looks "set") but serialized to `{"min":null}` over JSON, silently creating the alert with that threshold disabled rather than the value the user typed.
+
+All of these now throw a clear `--<flag> must be a number` / `must be a positive integer` / `must be a non-negative integer` error instead of silently producing a wrong result, matching the validation style already used by `--limit`/`--page` elsewhere in the CLI (`src/query-options.js`, `src/commands/research.js`).

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -305,6 +305,26 @@ describe('buildSmTokenFlowsData', () => {
     const result = buildSmTokenFlowsData({});
     expect(result).toEqual({});
   });
+
+  it('rejects a non-numeric range flag instead of silently producing NaN (regression)', () => {
+    // Before the fix: buildRange did `Number(minVal)` with no check. NaN
+    // passes isRangeSet()'s `!= null` test (NaN is neither null nor
+    // undefined), so a typo'd threshold looked "set" all the way through
+    // validation -- but JSON.stringify({min: NaN}) serializes to
+    // {"min":null}, silently disabling the threshold the user asked for
+    // instead of erroring on the bad input.
+    expect(() => buildSmTokenFlowsData({ 'market-cap-min': 'notanumber' }))
+      .toThrow('--market-cap-min must be a number');
+    expect(() => buildSmTokenFlowsData({ 'inflow-1h-max': 'abc' }))
+      .toThrow('--inflow-1h-max must be a number');
+    expect(() => buildSmTokenFlowsData({ 'fdv-min': 'nope' }))
+      .toThrow('--fdv-min must be a number');
+  });
+
+  it('rejects a non-numeric --token-age-max', () => {
+    expect(() => buildSmTokenFlowsData({ 'token-age-max': 'abc' }))
+      .toThrow('--token-age-max must be a number');
+  });
 });
 
 describe('buildCommonTokenTransferData', () => {
@@ -350,6 +370,21 @@ describe('buildCommonTokenTransferData', () => {
     });
     expect(result.inclusion).toEqual({ tokens: [{ address: '0xusdc', chain: 'ethereum' }] });
   });
+
+  it('rejects non-numeric --usd-min/--token-amount-max instead of silently producing NaN (regression)', () => {
+    expect(() => buildCommonTokenTransferData({ 'usd-min': 'notanumber' }))
+      .toThrow('--usd-min must be a number');
+    expect(() => buildCommonTokenTransferData({ 'token-amount-max': 'abc' }))
+      .toThrow('--token-amount-max must be a number');
+  });
+
+  it('rejects a non-numeric --token-age-min/--token-age-max', () => {
+expect(() => buildCommonTokenTransferData({ 'token-age-min': 'abc' }))
+  .toThrow('--token-age-min must be a number');
+expect(() => buildCommonTokenTransferData({ 'token-age-max': 'abc' }))
+  .toThrow('--token-age-max must be a number');
+
+});
 });
 
 describe('buildAlertData', () => {
@@ -766,6 +801,47 @@ describe('alerts list — client-side filtering', () => {
     const result = await cmd(['list'], mockApi, {}, { offset: 2 });
     expect(result).toHaveLength(3);
     expect(result[0].id).toBe('3');
+  });
+
+  it('rejects a non-numeric --limit instead of silently returning an empty list (regression)', async () => {
+    // Before the fix: `if (options.limit) alerts.slice(0, Number(options.limit))`
+    // -- Number('abc') is NaN, and Array.prototype.slice(0, NaN) evaluates the
+    // end index as 0, so a typo'd --limit silently returned [] instead of an
+    // error, indistinguishable from "you really have zero alerts".
+    const { mockApi, cmd } = setup();
+    await expect(cmd(['list'], mockApi, {}, { limit: 'abc' }))
+      .rejects.toThrow('--limit must be a positive integer');
+  });
+
+  it('rejects --limit 0 and non-integer --limit values', async () => {
+    const { mockApi, cmd } = setup();
+    await expect(cmd(['list'], mockApi, {}, { limit: 0 }))
+      .rejects.toThrow('--limit must be a positive integer');
+    await expect(cmd(['list'], mockApi, {}, { limit: 1.5 }))
+      .rejects.toThrow('--limit must be a positive integer');
+  });
+
+  it('rejects a negative --offset instead of silently counting from the end (regression)', async () => {
+    // Before the fix: `if (options.offset) alerts.slice(Number(options.offset))`
+    // -- Array.prototype.slice with a negative start counts from the end of
+    // the array, so --offset -2 silently returned the *last* 2 alerts
+    // instead of erroring on what is clearly not a valid pagination offset.
+    const { mockApi, cmd } = setup();
+    await expect(cmd(['list'], mockApi, {}, { offset: '-2' }))
+      .rejects.toThrow('--offset must be a non-negative integer');
+  });
+
+  it('rejects a non-numeric --offset', async () => {
+    const { mockApi, cmd } = setup();
+    await expect(cmd(['list'], mockApi, {}, { offset: 'abc' }))
+      .rejects.toThrow('--offset must be a non-negative integer');
+  });
+
+  it('still accepts --limit/--offset as numeric strings (how the real CLI parser passes them)', async () => {
+    const { mockApi, cmd } = setup();
+    const result = await cmd(['list'], mockApi, {}, { limit: '2', offset: '1' });
+    expect(result).toHaveLength(2);
+    expect(result.map(a => a.id)).toEqual(['2', '3']);
   });
 
   it('should apply --offset and --limit together', async () => {

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -379,12 +379,11 @@ describe('buildCommonTokenTransferData', () => {
   });
 
   it('rejects a non-numeric --token-age-min/--token-age-max', () => {
-expect(() => buildCommonTokenTransferData({ 'token-age-min': 'abc' }))
-  .toThrow('--token-age-min must be a number');
-expect(() => buildCommonTokenTransferData({ 'token-age-max': 'abc' }))
-  .toThrow('--token-age-max must be a number');
-
-});
+    expect(() => buildCommonTokenTransferData({ 'token-age-min': 'abc' }))
+      .toThrow('--token-age-min must be a number');
+    expect(() => buildCommonTokenTransferData({ 'token-age-max': 'abc' }))
+      .toThrow('--token-age-max must be a number');
+  });
 });
 
 describe('buildAlertData', () => {
@@ -804,10 +803,6 @@ describe('alerts list — client-side filtering', () => {
   });
 
   it('rejects a non-numeric --limit instead of silently returning an empty list (regression)', async () => {
-    // Before the fix: `if (options.limit) alerts.slice(0, Number(options.limit))`
-    // -- Number('abc') is NaN, and Array.prototype.slice(0, NaN) evaluates the
-    // end index as 0, so a typo'd --limit silently returned [] instead of an
-    // error, indistinguishable from "you really have zero alerts".
     const { mockApi, cmd } = setup();
     await expect(cmd(['list'], mockApi, {}, { limit: 'abc' }))
       .rejects.toThrow('--limit must be a positive integer');
@@ -822,10 +817,6 @@ describe('alerts list — client-side filtering', () => {
   });
 
   it('rejects a negative --offset instead of silently counting from the end (regression)', async () => {
-    // Before the fix: `if (options.offset) alerts.slice(Number(options.offset))`
-    // -- Array.prototype.slice with a negative start counts from the end of
-    // the array, so --offset -2 silently returned the *last* 2 alerts
-    // instead of erroring on what is clearly not a valid pagination offset.
     const { mockApi, cmd } = setup();
     await expect(cmd(['list'], mockApi, {}, { offset: '-2' }))
       .rejects.toThrow('--offset must be a non-negative integer');

--- a/src/commands/alerts.js
+++ b/src/commands/alerts.js
@@ -110,12 +110,34 @@ function parseChains(chainsOpt) {
 /**
  * Build a { min, max } range object from two option values.
  * Returns undefined if neither is provided.
+ *
+ * `label` is the CLI flag prefix (e.g. "market-cap" for --market-cap-min/max),
+ * used only to name the offending flag in the error message.
+ *
+ * A non-numeric value must throw here, not silently produce NaN: NaN passes
+ * the `!= null` check `isRangeSet()` uses (NaN is neither null nor
+ * undefined), so a bad value looked "set" -- but `JSON.stringify({min: NaN})`
+ * serializes to `{"min":null}`, so the alert would silently be created with
+ * that threshold disabled rather than the value the user typed, and no error
+ * would ever surface.
  */
-function buildRange(minVal, maxVal) {
+function buildRange(minVal, maxVal, label) {
   if (minVal === undefined && maxVal === undefined) return undefined;
   const r = {};
-  if (minVal !== undefined) r.min = Number(minVal);
-  if (maxVal !== undefined) r.max = Number(maxVal);
+  if (minVal !== undefined) {
+    const min = Number(minVal);
+    if (!Number.isFinite(min)) {
+      throw new NansenError(`--${label}-min must be a number`, ErrorCode.INVALID_PARAMS);
+    }
+    r.min = min;
+  }
+  if (maxVal !== undefined) {
+    const max = Number(maxVal);
+    if (!Number.isFinite(max)) {
+      throw new NansenError(`--${label}-max must be a number`, ErrorCode.INVALID_PARAMS);
+    }
+    r.max = max;
+  }
   return r;
 }
 
@@ -138,7 +160,7 @@ export function buildSmTokenFlowsData(options) {
 
   const flowFields = ['inflow-1h', 'inflow-1d', 'inflow-7d', 'outflow-1h', 'outflow-1d', 'outflow-7d', 'netflow-1h', 'netflow-1d', 'netflow-7d'];
   for (const field of flowFields) {
-    const range = buildRange(options[`${field}-min`], options[`${field}-max`]);
+    const range = buildRange(options[`${field}-min`], options[`${field}-max`], field);
     if (range) {
       // Convert CLI key "inflow-1h" → data key "inflow_1h"
       data[field.replace(/-/g, '_')] = range;
@@ -156,13 +178,17 @@ export function buildSmTokenFlowsData(options) {
   if (excludeSectors) data.exclusion = { ...data.exclusion, tokenSectors: excludeSectors };
 
   if (options['token-age-max'] !== undefined) {
-    data.inclusion = { ...data.inclusion, tokenAge: { max: Number(options['token-age-max']) } };
+    const tokenAgeMax = Number(options['token-age-max']);
+    if (!Number.isFinite(tokenAgeMax)) {
+      throw new NansenError('--token-age-max must be a number', ErrorCode.INVALID_PARAMS);
+    }
+    data.inclusion = { ...data.inclusion, tokenAge: { max: tokenAgeMax } };
   }
 
-  const marketCapRange = buildRange(options['market-cap-min'], options['market-cap-max']);
+  const marketCapRange = buildRange(options['market-cap-min'], options['market-cap-max'], 'market-cap');
   if (marketCapRange) data.inclusion = { ...data.inclusion, marketCap: marketCapRange };
 
-  const fdvRange = buildRange(options['fdv-min'], options['fdv-max']);
+  const fdvRange = buildRange(options['fdv-min'], options['fdv-max'], 'fdv');
   if (fdvRange) data.inclusion = { ...data.inclusion, fdvUsd: fdvRange };
 
   return data;
@@ -181,10 +207,10 @@ export function buildCommonTokenTransferData(options) {
     data.events = typeof options.events === 'string' ? options.events.split(',') : options.events;
   }
 
-  const usdRange = buildRange(options['usd-min'], options['usd-max']);
+  const usdRange = buildRange(options['usd-min'], options['usd-max'], 'usd');
   if (usdRange) data.usdValue = usdRange;
 
-  const amountRange = buildRange(options['token-amount-min'], options['token-amount-max']);
+  const amountRange = buildRange(options['token-amount-min'], options['token-amount-max'], 'token-amount');
   if (amountRange) data.tokenAmount = amountRange;
 
   const subjects = parseSubjects(options.subject);
@@ -207,12 +233,24 @@ export function buildCommonTokenTransferData(options) {
   const tokenAgeMax = options['token-age-max'];
   if (tokenAgeMin !== undefined || tokenAgeMax !== undefined) {
     const tokenAge = {};
-    if (tokenAgeMin !== undefined) tokenAge.min = Number(tokenAgeMin);
-    if (tokenAgeMax !== undefined) tokenAge.max = Number(tokenAgeMax);
+    if (tokenAgeMin !== undefined) {
+      const min = Number(tokenAgeMin);
+      if (!Number.isFinite(min)) {
+        throw new NansenError('--token-age-min must be a number', ErrorCode.INVALID_PARAMS);
+      }
+      tokenAge.min = min;
+    }
+    if (tokenAgeMax !== undefined) {
+      const max = Number(tokenAgeMax);
+      if (!Number.isFinite(max)) {
+        throw new NansenError('--token-age-max must be a number', ErrorCode.INVALID_PARAMS);
+      }
+      tokenAge.max = max;
+    }
     data.inclusion = { ...data.inclusion, tokenAge };
   }
 
-  const marketCapRange = buildRange(options['market-cap-min'], options['market-cap-max']);
+  const marketCapRange = buildRange(options['market-cap-min'], options['market-cap-max'], 'market-cap');
   if (marketCapRange) data.inclusion = { ...data.inclusion, marketCap: marketCapRange };
 
   const excludeFrom = parseSubjects(options['exclude-from']);
@@ -232,7 +270,7 @@ export function buildSmartContractCallData(options) {
   const chains = parseChains(options.chains);
   if (chains) data.chains = chains;
 
-  const usdRange = buildRange(options['usd-min'], options['usd-max']);
+  const usdRange = buildRange(options['usd-min'], options['usd-max'], 'usd');
   if (usdRange) data.usdValue = usdRange;
 
   if (options['signature-hash']) {
@@ -606,9 +644,29 @@ USAGE:
             });
           }
 
-          // Pagination (applied after filtering)
-          if (options.offset) alerts = alerts.slice(Number(options.offset));
-          if (options.limit) alerts = alerts.slice(0, Number(options.limit));
+          // Pagination (applied after filtering). Validated the same way as
+          // the API-side pagination in query-options.js/research.js's
+          // buildPagination: a non-numeric value must error, not silently
+          // degrade. Without this, Number('abc') is NaN and
+          // Array.prototype.slice(0, NaN) evaluates the end index as 0, so a
+          // typo'd --limit silently returned an empty list instead of an
+          // error. A negative --offset has the same problem in the opposite
+          // direction: slice() treats a negative index as "count from the
+          // end", so --offset -2 would silently return the last 2 alerts.
+          if (options.offset !== undefined) {
+            const offset = Number(options.offset);
+            if (!Number.isInteger(offset) || offset < 0) {
+              throw new NansenError('--offset must be a non-negative integer', ErrorCode.INVALID_PARAMS);
+            }
+            alerts = alerts.slice(offset);
+          }
+          if (options.limit !== undefined) {
+            const limit = Number(options.limit);
+            if (!Number.isInteger(limit) || limit < 1) {
+              throw new NansenError('--limit must be a positive integer', ErrorCode.INVALID_PARAMS);
+            }
+            alerts = alerts.slice(0, limit);
+          }
 
           return alerts;
         },

--- a/src/commands/alerts.js
+++ b/src/commands/alerts.js
@@ -644,15 +644,9 @@ USAGE:
             });
           }
 
-          // Pagination (applied after filtering). Validated the same way as
-          // the API-side pagination in query-options.js/research.js's
-          // buildPagination: a non-numeric value must error, not silently
-          // degrade. Without this, Number('abc') is NaN and
-          // Array.prototype.slice(0, NaN) evaluates the end index as 0, so a
-          // typo'd --limit silently returned an empty list instead of an
-          // error. A negative --offset has the same problem in the opposite
-          // direction: slice() treats a negative index as "count from the
-          // end", so --offset -2 would silently return the last 2 alerts.
+          // Pagination (applied after filtering). Validate first -- an
+          // unvalidated Number() on bad input silently degrades (NaN -> empty
+          // list via slice(0, NaN); negative index -> tail via slice()).
           if (options.offset !== undefined) {
             const offset = Number(options.offset);
             if (!Number.isInteger(offset) || offset < 0) {


### PR DESCRIPTION
## Summary

Fixes #578.

`src/commands/alerts.js` called `Number(optionValue)` in several places without checking whether the result was actually a valid number: the shared `buildRange()` helper (used by 7 numeric range flags on `alerts create`/`update`), two standalone `--token-age-min/max` blocks, and the `list` handler's `--limit`/`--offset` pagination.

A non-numeric value produced `NaN`, which is neither `null` nor `undefined`, so it silently passed the existing "is this flag set" checks. For the range flags, `JSON.stringify({min: NaN})` serializes to `{"min":null}`, so the alert was created with that threshold silently disabled instead of erroring. For `--limit`, `Array.prototype.slice(0, NaN)` evaluates the end index as `0`, so a typo'd `--limit` silently returned an empty list. For `--offset`, a negative value made `Array.prototype.slice()` count from the end of the array, so `--offset -2` silently returned the *last* 2 alerts.

## Fix

Validate with `Number.isFinite()` (range flags, which can be decimals) / `Number.isInteger()` (`--limit`/`--offset`, which must be whole numbers) and throw a `NansenError` on failure -- matching the existing `buildPagination` idiom already used in `src/query-options.js` and `src/commands/research.js`. I checked for the same unvalidated-`Number()` pattern elsewhere in `src/commands/` and confirmed `research.js`'s pagination already validates correctly, so this PR's scope (alerts.js only) is complete.

## Test plan

- Added regression tests covering all 9 fixed call sites (non-numeric range flags, non-numeric/negative token-age, non-numeric/negative/zero/non-integer `--limit` and `--offset`), plus a test confirming numeric strings (how the real CLI parser passes flag values) still work.
- `npx eslint src/commands/alerts.js src/__tests__/cli.internal.test.js` -- clean.
- `npx vitest run src/__tests__/cli.internal.test.js` -- 484/484 passed.
- Full suite (`npm test`): 2639 passed, 2 skipped, 0 failed.
- `npm install` produced only unrelated `package-lock.json` metadata noise, reverted before committing; `package.json` itself was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141eH4NcQy4GXgusCGbG1pm
