### PR TITLE
feat: add generated bash/zsh/fish shell completions

### DIFF
--- a/.changeset/generated-shell-completions.md
+++ b/.changeset/generated-shell-completions.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": minor
+---
+
+Add `nansen completion <bash|zsh|fish>`, which prints a shell completion script generated from the CLI's own command schema. Completions cover nested subcommands, per-command flags, global flags, and the enum values a flag accepts.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # zsh ships on ubuntu-latest; fish does not. Without it the fish
-      # completion tests skip and the fish script goes unexercised.
-      - name: Install fish for completion tests
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends fish
+      # The zsh and fish completion tests skip when the shell is missing, so
+      # install both and fail here if either is absent rather than skip quietly.
+      - name: Install zsh and fish for completion tests
+        run: |
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends fish zsh
+          zsh --version && fish --version
 
       - name: Run tests
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # zsh ships on ubuntu-latest; fish does not. Without it the fish
+      # completion tests skip and the fish script goes unexercised.
+      - name: Install fish for completion tests
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends fish
+
       - name: Run tests
         run: npm test
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ echo 'eval "$(nansen completion bash)"' >> ~/.bashrc
 
 # zsh
 nansen completion zsh > "${fpath[1]}/_nansen" && compinit
-# or: echo 'eval "$(nansen completion zsh)"' >> ~/.zshrc
+# or, in ~/.zshrc after the compinit line: eval "$(nansen completion zsh)"
 
 # fish
 nansen completion fish > ~/.config/fish/completions/nansen.fish

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ nansen trade quote --chain solana --from SOL --to USDC --amount 1000000000
 nansen trade execute --quote <quoteId>
 nansen wallet <subcommand> [options]
 nansen mcp install <client>           # add the Nansen MCP server to Claude Code/Desktop or Cursor
+nansen completion <bash|zsh|fish>     # shell completions (no API key needed)
 nansen schema [command] [--pretty]    # full command reference (no API key needed)
 ```
 
@@ -263,6 +264,28 @@ tempo request POST https://api.nansen.ai/api/v1/smart-money/netflow \
 | You already use tempo for other paid APIs, or want micropayments without managing your own wallet keys | MPP (`tempo request`) |
 
 > Note: MPP is server-side opt-in (`MPP_ENABLED=true` on the API). It's available on dev today and rolling out to prod — if `tempo request` returns a non-MPP 402, fall back to x402 or an API key.
+
+## Shell Completions
+
+Tab-completion for commands, subcommands, flags, and the values a flag accepts:
+
+```bash
+# bash
+echo 'eval "$(nansen completion bash)"' >> ~/.bashrc
+# or system-wide: nansen completion bash > /etc/bash_completion.d/nansen
+
+# zsh
+nansen completion zsh > "${fpath[1]}/_nansen" && compinit
+# or: echo 'eval "$(nansen completion zsh)"' >> ~/.zshrc
+
+# fish
+nansen completion fish > ~/.config/fish/completions/nansen.fish
+```
+
+The scripts are generated from the same schema as `nansen schema`, so they cover
+every nested subcommand and stay in step with the CLI. Nothing is written to
+disk and no network call is made — the script goes to stdout. Re-run the command
+after upgrading the CLI to pick up new commands.
 
 ## Key Options
 

--- a/src/__tests__/completion.test.js
+++ b/src/__tests__/completion.test.js
@@ -1,0 +1,285 @@
+/**
+ * Tests for `nansen completion <bash|zsh|fish>` (src/commands/completion.js).
+ *
+ * The scripts are generated, so the tests that matter are the ones a human
+ * would otherwise have to do by hand: does the shell parse it, does the tree
+ * still match the commands the CLI actually dispatches, and does a quoted
+ * description in schema.json survive into shell source intact.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  buildCompletionSpec,
+  buildCompletionCommands,
+  generateCompletion,
+  shortDesc,
+  COMPLETION_SHELLS,
+  COMPLETION_USAGE,
+  EXCLUDED_COMMANDS,
+  UNSCHEMA_COMMANDS,
+} from '../commands/completion.js';
+import { buildCommands, runCLI, VALUELESS_FLAGS, SCHEMA } from '../cli.js';
+import { buildWalletCommands } from '../wallet.js';
+import { buildTradingCommands } from '../trading.js';
+import { buildAlertsCommands } from '../commands/alerts.js';
+import { buildAgentCommands } from '../commands/agent.js';
+import { buildMcpCommands } from '../commands/mcp.js';
+
+const spec = buildCompletionSpec();
+const rootNode = spec.nodes.find(n => n.path === '');
+const scripts = Object.fromEntries(COMPLETION_SHELLS.map(sh => [sh, generateCompletion(sh)]));
+
+function hasBinary(bin) {
+  try {
+    execFileSync('sh', ['-c', `command -v ${bin}`], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function writeTemp(name, contents) {
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'nansen-completion-')), name);
+  fs.writeFileSync(file, contents);
+  return file;
+}
+
+describe('buildCompletionSpec', () => {
+  it('covers every top-level command the CLI dispatches', () => {
+    const runtime = {
+      ...buildCommands({}),
+      ...buildWalletCommands({}),
+      ...buildTradingCommands({}),
+      ...buildAlertsCommands({}),
+      ...buildAgentCommands({}),
+      ...buildMcpCommands({}),
+      ...buildCompletionCommands({}),
+    };
+    const completed = new Set(rootNode.subcommands.map(s => s.name));
+    const missing = Object.keys(runtime).filter(c => !completed.has(c) && !EXCLUDED_COMMANDS.has(c));
+    expect(missing, 'add to schema.json or to UNSCHEMA_COMMANDS/EXCLUDED_COMMANDS in completion.js').toEqual([]);
+  });
+
+  it('offers no deprecated top-level aliases', () => {
+    for (const name of rootNode.subcommands.map(s => s.name)) {
+      expect(EXCLUDED_COMMANDS.has(name), `${name} is deprecated and should not be completed`).toBe(false);
+    }
+  });
+
+  it('declares every command schema.json omits', () => {
+    for (const name of Object.keys(UNSCHEMA_COMMANDS)) {
+      expect(SCHEMA.commands[name], `${name} is now in schema.json — drop it from UNSCHEMA_COMMANDS`).toBeUndefined();
+    }
+  });
+
+  // The walker skips the word after any option not in this list. Missing one
+  // makes it swallow a real subcommand; an extra one is harmless.
+  it('treats every parser-valueless flag as valueless', () => {
+    for (const flag of VALUELESS_FLAGS) {
+      expect(spec.valuelessFlags, `--${flag} is valueless in parseArgs`).toContain(`--${flag}`);
+    }
+  });
+
+  it('walks nested subcommands down to the leaf', () => {
+    const paths = spec.nodes.map(n => n.path);
+    expect(paths).toContain('research');
+    expect(paths).toContain('research token');
+    expect(paths).toContain('trade limit-order');
+    const screener = spec.nodes.find(n => n.path === 'research token screener');
+    expect(screener.options.map(o => o.name)).toContain('--chain');
+  });
+
+  it('carries enum values through to the option', () => {
+    const order = spec.nodes.find(n => n.path === 'perp order');
+    expect(order.options.find(o => o.name === '--tif').values).toEqual(['Gtc', 'Ioc', 'Alo']);
+    expect(order.options.find(o => o.name === '--side').values).toContain('long');
+  });
+
+  it('falls back to schema.chains for research --chain', () => {
+    const netflow = spec.nodes.find(n => n.path === 'research smart-money netflow');
+    expect(netflow.options.find(o => o.name === '--chain').values).toEqual(SCHEMA.chains);
+  });
+
+  it('leaves --chain alone outside the research tree', () => {
+    const quote = spec.nodes.find(n => n.path === 'trade quote');
+    expect(quote.options.find(o => o.name === '--chain').values).toEqual([]);
+  });
+
+  it('includes global options exactly once, plus --help', () => {
+    const names = spec.globalOptions.map(o => o.name);
+    expect(names).toContain('--pretty');
+    expect(names).toContain('--fields');
+    expect(names).toContain('--help');
+    expect(new Set(names).size).toBe(names.length);
+  });
+});
+
+describe('shortDesc', () => {
+  it('flattens whitespace and caps length', () => {
+    expect(shortDesc('a\n  b\tc')).toBe('a b c');
+    expect(shortDesc('x'.repeat(200)).length).toBeLessThanOrEqual(72);
+    expect(shortDesc(undefined)).toBe('');
+  });
+});
+
+describe('generateCompletion', () => {
+  it('rejects an unknown shell with an actionable message', () => {
+    expect(() => generateCompletion('powershell')).toThrow(/Unsupported shell: powershell.*nansen completion <bash\|zsh\|fish>/s);
+  });
+
+  it('is deterministic', () => {
+    for (const shell of COMPLETION_SHELLS) {
+      expect(generateCompletion(shell)).toBe(scripts[shell]);
+    }
+  });
+
+  it.each(COMPLETION_SHELLS)('%s script names its shell and how to install it', (shell) => {
+    expect(scripts[shell]).toContain(`nansen completion ${shell}`);
+    expect(scripts[shell]).toContain('Install:');
+  });
+
+  it.each(COMPLETION_SHELLS)('%s script carries nested commands, flags and enum values', (shell) => {
+    expect(scripts[shell]).toContain('research token screener');
+    expect(scripts[shell]).toContain('trade limit-order');
+    expect(scripts[shell]).toContain('--pretty');
+    expect(scripts[shell]).toContain('Gtc');
+  });
+
+  // schema.json descriptions contain ' " ` $ and : — all of which end up inside
+  // quoted shell strings.
+  it.each(['zsh', 'fish'])('%s script keeps a quote-bearing description escaped', (shell) => {
+    expect(SCHEMA.commands.perp.subcommands.transfer.description).toContain("wallet's");
+    expect(scripts[shell]).toMatch(shell === 'fish' ? /wallet\\'s/ : /wallet'\\''s/);
+  });
+
+  it('bash script drops descriptions rather than quoting them', () => {
+    expect(scripts.bash).not.toContain("wallet's");
+  });
+});
+
+describe('shell syntax', () => {
+  it('bash parses the generated script', () => {
+    const file = writeTemp('nansen.bash', scripts.bash);
+    expect(() => execFileSync('bash', ['-n', file], { stdio: 'pipe' })).not.toThrow();
+  });
+
+  it.skipIf(!hasBinary('zsh'))('zsh parses the generated script', () => {
+    const file = writeTemp('_nansen', scripts.zsh);
+    expect(() => execFileSync('zsh', ['-n', file], { stdio: 'pipe' })).not.toThrow();
+  });
+
+  it.skipIf(!hasBinary('fish'))('fish parses the generated script', () => {
+    const file = writeTemp('nansen.fish', scripts.fish);
+    expect(() => execFileSync('fish', ['--no-execute', file], { stdio: 'pipe' })).not.toThrow();
+  });
+
+  // Fallback for machines without fish: every block still has to be closed.
+  it('fish script balances function/switch blocks', () => {
+    const lines = scripts.fish.split('\n');
+    const opens = lines.filter(l => /^\s*(function|switch|for|if)\b/.test(l)).length;
+    const closes = lines.filter(l => /^\s*end\s*$/.test(l)).length;
+    expect(closes).toBe(opens);
+  });
+});
+
+describe('bash completion behaviour', () => {
+  // Drive the real completion function the way bash does: set COMP_WORDS /
+  // COMP_CWORD, call it, print COMPREPLY.
+  function complete(words) {
+    const file = writeTemp('nansen.bash', scripts.bash);
+    const driver = `
+      source ${JSON.stringify(file)}
+      COMP_WORDS=(${words.map(w => JSON.stringify(w)).join(' ')})
+      COMP_CWORD=${words.length - 1}
+      _nansen_complete
+      printf '%s\\n' "\${COMPREPLY[@]}"
+    `;
+    return execFileSync('bash', ['-c', driver], { encoding: 'utf8' }).trim().split('\n').filter(Boolean);
+  }
+
+  it('completes top-level commands', () => {
+    const out = complete(['nansen', '']);
+    expect(out).toContain('research');
+    expect(out).toContain('trade');
+    expect(out).toContain('completion');
+    expect(out).not.toContain('token'); // deprecated alias
+  });
+
+  it('completes a prefix', () => {
+    expect(complete(['nansen', 'compl'])).toEqual(['completion']);
+  });
+
+  it('completes nested subcommands', () => {
+    expect(complete(['nansen', 'trade', 'limit-order', ''])).toEqual(['create', 'list', 'cancel', 'update']);
+    expect(complete(['nansen', 'completion', ''])).toEqual(['bash', 'zsh', 'fish']);
+  });
+
+  it('completes options for the resolved command', () => {
+    const out = complete(['nansen', 'research', 'token', 'screener', '--']);
+    expect(out).toContain('--chain');
+    expect(out).toContain('--pretty');
+  });
+
+  it('completes enum values after an option', () => {
+    expect(complete(['nansen', 'perp', 'order', '--tif', ''])).toEqual(['Gtc', 'Ioc', 'Alo']);
+    expect(complete(['nansen', 'research', 'smart-money', 'netflow', '--chain', ''])).toEqual(SCHEMA.chains);
+  });
+
+  it('does not lose the command path across a global flag', () => {
+    expect(complete(['nansen', '--pretty', 'trade', ''])).toContain('quote');
+  });
+
+  it('does not mistake an option value for a subcommand', () => {
+    // "screener" here is the value of --fields, not a subcommand of research.
+    const out = complete(['nansen', 'research', '--fields', 'screener', '']);
+    expect(out).toContain('token');
+  });
+});
+
+describe('nansen completion command', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('prints usage with no shell argument', async () => {
+    const lines = [];
+    const cmds = buildCompletionCommands({ log: l => lines.push(l) });
+    await cmds.completion([], null, {}, {});
+    expect(lines.join('\n')).toBe(COMPLETION_USAGE);
+  });
+
+  it('prints usage for --help', async () => {
+    const lines = [];
+    const cmds = buildCompletionCommands({ log: l => lines.push(l) });
+    await cmds.completion(['bash'], null, { help: true }, {});
+    expect(lines.join('\n')).toBe(COMPLETION_USAGE);
+  });
+
+  it('writes the script to stdout and touches no network', async () => {
+    const fetchSpy = vi.fn(() => { throw new Error('network access in completion'); });
+    vi.stubGlobal('fetch', fetchSpy);
+    const out = [];
+    const result = await runCLI(['completion', 'bash'], {
+      output: l => out.push(l),
+      errorOutput: () => {},
+      exit: () => {},
+    });
+    expect(result).toEqual({ type: 'no-output', command: 'completion' });
+    expect(out.join('\n')).toContain('complete -F _nansen_complete nansen');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('exits non-zero on an unknown shell', async () => {
+    const out = [];
+    const codes = [];
+    await runCLI(['completion', 'tcsh'], {
+      output: l => out.push(l),
+      errorOutput: () => {},
+      exit: c => codes.push(c),
+    });
+    expect(codes).toContain(1);
+    expect(out.join('\n')).toContain('Unsupported shell: tcsh');
+  });
+});

--- a/src/__tests__/completion.test.js
+++ b/src/__tests__/completion.test.js
@@ -2,13 +2,14 @@
  * Tests for `nansen completion <bash|zsh|fish>` (src/commands/completion.js).
  *
  * The scripts are generated, so the tests that matter are the ones a human
- * would otherwise have to do by hand: does the shell parse it, does the tree
- * still match the commands the CLI actually dispatches, and does a quoted
- * description in schema.json survive into shell source intact.
+ * would otherwise have to do by hand: does the shell parse it, does each
+ * shell's walker resolve the command path, does the tree still match the
+ * commands the CLI actually dispatches, and does a quoted description in
+ * schema.json survive into shell source intact.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -238,6 +239,113 @@ describe('bash completion behaviour', () => {
     const out = complete(['nansen', 'research', '--fields', 'screener', '']);
     expect(out).toContain('token');
   });
+
+  it('treats any single-dash token as valueless, like parseArgs', () => {
+    expect(complete(['nansen', '-p', 'research', ''])).toContain('token');
+    expect(complete(['nansen', 'research', 'token', '-x', ''])).toContain('screener');
+  });
+});
+
+describe.skipIf(!hasBinary('zsh'))('zsh completion behaviour', () => {
+  // Drive _nansen outside compsys: stub _describe to print the values it was
+  // handed, and set words/CURRENT the way zle does. The stub also checks $PATH
+  // is intact inside the function — zsh ties the array `path` to PATH, so a
+  // local by that name would empty PATH for the duration of every completion.
+  function complete(words) {
+    const file = writeTemp('_nansen', scripts.zsh);
+    const driver = `
+      compdef() { :; }
+      _describe() {
+        [[ "$PATH" == "$NANSEN_TEST_PATH" ]] || print -r -- '__PATH_CLOBBERED__'
+        local -a items
+        items=( "\${(@P)\${@[-1]}}" )
+        print -rl -- "\${items[@]%%:*}"
+      }
+      source ${JSON.stringify(file)}
+      words=(${words.map(w => JSON.stringify(w)).join(' ')})
+      CURRENT=${words.length}
+      _nansen
+    `;
+    const out = execFileSync('zsh', ['-f', '-c', driver], {
+      encoding: 'utf8',
+      env: { ...process.env, NANSEN_TEST_PATH: process.env.PATH },
+    }).trim().split('\n').filter(Boolean);
+    expect(out).not.toContain('__PATH_CLOBBERED__');
+    return out;
+  }
+
+  it('completes top-level commands', () => {
+    const out = complete(['nansen', '']);
+    expect(out).toContain('research');
+    expect(out).toContain('completion');
+    expect(out).not.toContain('token');
+  });
+
+  it('completes nested subcommands', () => {
+    expect(complete(['nansen', 'trade', 'limit-order', ''])).toEqual(['create', 'list', 'cancel', 'update']);
+  });
+
+  it('completes options for the resolved command', () => {
+    const out = complete(['nansen', 'research', 'token', 'screener', '--']);
+    expect(out).toContain('--chain');
+    expect(out).toContain('--pretty');
+  });
+
+  it('completes enum values after an option', () => {
+    expect(complete(['nansen', 'perp', 'order', '--tif', ''])).toEqual(['Gtc', 'Ioc', 'Alo']);
+  });
+
+  it('walks the path across flags and option values', () => {
+    expect(complete(['nansen', '--pretty', 'trade', ''])).toContain('quote');
+    expect(complete(['nansen', '-p', 'research', ''])).toContain('token');
+    expect(complete(['nansen', 'research', '--fields', 'screener', ''])).toContain('token');
+    expect(complete(['nansen', 'research', 'token', '--pretty', ''])).toContain('screener');
+  });
+});
+
+describe.skipIf(!hasBinary('fish'))('fish completion behaviour', () => {
+  // `complete -C` runs the registered completion for a command line exactly as
+  // a tab press would. A completion that writes to stderr (an unknown option to
+  // string split, say) would print over the prompt, so stderr must stay empty.
+  function complete(line) {
+    const file = writeTemp('nansen.fish', scripts.fish);
+    const { status, stdout, stderr } = spawnSync(
+      'fish',
+      ['-c', `source ${JSON.stringify(file)}; complete -C${JSON.stringify(line)}`],
+      { encoding: 'utf8' }
+    );
+    expect(stderr).toBe('');
+    expect(status).toBe(0);
+    return stdout.trim().split('\n').filter(Boolean).map(l => l.split('\t')[0]);
+  }
+
+  it('completes top-level commands', () => {
+    const out = complete('nansen ');
+    expect(out).toContain('research');
+    expect(out).toContain('completion');
+    expect(out).not.toContain('token');
+  });
+
+  it('completes nested subcommands', () => {
+    expect(complete('nansen trade limit-order ').sort()).toEqual(['cancel', 'create', 'list', 'update']);
+  });
+
+  it('completes options for the resolved command', () => {
+    const out = complete('nansen research token screener --');
+    expect(out).toContain('--chain');
+    expect(out).toContain('--pretty');
+  });
+
+  it('completes enum values after an option', () => {
+    expect(complete('nansen perp order --tif ').sort()).toEqual(['Alo', 'Gtc', 'Ioc']);
+  });
+
+  it('walks the path across flags and option values', () => {
+    expect(complete('nansen --pretty trade ')).toContain('quote');
+    expect(complete('nansen -p research ')).toContain('token');
+    expect(complete('nansen research --fields screener ')).toContain('token');
+    expect(complete('nansen research token --pretty ')).toContain('screener');
+  });
 });
 
 describe('nansen completion command', () => {
@@ -247,13 +355,6 @@ describe('nansen completion command', () => {
     const lines = [];
     const cmds = buildCompletionCommands({ log: l => lines.push(l) });
     await cmds.completion([], null, {}, {});
-    expect(lines.join('\n')).toBe(COMPLETION_USAGE);
-  });
-
-  it('prints usage for --help', async () => {
-    const lines = [];
-    const cmds = buildCompletionCommands({ log: l => lines.push(l) });
-    await cmds.completion(['bash'], null, { help: true }, {});
     expect(lines.join('\n')).toBe(COMPLETION_USAGE);
   });
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,6 +12,7 @@ import { buildLimitOrderCommands } from './limit-order.js';
 import { formatAlertsTable, buildAlertsCommands } from './commands/alerts.js';
 import { buildAgentCommands } from './commands/agent.js';
 import { buildMcpCommands } from './commands/mcp.js';
+import { buildCompletionCommands } from './commands/completion.js';
 import { buildResearchCommands, RESEARCH_HISTORICAL_SUBCOMMANDS, RESEARCH_SUBCOMMANDS } from './commands/research.js';
 import { buildPagination, parseSort } from './query-options.js';
 export { buildPagination, parseSort };
@@ -163,6 +164,15 @@ export function compactSchema(schema) {
   };
 }
 
+// Long options that never consume the next argument. The shell-completion
+// generator needs the same list to tell an option's value apart from a
+// subcommand, so it lives here rather than inline in parseArgs.
+export const VALUELESS_FLAGS = new Set([
+  'pretty', 'help', 'version', 'table', 'no-retry', 'cache', 'no-cache', 'stream',
+  'enrich', 'full', 'human', 'enabled', 'disabled', 'expert', 'json', 'offline',
+  'no-simulate', 'no-verify-outcome', 'no-revoke-excessive-allowance', 'dry-run',
+]);
+
 export function parseArgs(args) {
   const result = { _: [], flags: {}, options: {} };
   
@@ -173,7 +183,7 @@ export function parseArgs(args) {
       const key = arg.slice(2);
       const next = args[i + 1];
       
-      if (key === 'pretty' || key === 'help' || key === 'version' || key === 'table' || key === 'no-retry' || key === 'cache' || key === 'no-cache' || key === 'stream' || key === 'enrich' || key === 'full' || key === 'human' || key === 'enabled' || key === 'disabled' || key === 'expert' || key === 'json' || key === 'offline' || key === 'no-simulate' || key === 'no-verify-outcome' || key === 'no-revoke-excessive-allowance' || key === 'dry-run') {
+      if (VALUELESS_FLAGS.has(key)) {
         result.flags[key] = true;
       } else if (next && (!next.startsWith('-') || /^-\d/.test(next))) {
         // Try to parse as JSON first (for objects/arrays/booleans),
@@ -712,6 +722,7 @@ COMMANDS:
   logout      Remove saved API key
   doctor      Diagnostics: auth, wallets, caches, connectivity (--offline --json)
   schema      JSON schema for all commands (use "nansen schema <cmd>" for one)
+  completion  Shell completions: bash, zsh, fish
   cache       clear
   changelog   --since <version> to filter
 
@@ -1853,7 +1864,9 @@ export async function runCLI(rawArgs, deps = {}) {
   // contract covers the background update-check fetch and telemetry too,
   // not just the command's own requests.
   const isMcpUsage = command === 'mcp' && (subcommand !== 'verify' || flags.help || flags.h);
-  const isOfflineCommand = command === 'auth' || (command === 'doctor' && flags.offline) || isMcpUsage;
+  // `completion` renders from the checked-in schema — no network, and its
+  // stdout is piped straight into a shell, so keep the update check out of it.
+  const isOfflineCommand = command === 'auth' || (command === 'doctor' && flags.offline) || isMcpUsage || command === 'completion';
   const trackSucceeded = isOfflineCommand ? async () => {} : trackCommandSucceeded;
   const trackFailed = isOfflineCommand ? async () => {} : trackCommandFailed;
 
@@ -1875,7 +1888,7 @@ export async function runCLI(rawArgs, deps = {}) {
 
   // mcp prints its own output via `log`; runCLI callers inject their stdout
   // sink as `output`, so map it across (an explicit `log` dep still wins).
-  const commands = { ...buildCommands(deps), ...buildWalletCommands(deps), ...buildTradingCommands(deps), ...buildAlertsCommands(deps), ...buildAgentCommands(deps), ...buildMcpCommands({ ...deps, log: deps.log ?? output }), ...commandOverrides };
+  const commands = { ...buildCommands(deps), ...buildWalletCommands(deps), ...buildTradingCommands(deps), ...buildAlertsCommands(deps), ...buildAgentCommands(deps), ...buildMcpCommands({ ...deps, log: deps.log ?? output }), ...buildCompletionCommands({ ...deps, log: deps.log ?? output }), ...commandOverrides };
 
   if (flags.version || flags.v) {
     output(VERSION);

--- a/src/commands/completion.js
+++ b/src/commands/completion.js
@@ -1,0 +1,577 @@
+/**
+ * Nansen CLI - shell completion generator
+ *
+ * `nansen completion <bash|zsh|fish>` prints a completion script built from
+ * src/schema.json, the same source of truth `nansen schema` and `--help` read.
+ * Generating instead of checking in three hand-written scripts is what keeps
+ * completions from drifting the moment a command or flag is added.
+ *
+ * Purely local: no disk writes, no network calls.
+ */
+
+import { CommandError } from '../api.js';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const schemaDefinition = require('../schema.json');
+const { version: VERSION } = require('../../package.json');
+
+export const COMPLETION_SHELLS = ['bash', 'zsh', 'fish'];
+
+/**
+ * Commands the CLI dispatches that schema.json does not describe. Adding them
+ * to schema.json instead would change `nansen logout --help` (the schema help
+ * path runs before the hand-written text), so they are declared here.
+ * completion.test.js fails if a new top-level command appears in neither place.
+ */
+export const UNSCHEMA_COMMANDS = {
+  login: {
+    description: 'Save your Nansen API key',
+    options: {
+      'api-key': { type: 'string', description: 'API key (recorded in shell history — prefer --human)' },
+      human: { type: 'boolean', description: 'Prompt for the key interactively' },
+    },
+  },
+  logout: { description: 'Remove the saved API key' },
+  schema: {
+    description: 'Print the JSON schema for every command',
+    options: { full: { type: 'boolean', description: 'Verbose schema instead of the compact listing' } },
+  },
+  cache: {
+    description: 'API response cache maintenance',
+    subcommands: { clear: { description: 'Clear all cached responses' } },
+  },
+  changelog: {
+    description: 'Show release history',
+    options: { since: { type: 'string', description: 'Only show versions at or above this one' } },
+  },
+  help: { description: 'Show the top-level help' },
+};
+
+/**
+ * Deprecated top-level aliases still routed by runCLI. Left out on purpose:
+ * completion is a discoverability surface, and suggesting `nansen token ...`
+ * teaches the spelling we are trying to retire.
+ */
+export const EXCLUDED_COMMANDS = new Set([
+  'smart-money', 'profiler', 'token', 'search', 'portfolio', 'points', 'prediction-market',
+  'quote', 'execute',
+  // Undocumented top-level alias of `trade bridge-status`: reachable because
+  // runCLI spreads buildTradingCommands over the root, absent from HELP.
+  'bridge-status',
+]);
+
+/**
+ * Flags parseArgs treats as valueless but schema.json does not type as boolean
+ * (short aliases, and output flags that live only in the parser). The walker
+ * needs a *superset* of the real valueless flags: an extra name here is
+ * harmless (the following word is checked against the subcommand table anyway),
+ * a missing one makes the walker swallow a real subcommand.
+ */
+const EXTRA_VALUELESS = ['help', 'h', 'version', 'v', 'p', 't', 's', 'cache', 'no-cache', 'stream', 'enrich', 'full', 'human'];
+
+// Command, subcommand, option and enum tokens are interpolated straight into
+// shell source. Anything that is not a bare word is dropped rather than escaped
+// — a schema entry with a space or a quote in its *name* is a bug, not input we
+// should try to render.
+const SAFE_TOKEN = /^[A-Za-z0-9_.:@+-]+$/;
+
+const MAX_DESC = 72;
+
+/** One-line, length-capped description safe to sit inside a quoted shell string. */
+export function shortDesc(text) {
+  if (!text) return '';
+  const flat = String(text).replace(/\s+/g, ' ').trim();
+  return flat.length > MAX_DESC ? `${flat.slice(0, MAX_DESC - 1).trimEnd()}…` : flat;
+}
+
+function safeList(values) {
+  return values.map(String).filter(v => SAFE_TOKEN.test(v));
+}
+
+/**
+ * Values to offer after an option. Explicit `enum` first; `--chain` under the
+ * research tree falls back to schema.chains, which is exactly the list the
+ * research endpoints accept. Trade/bridge chains are narrower and are left to
+ * their own enums rather than guessed at.
+ */
+function optionValues(path, name, opt, schema) {
+  if (Array.isArray(opt.enum)) return safeList(opt.enum);
+  if (name === 'chain' && path.split(' ')[0] === 'research') return safeList(schema.chains || []);
+  return [];
+}
+
+/**
+ * Flatten the schema into one node per command path:
+ *   { path: 'research token', subcommands: [...], options: [...] }
+ * The root node has path '' and every top-level command as its subcommands.
+ */
+export function buildCompletionSpec({ schema = schemaDefinition, version = VERSION } = {}) {
+  const nodes = [];
+  const valueless = new Set(EXTRA_VALUELESS);
+
+  const visit = (path, node) => {
+    const subEntries = Object.entries(node.subcommands || {})
+      .filter(([name]) => SAFE_TOKEN.test(name) && !(path === '' && EXCLUDED_COMMANDS.has(name)));
+    const options = [];
+    for (const [name, opt] of Object.entries(node.options || {})) {
+      if (!SAFE_TOKEN.test(name)) continue;
+      if (opt.type === 'boolean') valueless.add(name);
+      options.push({
+        name: `--${name}`,
+        description: shortDesc(opt.description),
+        values: optionValues(path, name, opt, schema),
+      });
+    }
+    nodes.push({
+      path,
+      subcommands: subEntries.map(([name, sub]) => ({ name, description: shortDesc(sub.description) })),
+      options,
+    });
+    for (const [name, sub] of subEntries) visit(path ? `${path} ${name}` : name, sub);
+  };
+
+  visit('', { subcommands: { ...schema.commands, ...UNSCHEMA_COMMANDS } });
+
+  const globalOptions = Object.entries(schema.globalOptions || {})
+    .filter(([name]) => SAFE_TOKEN.test(name))
+    .map(([name, opt]) => {
+      if (opt.type === 'boolean') valueless.add(name);
+      return {
+        name: `--${name}`,
+        description: shortDesc(opt.description),
+        values: Array.isArray(opt.enum) ? safeList(opt.enum) : [],
+      };
+    });
+  globalOptions.push({ name: '--help', description: 'Show help for this command', values: [] });
+
+  return {
+    version,
+    nodes,
+    globalOptions,
+    valuelessFlags: [...valueless].sort().map(f => (f.length === 1 ? `-${f}` : `--${f}`)),
+  };
+}
+
+// ============= Shell quoting =============
+
+// Every interpolated token is SAFE_TOKEN or a shortDesc string, so the only
+// metacharacter that can reach these is a quote inside a description.
+const dq = s => `"${s}"`;                                        // bash: tokens only
+const sq = s => `'${String(s).replace(/'/g, "'\\''")}'`;         // bash/zsh
+const fq = s => `'${String(s).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`; // fish
+
+function header(shell, version, install) {
+  return [
+    `# nansen ${shell} completion — generated by \`nansen completion ${shell}\` (nansen-cli v${version}).`,
+    '# Regenerate after upgrading the CLI; do not edit by hand.',
+    ...install.map(line => `# ${line}`),
+  ].join('\n');
+}
+
+/** Group (path, option) pairs that share an identical value list into one case arm. */
+function valueGroups(nodes) {
+  const groups = new Map();
+  for (const node of nodes) {
+    for (const opt of node.options) {
+      if (!opt.values.length) continue;
+      const key = opt.values.join(' ');
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(`${node.path}|${opt.name}`);
+    }
+  }
+  return groups;
+}
+
+// ============= bash =============
+
+export function generateBash(spec) {
+  const { nodes, globalOptions, valuelessFlags, version } = spec;
+
+  const subArms = nodes
+    .filter(n => n.subcommands.length)
+    .map(n => `    ${dq(n.path)}) echo ${dq(n.subcommands.map(s => s.name).join(' '))} ;;`);
+
+  const optArms = nodes
+    .filter(n => n.options.length)
+    .map(n => `    ${dq(n.path)}) echo ${dq(n.options.map(o => o.name).join(' '))} ;;`);
+
+  const valArms = [...valueGroups(nodes)].map(([values, keys]) =>
+    `    ${keys.map(dq).join('|')}) echo ${dq(values)} ;;`);
+
+  return `${header('bash', version, [
+    'Install:  eval "$(nansen completion bash)"        # add to ~/.bashrc',
+    '     or:  nansen completion bash > /etc/bash_completion.d/nansen',
+  ])}
+
+# Options that never consume the following word. Used to tell an option's value
+# apart from a subcommand while walking the command line.
+_nansen_is_flag() {
+  case " ${valuelessFlags.join(' ')} " in
+    *" $1 "*) return 0 ;;
+  esac
+  return 1
+}
+
+_nansen_subs() {
+  case "$1" in
+${subArms.join('\n')}
+  esac
+}
+
+_nansen_opts() {
+  case "$1" in
+${optArms.join('\n')}
+  esac
+}
+
+_nansen_values() {
+  case "$1|$2" in
+${valArms.join('\n')}
+  esac
+}
+
+_nansen_global_opts() {
+  echo ${dq(globalOptions.map(o => o.name).join(' '))}
+}
+
+_nansen_has_sub() {
+  case " $(_nansen_subs "$1") " in
+    *" $2 "*) return 0 ;;
+  esac
+  return 1
+}
+
+_nansen_complete() {
+  local cur prev path word i
+  COMPREPLY=()
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  prev=""
+  [ "$COMP_CWORD" -gt 0 ] && prev="\${COMP_WORDS[COMP_CWORD-1]}"
+
+  # Rebuild the command path: a bare word only extends it when it is a known
+  # subcommand there, so option values and positionals are ignored.
+  path=""
+  i=1
+  while [ "$i" -lt "$COMP_CWORD" ]; do
+    word="\${COMP_WORDS[i]}"
+    case "$word" in
+      -*)
+        _nansen_is_flag "$word" || i=$((i + 1))
+        ;;
+      *)
+        if _nansen_has_sub "$path" "$word"; then
+          if [ -z "$path" ]; then path="$word"; else path="$path $word"; fi
+        fi
+        ;;
+    esac
+    i=$((i + 1))
+  done
+
+  case "$cur" in
+    -*)
+      COMPREPLY=( $(compgen -W "$(_nansen_opts "$path") $(_nansen_global_opts)" -- "$cur") )
+      return 0
+      ;;
+  esac
+
+  case "$prev" in
+    -*)
+      if ! _nansen_is_flag "$prev"; then
+        COMPREPLY=( $(compgen -W "$(_nansen_values "$path" "$prev")" -- "$cur") )
+        return 0
+      fi
+      ;;
+  esac
+
+  COMPREPLY=( $(compgen -W "$(_nansen_subs "$path")" -- "$cur") )
+  return 0
+}
+
+complete -F _nansen_complete nansen
+`;
+}
+
+// ============= zsh =============
+
+function zshItems(items) {
+  // _describe reads "value:description" and splits on the first colon.
+  return items.map(({ name, description }) =>
+    sq(description ? `${name.replace(/:/g, '\\:')}:${description}` : name.replace(/:/g, '\\:'))
+  ).join(' ');
+}
+
+export function generateZsh(spec) {
+  const { nodes, globalOptions, valuelessFlags, version } = spec;
+
+  const subArms = nodes
+    .filter(n => n.subcommands.length)
+    .map(n => `    ${sq(n.path)}) _nansen_reply=( ${zshItems(n.subcommands)} ) ;;`);
+
+  const optArms = nodes
+    .filter(n => n.options.length)
+    .map(n => `    ${sq(n.path)}) _nansen_reply=( ${zshItems(n.options)} ) ;;`);
+
+  const valArms = [...valueGroups(nodes)].map(([values, keys]) =>
+    `    ${keys.map(sq).join('|')}) _nansen_reply=( ${values.split(' ').map(sq).join(' ')} ) ;;`);
+
+  return `#compdef nansen
+${header('zsh', version, [
+    'Install:  nansen completion zsh > "${fpath[1]}/_nansen" && compinit',
+    '     or:  eval "$(nansen completion zsh)"              # add to ~/.zshrc',
+  ])}
+
+_nansen_is_flag() {
+  case " ${valuelessFlags.join(' ')} " in
+    *" $1 "*) return 0 ;;
+  esac
+  return 1
+}
+
+# Each table fills the shared _nansen_reply array with "value:description" items.
+_nansen_subs() {
+  _nansen_reply=()
+  case "$1" in
+${subArms.join('\n')}
+  esac
+}
+
+_nansen_opts() {
+  _nansen_reply=()
+  case "$1" in
+${optArms.join('\n')}
+  esac
+}
+
+_nansen_values() {
+  _nansen_reply=()
+  case "$1|$2" in
+${valArms.join('\n')}
+  esac
+}
+
+_nansen_global_opts() {
+  _nansen_reply=( ${zshItems(globalOptions)} )
+}
+
+_nansen_has_sub() {
+  local item
+  _nansen_subs "$1"
+  for item in "\${_nansen_reply[@]}"; do
+    [[ "\${item%%:*}" == "$2" ]] && return 0
+  done
+  return 1
+}
+
+_nansen() {
+  local -a _nansen_reply all
+  local path="" cur prev word
+  local -i i
+
+  cur="\${words[CURRENT]}"
+  prev=""
+  (( CURRENT > 1 )) && prev="\${words[CURRENT-1]}"
+
+  # See the bash script: a bare word extends the path only where it is a real
+  # subcommand, which keeps option values and positionals out of it.
+  for (( i = 2; i < CURRENT; i++ )); do
+    word="\${words[i]}"
+    if [[ "$word" == -* ]]; then
+      _nansen_is_flag "$word" || (( i++ ))
+      continue
+    fi
+    if _nansen_has_sub "$path" "$word"; then
+      if [[ -z "$path" ]]; then path="$word"; else path="$path $word"; fi
+    fi
+  done
+
+  if [[ "$cur" == -* ]]; then
+    _nansen_opts "$path"
+    all=( "\${_nansen_reply[@]}" )
+    _nansen_global_opts
+    all+=( "\${_nansen_reply[@]}" )
+    _nansen_reply=( "\${all[@]}" )
+    _describe -t options 'option' _nansen_reply
+    return
+  fi
+
+  if [[ "$prev" == -* ]] && ! _nansen_is_flag "$prev"; then
+    _nansen_values "$path" "$prev"
+    (( \${#_nansen_reply[@]} )) && _describe -t values 'value' _nansen_reply
+    return
+  fi
+
+  _nansen_subs "$path"
+  _describe -t commands 'command' _nansen_reply
+}
+
+if [[ "$funcstack[1]" == "_nansen" ]]; then
+  _nansen "$@"
+else
+  compdef _nansen nansen
+fi
+`;
+}
+
+// ============= fish =============
+
+function fishItems(items) {
+  // printf reuses the format string for every remaining pair, so one call emits
+  // the whole table as fish's "value<TAB>description" completion format.
+  return items.map(({ name, description }) => `${fq(name)} ${fq(description)}`).join(' ');
+}
+
+export function generateFish(spec) {
+  const { nodes, globalOptions, valuelessFlags, version } = spec;
+
+  const subArms = nodes
+    .filter(n => n.subcommands.length)
+    .map(n => `        case ${fq(n.path)}\n            printf '%s\\t%s\\n' ${fishItems(n.subcommands)}`);
+
+  const optArms = nodes
+    .filter(n => n.options.length)
+    .map(n => `        case ${fq(n.path)}\n            printf '%s\\t%s\\n' ${fishItems(n.options)}`);
+
+  const valArms = [...valueGroups(nodes)].map(([values, keys]) =>
+    `        case ${keys.map(fq).join(' ')}\n            printf '%s\\n' ${values.split(' ').map(fq).join(' ')}`);
+
+  return `${header('fish', version, [
+    'Install:  nansen completion fish > ~/.config/fish/completions/nansen.fish',
+  ])}
+
+function __nansen_flags
+    echo ${fq(valuelessFlags.join(' '))}
+end
+
+function __nansen_subs
+    switch "$argv[1]"
+${subArms.join('\n')}
+    end
+end
+
+function __nansen_opts
+    switch "$argv[1]"
+${optArms.join('\n')}
+    end
+end
+
+function __nansen_values
+    switch "$argv[1]|$argv[2]"
+${valArms.join('\n')}
+    end
+end
+
+function __nansen_global_opts
+    printf '%s\\t%s\\n' ${fishItems(globalOptions)}
+end
+
+# See the bash script: a bare word extends the path only where it is a real
+# subcommand, which keeps option values and positionals out of it.
+function __nansen_path
+    # -opc is deprecated in fish 4 in favour of -xpc, but is the only spelling
+    # that also works on fish 3. Revisit once fish 3 support is dropped.
+    set -l tokens (commandline -opc)
+    set -l flags (string split ' ' (__nansen_flags))
+    set -l path ''
+    set -l skip 0
+    set -l count (count $tokens)
+    if test $count -ge 2
+        for i in (seq 2 $count)
+            set -l word $tokens[$i]
+            if test $skip -eq 1
+                set skip 0
+                continue
+            end
+            if string match -q -- '-*' $word
+                if not contains -- $word $flags
+                    set skip 1
+                end
+                continue
+            end
+            if contains -- $word (__nansen_subs "$path" | string replace -r '\\t.*$' '')
+                if test -z "$path"
+                    set path $word
+                else
+                    set path "$path $word"
+                end
+            end
+        end
+    end
+    echo $path
+end
+
+function __nansen_complete
+    set -l path (__nansen_path)
+    set -l cur (commandline -ct)
+    set -l tokens (commandline -opc)
+
+    if string match -q -- '-*' $cur
+        __nansen_opts "$path"
+        __nansen_global_opts
+        return
+    end
+
+    if test (count $tokens) -ge 2
+        set -l prev $tokens[-1]
+        if string match -q -- '-*' $prev
+            if not contains -- $prev (string split ' ' (__nansen_flags))
+                __nansen_values "$path" "$prev"
+                return
+            end
+        end
+    end
+
+    __nansen_subs "$path"
+end
+
+complete -c nansen -f -a '(__nansen_complete)'
+`;
+}
+
+const GENERATORS = { bash: generateBash, zsh: generateZsh, fish: generateFish };
+
+/** Render the completion script for one shell. Throws on an unknown shell. */
+export function generateCompletion(shell, spec = buildCompletionSpec()) {
+  const generate = GENERATORS[shell];
+  if (!generate) {
+    throw new CommandError(
+      `Unsupported shell: ${shell}. Run: nansen completion <${COMPLETION_SHELLS.join('|')}>`,
+      'INVALID_PARAMS'
+    );
+  }
+  return generate(spec);
+}
+
+export const COMPLETION_USAGE = `nansen completion — Generate a shell completion script
+
+USAGE:
+  nansen completion bash     Print the bash completion script
+  nansen completion zsh      Print the zsh completion script
+  nansen completion fish     Print the fish completion script
+
+INSTALL:
+  bash   echo 'eval "$(nansen completion bash)"' >> ~/.bashrc
+         # or: nansen completion bash > /etc/bash_completion.d/nansen
+  zsh    nansen completion zsh > "\${fpath[1]}/_nansen" && compinit
+         # or: echo 'eval "$(nansen completion zsh)"' >> ~/.zshrc
+  fish   nansen completion fish > ~/.config/fish/completions/nansen.fish
+
+Completions cover nested subcommands, per-command flags, global flags, and the
+enum values a flag accepts. They are generated from the same schema as
+\`nansen schema\`, so re-run this after upgrading the CLI.`;
+
+export function buildCompletionCommands(deps = {}) {
+  const { log = console.log } = deps;
+
+  return {
+    'completion': async (args, _apiInstance, flags, _options) => {
+      const shell = args[0];
+      if (!shell || flags.help || flags.h) {
+        log(COMPLETION_USAGE);
+        return undefined;
+      }
+      log(generateCompletion(shell));
+      return undefined;
+    },
+  };
+}

--- a/src/commands/completion.js
+++ b/src/commands/completion.js
@@ -62,13 +62,15 @@ export const EXCLUDED_COMMANDS = new Set([
 ]);
 
 /**
- * Flags parseArgs treats as valueless but schema.json does not type as boolean
- * (short aliases, and output flags that live only in the parser). The walker
- * needs a *superset* of the real valueless flags: an extra name here is
- * harmless (the following word is checked against the subcommand table anyway),
- * a missing one makes the walker swallow a real subcommand.
+ * Long flags parseArgs treats as valueless but schema.json does not type as
+ * boolean (output flags that live only in the parser). Single-dash tokens
+ * (-p, -h, -5) never take a value in parseArgs, so the walkers treat every one
+ * as valueless without a list. The walker needs a *superset* of the real
+ * valueless flags: an extra name here is harmless (the following word is
+ * checked against the subcommand table anyway), a missing one makes the walker
+ * swallow a real subcommand.
  */
-const EXTRA_VALUELESS = ['help', 'h', 'version', 'v', 'p', 't', 's', 'cache', 'no-cache', 'stream', 'enrich', 'full', 'human'];
+const EXTRA_VALUELESS = ['help', 'version', 'cache', 'no-cache', 'stream', 'enrich', 'full', 'human'];
 
 // Command, subcommand, option and enum tokens are interpolated straight into
 // shell source. Anything that is not a bare word is dropped rather than escaped
@@ -149,7 +151,7 @@ export function buildCompletionSpec({ schema = schemaDefinition, version = VERSI
     version,
     nodes,
     globalOptions,
-    valuelessFlags: [...valueless].sort().map(f => (f.length === 1 ? `-${f}` : `--${f}`)),
+    valuelessFlags: [...valueless].sort().map(f => `--${f}`),
   };
 }
 
@@ -205,8 +207,13 @@ export function generateBash(spec) {
   ])}
 
 # Options that never consume the following word. Used to tell an option's value
-# apart from a subcommand while walking the command line.
+# apart from a subcommand while walking the command line. A single-dash token
+# never takes a value; only --long options need the lookup.
 _nansen_is_flag() {
+  case "$1" in
+    --*) ;;
+    *) return 0 ;;
+  esac
   case " ${valuelessFlags.join(' ')} " in
     *" $1 "*) return 0 ;;
   esac
@@ -318,10 +325,15 @@ export function generateZsh(spec) {
   return `#compdef nansen
 ${header('zsh', version, [
     'Install:  nansen completion zsh > "${fpath[1]}/_nansen" && compinit',
-    '     or:  eval "$(nansen completion zsh)"              # add to ~/.zshrc',
+    '     or:  eval "$(nansen completion zsh)"              # in ~/.zshrc, after compinit',
   ])}
 
+# A single-dash token never takes a value; only --long options need the lookup.
 _nansen_is_flag() {
+  case "$1" in
+    --*) ;;
+    *) return 0 ;;
+  esac
   case " ${valuelessFlags.join(' ')} " in
     *" $1 "*) return 0 ;;
   esac
@@ -364,8 +376,10 @@ _nansen_has_sub() {
 }
 
 _nansen() {
+  # Not "path": zsh ties that array to PATH, and a local by that name would
+  # empty PATH for the duration of every completion.
   local -a _nansen_reply all
-  local path="" cur prev word
+  local cmdpath="" cur prev word
   local -i i
 
   cur="\${words[CURRENT]}"
@@ -380,13 +394,13 @@ _nansen() {
       _nansen_is_flag "$word" || (( i++ ))
       continue
     fi
-    if _nansen_has_sub "$path" "$word"; then
-      if [[ -z "$path" ]]; then path="$word"; else path="$path $word"; fi
+    if _nansen_has_sub "$cmdpath" "$word"; then
+      if [[ -z "$cmdpath" ]]; then cmdpath="$word"; else cmdpath="$cmdpath $word"; fi
     fi
   done
 
   if [[ "$cur" == -* ]]; then
-    _nansen_opts "$path"
+    _nansen_opts "$cmdpath"
     all=( "\${_nansen_reply[@]}" )
     _nansen_global_opts
     all+=( "\${_nansen_reply[@]}" )
@@ -396,12 +410,12 @@ _nansen() {
   fi
 
   if [[ "$prev" == -* ]] && ! _nansen_is_flag "$prev"; then
-    _nansen_values "$path" "$prev"
+    _nansen_values "$cmdpath" "$prev"
     (( \${#_nansen_reply[@]} )) && _describe -t values 'value' _nansen_reply
     return
   fi
 
-  _nansen_subs "$path"
+  _nansen_subs "$cmdpath"
   _describe -t commands 'command' _nansen_reply
 }
 
@@ -443,6 +457,14 @@ function __nansen_flags
     echo ${fq(valuelessFlags.join(' '))}
 end
 
+# A single-dash token never takes a value; only --long options need the lookup.
+# The "--" matters: the flag list itself starts with "--", and without it
+# string split reads the list as its own options.
+function __nansen_is_flag
+    string match -q -- '--*' $argv[1]; or return 0
+    contains -- $argv[1] (string split -- ' ' (__nansen_flags))
+end
+
 function __nansen_subs
     switch "$argv[1]"
 ${subArms.join('\n')}
@@ -471,7 +493,6 @@ function __nansen_path
     # -opc is deprecated in fish 4 in favour of -xpc, but is the only spelling
     # that also works on fish 3. Revisit once fish 3 support is dropped.
     set -l tokens (commandline -opc)
-    set -l flags (string split ' ' (__nansen_flags))
     set -l path ''
     set -l skip 0
     set -l count (count $tokens)
@@ -483,7 +504,7 @@ function __nansen_path
                 continue
             end
             if string match -q -- '-*' $word
-                if not contains -- $word $flags
+                if not __nansen_is_flag $word
                     set skip 1
                 end
                 continue
@@ -514,7 +535,7 @@ function __nansen_complete
     if test (count $tokens) -ge 2
         set -l prev $tokens[-1]
         if string match -q -- '-*' $prev
-            if not contains -- $prev (string split ' ' (__nansen_flags))
+            if not __nansen_is_flag $prev
                 __nansen_values "$path" "$prev"
                 return
             end
@@ -553,7 +574,7 @@ INSTALL:
   bash   echo 'eval "$(nansen completion bash)"' >> ~/.bashrc
          # or: nansen completion bash > /etc/bash_completion.d/nansen
   zsh    nansen completion zsh > "\${fpath[1]}/_nansen" && compinit
-         # or: echo 'eval "$(nansen completion zsh)"' >> ~/.zshrc
+         # or, in ~/.zshrc after the compinit line: eval "$(nansen completion zsh)"
   fish   nansen completion fish > ~/.config/fish/completions/nansen.fish
 
 Completions cover nested subcommands, per-command flags, global flags, and the
@@ -564,9 +585,10 @@ export function buildCompletionCommands(deps = {}) {
   const { log = console.log } = deps;
 
   return {
-    'completion': async (args, _apiInstance, flags, _options) => {
+    // --help never reaches here: runCLI answers it from schema.json first.
+    'completion': async (args) => {
       const shell = args[0];
-      if (!shell || flags.help || flags.h) {
+      if (!shell) {
         log(COMPLETION_USAGE);
         return undefined;
       }

--- a/src/schema.json
+++ b/src/schema.json
@@ -2161,6 +2161,30 @@
           ]
         }
       }
+    },
+    "completion": {
+      "description": "Generate a shell completion script from this schema (prints to stdout; nothing is written or fetched)",
+      "subcommands": {
+        "bash": {
+          "description": "Print the bash completion script",
+          "examples": [
+            "nansen completion bash > /etc/bash_completion.d/nansen",
+            "eval \"$(nansen completion bash)\""
+          ]
+        },
+        "zsh": {
+          "description": "Print the zsh completion script",
+          "examples": [
+            "nansen completion zsh > \"${fpath[1]}/_nansen\""
+          ]
+        },
+        "fish": {
+          "description": "Print the fish completion script",
+          "examples": [
+            "nansen completion fish > ~/.config/fish/completions/nansen.fish"
+          ]
+        }
+      }
     }
   },
   "globalOptions": {


### PR DESCRIPTION
Adds `nansen completion <bash|zsh|fish>`, closing the gap against `gh completion`, Railway, AWS CLI, and Terraform.

Refs **API-273**.

## What

```bash
nansen completion bash     # prints the script to stdout
nansen completion zsh
nansen completion fish
nansen completion          # usage + install instructions for all three
```

The scripts are **generated from `src/schema.json`** — the same source of truth `nansen schema` and `--help` read — so they cannot drift from the documented command surface. They cover:

- nested subcommands, to full depth (`nansen research token screener`, `nansen trade limit-order create`)
- per-command flags and global flags (`--pretty`, `--fields`, `--limit`, …)
- enum values a flag accepts (`--tif Gtc|Ioc|Alo`, `--side buy|long|sell|short`, `--chain …`)

Each script walks the command line to resolve the current command path, skipping option values so they are never mistaken for a subcommand — `nansen --pretty research smart-money <TAB>` and `nansen research --fields screener <TAB>` both resolve correctly.

zsh and fish also carry per-item descriptions from the schema; bash emits names only (its default menu has nowhere to show them).

`completion` is treated as an offline command: no network, no disk writes, and the background update check and telemetry are skipped so nothing else can land on a stdout that gets piped into a shell.

## Install

```bash
# bash
echo 'eval "$(nansen completion bash)"' >> ~/.bashrc
# or: nansen completion bash > /etc/bash_completion.d/nansen

# zsh
nansen completion zsh > "${fpath[1]}/_nansen" && compinit

# fish
nansen completion fish > ~/.config/fish/completions/nansen.fish
```

## Testing in CI

`src/__tests__/completion.test.js` (35 tests) keeps generation honest without a human tabbing through a terminal:

1. **Syntax** — `bash -n` on the generated script every run; `zsh -n` and `fish --no-execute` when those shells exist on the runner, plus a shell-agnostic block-balance check for fish so the fish path is never wholly unchecked.
2. **Behaviour** — the bash script is sourced in a subprocess and driven the way bash drives it (`COMP_WORDS`/`COMP_CWORD` → `COMPREPLY`), asserting top-level commands, prefix matching, nested subcommands, per-command options, enum values, and the two path-walking edge cases above.
3. **Drift** — every top-level command the CLI actually dispatches must appear in the completion tree or in an explicit exclusion list, and every flag `parseArgs` treats as valueless must be valueless to the walker. Adding a command without updating the schema fails the suite.
4. **Quoting** — `schema.json` descriptions contain `'`, `"`, `` ` ``, `$` and `:`; a test pins that a quote-bearing description survives into zsh and fish source escaped.

## Assumptions (issue left these open)

- **Deprecated top-level aliases are not completed.** `nansen token …`, `nansen quote …` etc. still work, but completion is a discoverability surface and suggesting them teaches the spelling we're retiring. `bridge-status` is excluded on the same grounds — it's an undocumented top-level alias of `trade bridge-status`. The list is explicit in `EXCLUDED_COMMANDS`.
- **Six commands the CLI dispatches aren't in `schema.json`** (`login`, `logout`, `schema`, `cache`, `changelog`, `help`). They're declared in `UNSCHEMA_COMMANDS` in the generator rather than added to `schema.json`, because the schema help path runs before their hand-written `--help` text and adding them would change existing output. A test fails if either list drifts.
- **`--chain` under `research` falls back to `schema.chains`.** Research `--chain` options declare no `enum`, and `schema.chains` is exactly the list those endpoints accept. Trade/bridge chains are narrower, so they get only their own declared enums rather than a guess.
- **Enum completion is only as good as `schema.json`.** Options that document a closed set in prose but declare no `enum` (e.g. `trade limit-order create --trigger-condition`, documented as `above`/`below`) complete nothing. Adding `enum` to those entries is a follow-up that improves `--help` and completion together.

## Other changes

- `parseArgs`' 20-clause valueless-flag condition is now an exported `VALUELESS_FLAGS` set — the generator's walker needs the same list, and the test asserts they stay in step.
- `schema.json`, `HELP`, and the README gain the `completion` command.
- Changeset: `minor`.

## Checks

```
npm run lint     # clean
npm test
 Test Files  65 passed (65)
      Tests  2670 passed | 3 skipped (2673)
```

(No build step — ESM, no transpilation. `npm pack --dry-run` confirms `src/commands/completion.js` ships.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
