### PR TITLE
feat(schema): describe every option, complete mcp client positionals

### DIFF
--- a/.changeset/schema-descriptions-and-positional-completion.md
+++ b/.changeset/schema-descriptions-and-positional-completion.md
@@ -1,5 +1,5 @@
 ---
-"nansen-cli": patch
+"nansen-cli": minor
 ---
 
 Every command option in `nansen schema` now carries a type and a description (140 research and `wallet send` options had neither), and the `research points` group is described. `research token ohlcv --timeframe` documents its real default (`1d`), and `wallet send --chain`, `research search --type`, and the prediction-market `--neg-risk` filters declare the values they accept, so `--help` and shell completion offer them. Fixed `--neg-risk true` on the prediction-market screeners, which was sent to the API as `neg_risk: false` because the parsed boolean was compared against the string `'true'`. `nansen mcp install` and `nansen mcp uninstall` declare their positional client in the schema, and `nansen completion` scripts now complete it (`claude-code`, `claude-desktop`, `cursor`) in bash, zsh, and fish.

--- a/.changeset/schema-descriptions-and-positional-completion.md
+++ b/.changeset/schema-descriptions-and-positional-completion.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Every command option in `nansen schema` now carries a type and a description (140 research and `wallet send` options had neither), and the `research points` group is described. `research token ohlcv --timeframe` documents its real default (`1d`), and `wallet send --chain`, `research search --type`, and the prediction-market `--neg-risk` filters declare the values they accept, so `--help` and shell completion offer them. Fixed `--neg-risk true` on the prediction-market screeners, which was sent to the API as `neg_risk: false` because the parsed boolean was compared against the string `'true'`. `nansen mcp install` and `nansen mcp uninstall` declare their positional client in the schema, and `nansen completion` scripts now complete it (`claude-code`, `claude-desktop`, `cursor`) in bash, zsh, and fish.

--- a/src/__tests__/completion.test.js
+++ b/src/__tests__/completion.test.js
@@ -110,6 +110,13 @@ describe('buildCompletionSpec', () => {
     expect(quote.options.find(o => o.name === '--chain').values).toEqual([]);
   });
 
+  it('carries positional enum values without making them subcommands', () => {
+    const install = spec.nodes.find(n => n.path === 'mcp install');
+    expect(install.args).toEqual(['claude-code', 'claude-desktop', 'cursor']);
+    expect(install.subcommands).toEqual([]);
+    expect(spec.nodes.map(n => n.path)).not.toContain('mcp install claude-code');
+  });
+
   it('includes global options exactly once, plus --help', () => {
     const names = spec.globalOptions.map(o => o.name);
     expect(names).toContain('--pretty');
@@ -244,6 +251,11 @@ describe('bash completion behaviour', () => {
     expect(complete(['nansen', '-p', 'research', ''])).toContain('token');
     expect(complete(['nansen', 'research', 'token', '-x', ''])).toContain('screener');
   });
+
+  it('completes positional argument values and keeps the path after one', () => {
+    expect(complete(['nansen', 'mcp', 'install', ''])).toEqual(['claude-code', 'claude-desktop', 'cursor']);
+    expect(complete(['nansen', 'mcp', 'install', 'cursor', '--'])).toContain('--dry-run');
+  });
 });
 
 describe.skipIf(!hasBinary('zsh'))('zsh completion behaviour', () => {
@@ -301,6 +313,11 @@ describe.skipIf(!hasBinary('zsh'))('zsh completion behaviour', () => {
     expect(complete(['nansen', 'research', '--fields', 'screener', ''])).toContain('token');
     expect(complete(['nansen', 'research', 'token', '--pretty', ''])).toContain('screener');
   });
+
+  it('completes positional argument values and keeps the path after one', () => {
+    expect(complete(['nansen', 'mcp', 'install', ''])).toEqual(['claude-code', 'claude-desktop', 'cursor']);
+    expect(complete(['nansen', 'mcp', 'install', 'cursor', '--'])).toContain('--dry-run');
+  });
 });
 
 describe.skipIf(!hasBinary('fish'))('fish completion behaviour', () => {
@@ -345,6 +362,11 @@ describe.skipIf(!hasBinary('fish'))('fish completion behaviour', () => {
     expect(complete('nansen -p research ')).toContain('token');
     expect(complete('nansen research --fields screener ')).toContain('token');
     expect(complete('nansen research token --pretty ')).toContain('screener');
+  });
+
+  it('completes positional argument values and keeps the path after one', () => {
+    expect(complete('nansen mcp install ').sort()).toEqual(['claude-code', 'claude-desktop', 'cursor']);
+    expect(complete('nansen mcp install cursor --')).toContain('--dry-run');
   });
 });
 

--- a/src/__tests__/completion.test.js
+++ b/src/__tests__/completion.test.js
@@ -110,6 +110,13 @@ describe('buildCompletionSpec', () => {
     expect(quote.options.find(o => o.name === '--chain').values).toEqual([]);
   });
 
+  it('keeps a boolean option with an enum value-taking so its values are offered', () => {
+    const screener = spec.nodes.find(n => n.path === 'research prediction-market market-screener');
+    expect(screener.options.find(o => o.name === '--neg-risk').values).toEqual(['true', 'false']);
+    expect(spec.valuelessFlags).not.toContain('--neg-risk');
+    expect(spec.valuelessFlags).toContain('--premium-labels'); // plain boolean stays valueless
+  });
+
   it('carries positional enum values without making them subcommands', () => {
     const install = spec.nodes.find(n => n.path === 'mcp install');
     expect(install.args).toEqual(['claude-code', 'claude-desktop', 'cursor']);
@@ -235,6 +242,7 @@ describe('bash completion behaviour', () => {
   it('completes enum values after an option', () => {
     expect(complete(['nansen', 'perp', 'order', '--tif', ''])).toEqual(['Gtc', 'Ioc', 'Alo']);
     expect(complete(['nansen', 'research', 'smart-money', 'netflow', '--chain', ''])).toEqual(SCHEMA.chains);
+    expect(complete(['nansen', 'research', 'prediction-market', 'market-screener', '--neg-risk', ''])).toEqual(['true', 'false']);
   });
 
   it('does not lose the command path across a global flag', () => {

--- a/src/__tests__/prediction-market-neg-risk.test.js
+++ b/src/__tests__/prediction-market-neg-risk.test.js
@@ -1,5 +1,7 @@
 /**
- * `--neg-risk true|false` reaches the API with the matching boolean.
+ * `--neg-risk` reaches the API with the matching boolean, in every form
+ * resolveBooleanOption accepts: `--neg-risk`, `--neg-risk true|false`,
+ * `--neg-risk 1|0`.
  *
  * parseArgs JSON-parses bare `true`/`false` into booleans, so the handler must
  * not compare the raw option against the string 'true' — that inverted the
@@ -15,6 +17,9 @@ function run(argv) {
     pmEventScreener: vi.fn(async () => ({ data: [] })),
   };
   const { _: args, flags, options } = parseArgs(argv);
+  // The handler reaches the API through its `apiInstance` argument (the second
+  // parameter), not through buildCommands' deps, so the mock is passed there.
+  // Empty deps are fine: the prediction-market handler reads none of them.
   return buildCommands({})['prediction-market'](args, api, flags, options).then(() => api);
 }
 
@@ -27,6 +32,18 @@ describe('prediction-market --neg-risk', () => {
   it('sends negRisk: false for --neg-risk false', async () => {
     const api = await run(['market-screener', '--neg-risk', 'false']);
     expect(api.pmMarketScreener).toHaveBeenCalledWith(expect.objectContaining({ negRisk: false }));
+  });
+
+  it('treats a bare --neg-risk as true', async () => {
+    const api = await run(['market-screener', '--neg-risk']);
+    expect(api.pmMarketScreener).toHaveBeenCalledWith(expect.objectContaining({ negRisk: true }));
+  });
+
+  it('accepts 1 and 0', async () => {
+    const on = await run(['market-screener', '--neg-risk', '1']);
+    expect(on.pmMarketScreener).toHaveBeenCalledWith(expect.objectContaining({ negRisk: true }));
+    const off = await run(['market-screener', '--neg-risk', '0']);
+    expect(off.pmMarketScreener).toHaveBeenCalledWith(expect.objectContaining({ negRisk: false }));
   });
 
   it('leaves negRisk undefined when the flag is absent', async () => {

--- a/src/__tests__/prediction-market-neg-risk.test.js
+++ b/src/__tests__/prediction-market-neg-risk.test.js
@@ -1,0 +1,41 @@
+/**
+ * `--neg-risk true|false` reaches the API with the matching boolean.
+ *
+ * parseArgs JSON-parses bare `true`/`false` into booleans, so the handler must
+ * not compare the raw option against the string 'true' — that inverted the
+ * filter (`--neg-risk true` sent `neg_risk: false`).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { buildCommands, parseArgs } from '../cli.js';
+
+function run(argv) {
+  const api = {
+    pmMarketScreener: vi.fn(async () => ({ data: [] })),
+    pmEventScreener: vi.fn(async () => ({ data: [] })),
+  };
+  const { _: args, flags, options } = parseArgs(argv);
+  return buildCommands({})['prediction-market'](args, api, flags, options).then(() => api);
+}
+
+describe('prediction-market --neg-risk', () => {
+  it('sends negRisk: true for --neg-risk true', async () => {
+    const api = await run(['market-screener', '--neg-risk', 'true']);
+    expect(api.pmMarketScreener).toHaveBeenCalledWith(expect.objectContaining({ negRisk: true }));
+  });
+
+  it('sends negRisk: false for --neg-risk false', async () => {
+    const api = await run(['market-screener', '--neg-risk', 'false']);
+    expect(api.pmMarketScreener).toHaveBeenCalledWith(expect.objectContaining({ negRisk: false }));
+  });
+
+  it('leaves negRisk undefined when the flag is absent', async () => {
+    const api = await run(['market-screener']);
+    expect(api.pmMarketScreener).toHaveBeenCalledWith(expect.objectContaining({ negRisk: undefined }));
+  });
+
+  it('applies to the event screener too', async () => {
+    const api = await run(['event-screener', '--neg-risk', 'true']);
+    expect(api.pmEventScreener).toHaveBeenCalledWith(expect.objectContaining({ negRisk: true }));
+  });
+});

--- a/src/cli.js
+++ b/src/cli.js
@@ -1573,7 +1573,7 @@ export function buildCommands(deps = {}) {
       const maxUniqueTraders24h = options['max-unique-traders-24h'] != null ? Number(options['max-unique-traders-24h']) : undefined;
       const minVolume24hr = options['min-volume-24hr'] != null ? Number(options['min-volume-24hr']) : undefined;
       const maxVolume24hr = options['max-volume-24hr'] != null ? Number(options['max-volume-24hr']) : undefined;
-      const negRisk = options['neg-risk'] != null ? String(options['neg-risk']) === 'true' : undefined;
+      const negRisk = resolveBooleanOption(options, flags, 'neg-risk');
       const minOpenInterest = options['min-open-interest'] != null ? Number(options['min-open-interest']) : undefined;
       const maxOpenInterest = options['max-open-interest'] != null ? Number(options['max-open-interest']) : undefined;
       const endDateBefore = options['end-date-before'];

--- a/src/cli.js
+++ b/src/cli.js
@@ -1573,7 +1573,7 @@ export function buildCommands(deps = {}) {
       const maxUniqueTraders24h = options['max-unique-traders-24h'] != null ? Number(options['max-unique-traders-24h']) : undefined;
       const minVolume24hr = options['min-volume-24hr'] != null ? Number(options['min-volume-24hr']) : undefined;
       const maxVolume24hr = options['max-volume-24hr'] != null ? Number(options['max-volume-24hr']) : undefined;
-      const negRisk = options['neg-risk'] != null ? options['neg-risk'] === 'true' : undefined;
+      const negRisk = options['neg-risk'] != null ? String(options['neg-risk']) === 'true' : undefined;
       const minOpenInterest = options['min-open-interest'] != null ? Number(options['min-open-interest']) : undefined;
       const maxOpenInterest = options['max-open-interest'] != null ? Number(options['max-open-interest']) : undefined;
       const endDateBefore = options['end-date-before'];

--- a/src/commands/completion.js
+++ b/src/commands/completion.js
@@ -92,6 +92,16 @@ function safeList(values) {
 }
 
 /**
+ * A boolean option never consumes the next word — unless it also declares an
+ * enum, which means it accepts an explicit value (`--neg-risk true`, resolved
+ * by resolveBooleanOption). Those stay value-taking so the enum is offered
+ * after them and the walker skips the value.
+ */
+function isValueless(opt) {
+  return opt.type === 'boolean' && !Array.isArray(opt.enum);
+}
+
+/**
  * Values to offer after an option. Explicit `enum` first; `--chain` under the
  * research tree falls back to schema.chains, which is exactly the list the
  * research endpoints accept. Trade/bridge chains are narrower and are left to
@@ -121,7 +131,7 @@ export function buildCompletionSpec({ schema = schemaDefinition, version = VERSI
     const options = [];
     for (const [name, opt] of Object.entries(node.options || {})) {
       if (!SAFE_TOKEN.test(name)) continue;
-      if (opt.type === 'boolean') valueless.add(name);
+      if (isValueless(opt)) valueless.add(name);
       options.push({
         name: `--${name}`,
         description: shortDesc(opt.description),
@@ -142,7 +152,7 @@ export function buildCompletionSpec({ schema = schemaDefinition, version = VERSI
   const globalOptions = Object.entries(schema.globalOptions || {})
     .filter(([name]) => SAFE_TOKEN.test(name))
     .map(([name, opt]) => {
-      if (opt.type === 'boolean') valueless.add(name);
+      if (isValueless(opt)) valueless.add(name);
       return {
         name: `--${name}`,
         description: shortDesc(opt.description),

--- a/src/commands/completion.js
+++ b/src/commands/completion.js
@@ -105,8 +105,11 @@ function optionValues(path, name, opt, schema) {
 
 /**
  * Flatten the schema into one node per command path:
- *   { path: 'research token', subcommands: [...], options: [...] }
+ *   { path: 'research token', subcommands: [...], options: [...], args: [...] }
  * The root node has path '' and every top-level command as its subcommands.
+ * `args` holds the enum values of a command's positional arguments (schema
+ * `args: [{ name, enum }]`); they are offered like subcommands but never
+ * extend the command path.
  */
 export function buildCompletionSpec({ schema = schemaDefinition, version = VERSION } = {}) {
   const nodes = [];
@@ -129,6 +132,7 @@ export function buildCompletionSpec({ schema = schemaDefinition, version = VERSI
       path,
       subcommands: subEntries.map(([name, sub]) => ({ name, description: shortDesc(sub.description) })),
       options,
+      args: safeList((node.args || []).flatMap(a => (Array.isArray(a.enum) ? a.enum : []))),
     });
     for (const [name, sub] of subEntries) visit(path ? `${path} ${name}` : name, sub);
   };
@@ -201,6 +205,10 @@ export function generateBash(spec) {
   const valArms = [...valueGroups(nodes)].map(([values, keys]) =>
     `    ${keys.map(dq).join('|')}) echo ${dq(values)} ;;`);
 
+  const argArms = nodes
+    .filter(n => n.args.length)
+    .map(n => `    ${dq(n.path)}) echo ${dq(n.args.join(' '))} ;;`);
+
   return `${header('bash', version, [
     'Install:  eval "$(nansen completion bash)"        # add to ~/.bashrc',
     '     or:  nansen completion bash > /etc/bash_completion.d/nansen',
@@ -235,6 +243,13 @@ ${optArms.join('\n')}
 _nansen_values() {
   case "$1|$2" in
 ${valArms.join('\n')}
+  esac
+}
+
+# Positional argument values; offered alongside subcommands, never part of the path.
+_nansen_args() {
+  case "$1" in
+${argArms.join('\n')}
   esac
 }
 
@@ -291,7 +306,7 @@ _nansen_complete() {
       ;;
   esac
 
-  COMPREPLY=( $(compgen -W "$(_nansen_subs "$path")" -- "$cur") )
+  COMPREPLY=( $(compgen -W "$(_nansen_subs "$path") $(_nansen_args "$path")" -- "$cur") )
   return 0
 }
 
@@ -321,6 +336,10 @@ export function generateZsh(spec) {
 
   const valArms = [...valueGroups(nodes)].map(([values, keys]) =>
     `    ${keys.map(sq).join('|')}) _nansen_reply=( ${values.split(' ').map(sq).join(' ')} ) ;;`);
+
+  const argArms = nodes
+    .filter(n => n.args.length)
+    .map(n => `    ${sq(n.path)}) _nansen_reply=( ${n.args.map(sq).join(' ')} ) ;;`);
 
   return `#compdef nansen
 ${header('zsh', version, [
@@ -359,6 +378,14 @@ _nansen_values() {
   _nansen_reply=()
   case "$1|$2" in
 ${valArms.join('\n')}
+  esac
+}
+
+# Positional argument values; offered alongside subcommands, never part of the path.
+_nansen_args() {
+  _nansen_reply=()
+  case "$1" in
+${argArms.join('\n')}
   esac
 }
 
@@ -415,8 +442,12 @@ _nansen() {
     return
   fi
 
+  local ret=1
   _nansen_subs "$cmdpath"
-  _describe -t commands 'command' _nansen_reply
+  (( \${#_nansen_reply[@]} )) && _describe -t commands 'command' _nansen_reply && ret=0
+  _nansen_args "$cmdpath"
+  (( \${#_nansen_reply[@]} )) && _describe -t arguments 'argument' _nansen_reply && ret=0
+  return ret
 }
 
 if [[ "$funcstack[1]" == "_nansen" ]]; then
@@ -449,6 +480,10 @@ export function generateFish(spec) {
   const valArms = [...valueGroups(nodes)].map(([values, keys]) =>
     `        case ${keys.map(fq).join(' ')}\n            printf '%s\\n' ${values.split(' ').map(fq).join(' ')}`);
 
+  const argArms = nodes
+    .filter(n => n.args.length)
+    .map(n => `        case ${fq(n.path)}\n            printf '%s\\n' ${n.args.map(fq).join(' ')}`);
+
   return `${header('fish', version, [
     'Install:  nansen completion fish > ~/.config/fish/completions/nansen.fish',
   ])}
@@ -480,6 +515,13 @@ end
 function __nansen_values
     switch "$argv[1]|$argv[2]"
 ${valArms.join('\n')}
+    end
+end
+
+# Positional argument values; offered alongside subcommands, never part of the path.
+function __nansen_args
+    switch "$argv[1]"
+${argArms.join('\n')}
     end
 end
 
@@ -543,6 +585,7 @@ function __nansen_complete
     end
 
     __nansen_subs "$path"
+    __nansen_args "$path"
 end
 
 complete -c nansen -f -a '(__nansen_complete)'

--- a/src/schema.json
+++ b/src/schema.json
@@ -2276,7 +2276,7 @@
               "type": "string",
               "required": true,
               "enum": ["evm", "solana", "ethereum", "base"],
-              "description": "Chain to send on"
+              "description": "Chain to send on (evm is an alias for ethereum)"
             },
             "amount": {
               "type": "string",

--- a/src/schema.json
+++ b/src/schema.json
@@ -419,7 +419,9 @@
               "description": "DeFi holdings across protocols",
               "options": {
                 "wallet": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Wallet address to fetch DeFi positions for"
                 }
               }
             }
@@ -433,7 +435,9 @@
               "description": "Net capital flows (inflows vs outflows)",
               "options": {
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain to query"
                 }
               }
             },
@@ -442,7 +446,9 @@
               "description": "Real-time DEX trading activity",
               "options": {
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain to query"
                 }
               }
             },
@@ -459,7 +465,9 @@
               "description": "Aggregated token balances",
               "options": {
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain to query"
                 }
               }
             },
@@ -468,10 +476,14 @@
               "description": "Historical holdings over time",
               "options": {
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain to query"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 }
               }
             }
@@ -485,13 +497,19 @@
               "description": "Transaction history",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Wallet address to profile"
                 },
                 "chain": {
-                  "default": "ethereum"
+                  "type": "string",
+                  "default": "ethereum",
+                  "description": "Chain to profile the address on"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 }
               }
             },
@@ -500,13 +518,19 @@
               "description": "Summarized PnL metrics",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Wallet address to profile"
                 },
                 "chain": {
-                  "default": "ethereum"
+                  "type": "string",
+                  "default": "ethereum",
+                  "description": "Chain to profile the address on"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 }
               }
             },
@@ -515,10 +539,14 @@
               "description": "Current token holdings",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Wallet address to profile"
                 },
                 "chain": {
-                  "default": "ethereum"
+                  "type": "string",
+                  "default": "ethereum",
+                  "description": "Chain to profile the address on"
                 }
               }
             },
@@ -527,13 +555,19 @@
               "description": "Top counterparties by volume",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Wallet address to profile"
                 },
                 "chain": {
-                  "default": "ethereum"
+                  "type": "string",
+                  "default": "ethereum",
+                  "description": "Chain to profile the address on"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 }
               }
             },
@@ -542,13 +576,19 @@
               "description": "Historical balances over time",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Wallet address to profile"
                 },
                 "chain": {
-                  "default": "ethereum"
+                  "type": "string",
+                  "default": "ethereum",
+                  "description": "Chain to profile the address on"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 }
               }
             },
@@ -557,10 +597,14 @@
               "description": "Find wallets related to an address",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Wallet address to profile"
                 },
                 "chain": {
-                  "default": "ethereum"
+                  "type": "string",
+                  "default": "ethereum",
+                  "description": "Chain to profile the address on"
                 }
               }
             },
@@ -569,7 +613,9 @@
               "description": "Find the first wallet that funded an EVM address",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Address whose first funder to find"
                 }
               }
             },
@@ -578,13 +624,19 @@
               "description": "PnL and trade performance",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Wallet address to profile"
                 },
                 "chain": {
-                  "default": "ethereum"
+                  "type": "string",
+                  "default": "ethereum",
+                  "description": "Chain to profile the address on"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 }
               }
             },
@@ -593,10 +645,14 @@
               "description": "Behavioral and entity labels",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Wallet address to profile"
                 },
                 "chain": {
-                  "default": "ethereum"
+                  "type": "string",
+                  "default": "ethereum",
+                  "description": "Chain to profile the address on"
                 }
               }
             },
@@ -605,7 +661,9 @@
               "description": "Current perpetual positions",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Hyperliquid trader address"
                 }
               }
             },
@@ -614,10 +672,14 @@
               "description": "Perpetual trading history",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Hyperliquid trader address"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 }
               }
             },
@@ -626,13 +688,19 @@
               "description": "DEX trade history for a wallet",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Wallet address to profile"
                 },
                 "chain": {
-                  "default": "ethereum"
+                  "type": "string",
+                  "default": "ethereum",
+                  "description": "Chain to profile the address on"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 }
               }
             },
@@ -641,7 +709,9 @@
               "description": "Search for entities by name",
               "options": {
                 "query": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Entity or label name to search for"
                 }
               }
             },
@@ -649,13 +719,19 @@
               "description": "Batch profile multiple addresses",
               "options": {
                 "chain": {
-                  "default": "ethereum"
+                  "type": "string",
+                  "default": "ethereum",
+                  "description": "Chain to profile every address on"
                 },
                 "include": {
-                  "default": "labels,balance"
+                  "type": "string",
+                  "default": "labels,balance",
+                  "description": "Comma-separated sections to fetch per address: labels, balance, pnl"
                 },
                 "delay": {
-                  "default": 1000
+                  "type": "number",
+                  "default": 1000,
+                  "description": "Delay in milliseconds between API calls"
                 }
               }
             },
@@ -663,22 +739,34 @@
               "description": "Multi-hop counterparty trace (BFS)",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Address to start tracing from"
                 },
                 "chain": {
-                  "default": "ethereum"
+                  "type": "string",
+                  "default": "ethereum",
+                  "description": "Chain to profile the address on"
                 },
                 "depth": {
-                  "default": 2
+                  "type": "number",
+                  "default": 2,
+                  "description": "Hops to follow from the starting address (1-5)"
                 },
                 "width": {
-                  "default": 10
+                  "type": "number",
+                  "default": 10,
+                  "description": "Counterparties to follow at each hop"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days at each hop"
                 },
                 "delay": {
-                  "default": 1000
+                  "type": "number",
+                  "default": 1000,
+                  "description": "Delay in milliseconds between API calls"
                 }
               }
             },
@@ -686,13 +774,19 @@
               "description": "Compare two wallets (shared counterparties, tokens)",
               "options": {
                 "addresses": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Comma-separated list (or JSON array) of wallet addresses to compare"
                 },
                 "chain": {
-                  "default": "ethereum"
+                  "type": "string",
+                  "default": "ethereum",
+                  "description": "Chain to compare the wallets on"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 }
               }
             }
@@ -706,13 +800,19 @@
               "description": "Token flow metrics",
               "options": {
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain the token lives on"
                 },
                 "token": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Token contract address (mint address on Solana)"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 },
                 "label": {
                   "description": "Holder segment to filter flows by",
@@ -732,13 +832,19 @@
               "description": "Recent buyers and sellers",
               "options": {
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain the token lives on"
                 },
                 "token": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Token contract address (mint address on Solana)"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 },
                 "buy-or-sell": {
                   "description": "Filter by buy or sell side",
@@ -755,13 +861,19 @@
               "description": "DEX trading activity",
               "options": {
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain the token lives on"
                 },
                 "token": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Token contract address (mint address on Solana)"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 }
               }
             },
@@ -770,13 +882,19 @@
               "description": "Token transfer history",
               "options": {
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain the token lives on"
                 },
                 "token": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Token contract address (mint address on Solana)"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 }
               }
             },
@@ -785,10 +903,14 @@
               "description": "Token holder analysis",
               "options": {
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain the token lives on"
                 },
                 "token": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Token contract address (mint address on Solana)"
                 },
                 "premium-labels": {
                   "description": "Include premium Nansen labels in the response (true=premium, false=free-tier). When omitted, uses API default.",
@@ -801,13 +923,19 @@
               "description": "PnL leaderboard",
               "options": {
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain the token lives on"
                 },
                 "token": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Token contract address (mint address on Solana)"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 },
                 "premium-labels": {
                   "description": "Include premium Nansen labels in the response (true=premium, false=free-tier). When omitted, uses API default.",
@@ -820,10 +948,14 @@
               "description": "Perp PnL leaderboard by token",
               "options": {
                 "symbol": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Perp symbol, e.g. BTC"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 },
                 "premium-labels": {
                   "description": "Include premium Nansen labels in the response (true=premium, false=free-tier). When omitted, uses API default.",
@@ -836,7 +968,9 @@
               "description": "Open perp positions by token symbol",
               "options": {
                 "symbol": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Perp symbol, e.g. BTC"
                 }
               }
             },
@@ -845,10 +979,14 @@
               "description": "Perp trades by token symbol",
               "options": {
                 "symbol": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Perp symbol, e.g. BTC"
                 },
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 }
               }
             },
@@ -857,13 +995,19 @@
               "description": "Detailed flow intelligence by label",
               "options": {
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain the token lives on"
                 },
                 "token": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Token contract address (mint address on Solana)"
                 },
                 "timeframe": {
-                  "default": "1d"
+                  "type": "string",
+                  "default": "1d",
+                  "description": "Time window for the flow metrics"
                 }
               }
             },
@@ -872,13 +1016,19 @@
               "description": "Get detailed information for a specific token",
               "options": {
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain the token lives on"
                 },
                 "token": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Token contract address (mint address on Solana)"
                 },
                 "timeframe": {
-                  "default": "1d"
+                  "type": "string",
+                  "default": "1d",
+                  "description": "Time window for the price-change and volume fields"
                 }
               }
             },
@@ -887,10 +1037,14 @@
               "description": "Risk and reward indicators for a token (Nansen Score)",
               "options": {
                 "chain": {
-                  "default": "ethereum"
+                  "type": "string",
+                  "default": "ethereum",
+                  "description": "Chain the token lives on"
                 },
                 "token": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Token contract address (mint address on Solana)"
                 }
               }
             },
@@ -899,13 +1053,19 @@
               "description": "OHLCV candle data for a token",
               "options": {
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain the token lives on"
                 },
                 "token": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Token contract address (mint address on Solana)"
                 },
                 "timeframe": {
-                  "default": "1h"
+                  "type": "string",
+                  "default": "1d",
+                  "description": "Candle interval"
                 }
               }
             },
@@ -914,7 +1074,9 @@
               "description": "Jupiter DCA orders for token",
               "options": {
                 "token": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Token mint address"
                 }
               }
             },
@@ -923,10 +1085,14 @@
               "description": "Discover and filter tokens",
               "options": {
                 "timeframe": {
-                  "default": "24h"
+                  "type": "string",
+                  "default": "24h",
+                  "description": "Time window for volume, flow, and price-change metrics"
                 },
                 "chain": {
-                  "default": "solana"
+                  "type": "string",
+                  "default": "solana",
+                  "description": "Chain the token lives on"
                 },
                 "include-stablecoins": {
                   "description": "Whether to include stablecoins in screener results (default true on API side)",
@@ -947,7 +1113,9 @@
                   ]
                 },
                 "limit": {
-                  "default": 25
+                  "type": "number",
+                  "default": 25,
+                  "description": "Number of tokens to return"
                 }
               }
             }
@@ -959,13 +1127,20 @@
           "description": "Search for tokens and entities across Nansen",
           "options": {
             "query": {
-              "required": true
+              "type": "string",
+              "required": true,
+              "description": "Token name, symbol, or address, or an entity name"
             },
             "type": {
-              "default": "any"
+              "type": "string",
+              "default": "any",
+              "enum": ["any", "token", "entity"],
+              "description": "Result type: token, entity, or any"
             },
             "limit": {
-              "default": 25
+              "type": "number",
+              "default": 25,
+              "description": "Maximum number of results"
             }
           }
         },
@@ -976,7 +1151,9 @@
               "description": "Screen perpetual futures contracts",
               "options": {
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 },
                 "trader-type": {
                   "description": "Filter by trader type. One of: all, sm, whale, public_figure, high_winrate_hl_perps_trader. Defaults to all.",
@@ -1004,7 +1181,9 @@
               "description": "Perpetual futures PnL leaderboard",
               "options": {
                 "days": {
-                  "default": 30
+                  "type": "number",
+                  "default": 30,
+                  "description": "Lookback window in days"
                 },
                 "premium-labels": {
                   "description": "Include premium Nansen labels in the response (true=premium, false=free-tier). When omitted, uses API default.",
@@ -1022,7 +1201,9 @@
               "description": "Get Prediction Market OHLCV Candles",
               "options": {
                 "market-id": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Polymarket market ID (numeric, from the screener)"
                 }
               }
             },
@@ -1031,7 +1212,9 @@
               "description": "Get Prediction Market Orderbook",
               "options": {
                 "market-id": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Polymarket market ID (numeric, from the screener)"
                 }
               }
             },
@@ -1040,7 +1223,9 @@
               "description": "Get Prediction Market Top Holders",
               "options": {
                 "market-id": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Polymarket market ID (numeric, from the screener)"
                 }
               }
             },
@@ -1049,7 +1234,9 @@
               "description": "Get Prediction Market Trades by Market",
               "options": {
                 "market-id": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Polymarket market ID (numeric, from the screener)"
                 }
               }
             },
@@ -1058,25 +1245,70 @@
               "description": "Get Prediction Market Screener",
               "options": {
                 "query": {
-                  "default": ""
+                  "type": "string",
+                  "default": "",
+                  "description": "Text filter on market titles"
                 },
                 "sort-by": {
                   "description": "Deprecated: use --sort field:dir instead"
                 },
-                "tags": {},
-                "min-liquidity": {},
-                "max-liquidity": {},
-                "min-unique-traders-24h": {},
-                "max-unique-traders-24h": {},
-                "min-volume-24hr": {},
-                "max-volume-24hr": {},
-                "neg-risk": {},
-                "min-open-interest": {},
-                "max-open-interest": {},
-                "end-date-before": {},
-                "end-date-after": {},
-                "min-price": {},
-                "max-price": {}
+                "tags": {
+                  "type": "string",
+                  "description": "Comma-separated Polymarket tags to filter by"
+                },
+                "min-liquidity": {
+                  "type": "number",
+                  "description": "Minimum liquidity in USD"
+                },
+                "max-liquidity": {
+                  "type": "number",
+                  "description": "Maximum liquidity in USD"
+                },
+                "min-unique-traders-24h": {
+                  "type": "number",
+                  "description": "Minimum unique traders in the last 24 hours"
+                },
+                "max-unique-traders-24h": {
+                  "type": "number",
+                  "description": "Maximum unique traders in the last 24 hours"
+                },
+                "min-volume-24hr": {
+                  "type": "number",
+                  "description": "Minimum 24-hour volume in USD"
+                },
+                "max-volume-24hr": {
+                  "type": "number",
+                  "description": "Maximum 24-hour volume in USD"
+                },
+                "neg-risk": {
+                  "type": "string",
+                  "enum": ["true", "false"],
+                  "description": "Only negative-risk markets (true) or only standard markets (false)"
+                },
+                "min-open-interest": {
+                  "type": "number",
+                  "description": "Minimum open interest in USD"
+                },
+                "max-open-interest": {
+                  "type": "number",
+                  "description": "Maximum open interest in USD"
+                },
+                "end-date-before": {
+                  "type": "string",
+                  "description": "Only markets ending before this date (ISO 8601)"
+                },
+                "end-date-after": {
+                  "type": "string",
+                  "description": "Only markets ending after this date (ISO 8601)"
+                },
+                "min-price": {
+                  "type": "number",
+                  "description": "Minimum outcome price (0-1)"
+                },
+                "max-price": {
+                  "type": "number",
+                  "description": "Maximum outcome price (0-1)"
+                }
               }
             },
             "event-screener": {
@@ -1084,23 +1316,62 @@
               "description": "Get Prediction Market Event Screener",
               "options": {
                 "query": {
-                  "default": ""
+                  "type": "string",
+                  "default": "",
+                  "description": "Text filter on event titles"
                 },
                 "sort-by": {
                   "description": "Deprecated: use --sort field:dir instead"
                 },
-                "tags": {},
-                "min-liquidity": {},
-                "max-liquidity": {},
-                "min-unique-traders-24h": {},
-                "max-unique-traders-24h": {},
-                "min-volume-24hr": {},
-                "max-volume-24hr": {},
-                "neg-risk": {},
-                "min-open-interest": {},
-                "max-open-interest": {},
-                "end-date-before": {},
-                "end-date-after": {}
+                "tags": {
+                  "type": "string",
+                  "description": "Comma-separated Polymarket tags to filter by"
+                },
+                "min-liquidity": {
+                  "type": "number",
+                  "description": "Minimum liquidity in USD"
+                },
+                "max-liquidity": {
+                  "type": "number",
+                  "description": "Maximum liquidity in USD"
+                },
+                "min-unique-traders-24h": {
+                  "type": "number",
+                  "description": "Minimum unique traders in the last 24 hours"
+                },
+                "max-unique-traders-24h": {
+                  "type": "number",
+                  "description": "Maximum unique traders in the last 24 hours"
+                },
+                "min-volume-24hr": {
+                  "type": "number",
+                  "description": "Minimum 24-hour volume in USD"
+                },
+                "max-volume-24hr": {
+                  "type": "number",
+                  "description": "Maximum 24-hour volume in USD"
+                },
+                "neg-risk": {
+                  "type": "string",
+                  "enum": ["true", "false"],
+                  "description": "Only negative-risk markets (true) or only standard markets (false)"
+                },
+                "min-open-interest": {
+                  "type": "number",
+                  "description": "Minimum open interest in USD"
+                },
+                "max-open-interest": {
+                  "type": "number",
+                  "description": "Maximum open interest in USD"
+                },
+                "end-date-before": {
+                  "type": "string",
+                  "description": "Only events ending before this date (ISO 8601)"
+                },
+                "end-date-after": {
+                  "type": "string",
+                  "description": "Only events ending after this date (ISO 8601)"
+                }
               }
             },
             "pnl-by-market": {
@@ -1108,7 +1379,9 @@
               "description": "Get Prediction Market PnL by Market",
               "options": {
                 "market-id": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Polymarket market ID (numeric, from the screener)"
                 }
               }
             },
@@ -1117,7 +1390,9 @@
               "description": "Get Prediction Market PnL by Address",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Polymarket trader address"
                 }
               }
             },
@@ -1126,7 +1401,9 @@
               "description": "Get Prediction Market Position Detail",
               "options": {
                 "market-id": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Polymarket market ID (numeric, from the screener)"
                 }
               }
             },
@@ -1135,7 +1412,9 @@
               "description": "Get Prediction Market Trades by Address",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Polymarket trader address"
                 }
               }
             },
@@ -1148,7 +1427,9 @@
               "description": "Get wallet-level PnL summary for a Polymarket address",
               "options": {
                 "address": {
-                  "required": true
+                  "type": "string",
+                  "required": true,
+                  "description": "Polymarket trader address"
                 }
               }
             }
@@ -1156,6 +1437,7 @@
           "description": "Polymarket prediction market analytics"
         },
         "points": {
+          "description": "Nansen Points analytics",
           "subcommands": {
             "leaderboard": {
               "description": "Points leaderboard"
@@ -1169,11 +1451,14 @@
             "timeframe-days": {
               "type": "number",
               "enum": [7, 30, 365],
-              "default": 7
+              "default": 7,
+              "description": "Growth window in days"
             },
             "chain-type": {
+              "type": "string",
               "enum": ["all", "evm"],
-              "default": "all"
+              "default": "all",
+              "description": "Include all chains or only EVM chains"
             }
           }
         },
@@ -1186,16 +1471,24 @@
           "description": "Get all labels for an address, including premium labels",
           "options": {
             "address": {
-              "required": true
+              "type": "string",
+              "required": true,
+              "description": "Address to fetch labels for"
             },
             "chain": {
-              "default": "all"
+              "type": "string",
+              "default": "all",
+              "description": "Chain to fetch labels for, or all"
             },
             "page": {
-              "default": 1
+              "type": "number",
+              "default": 1,
+              "description": "1-based page number"
             },
             "limit": {
-              "default": 100
+              "type": "number",
+              "default": 100,
+              "description": "Labels per page"
             }
           }
         },
@@ -1247,7 +1540,9 @@
           "description": "Summarize realized Hyperliquid PnL for an address",
           "options": {
             "address": {
-              "required": true
+              "type": "string",
+              "required": true,
+              "description": "Hyperliquid trader address"
             },
             "from-date": {
               "required": true,
@@ -1268,8 +1563,10 @@
               "description": "Token address or Hyperliquid asset symbol"
             },
             "chain": {
+              "type": "string",
               "enum": ["base", "bnb", "ethereum", "hyperliquid", "solana"],
-              "default": "solana"
+              "default": "solana",
+              "description": "Chain the token lives on"
             },
             "from-date": {
               "required": true,
@@ -1282,8 +1579,10 @@
               "description": "Exact Hyperliquid cutoff timestamp; exactly one of --as-of-date or --as-of-ts is required"
             },
             "timeframe": {
+              "type": "string",
               "required": true,
-              "enum": ["5m", "15m", "30m", "1h", "1d", "1w"]
+              "enum": ["5m", "15m", "30m", "1h", "1d", "1w"],
+              "description": "Candle interval"
             },
             "apply-blacklist-filter": {
               "type": "boolean",
@@ -1296,11 +1595,15 @@
           "description": "Look up a transaction and its token/NFT transfers",
           "options": {
             "transaction-hash": {
-              "required": true
+              "type": "string",
+              "required": true,
+              "description": "Transaction hash to look up"
             },
             "chain": {
+              "type": "string",
               "enum": ["all", "arbitrum", "avalanche", "base", "bitcoin", "bnb", "ethereum", "hyperevm", "injective", "iotaevm", "linea", "mantle", "mantra", "monad", "near", "optimism", "plasma", "robinhood", "sei", "sonic", "starknet", "sui", "ton", "tron"],
-              "default": "ethereum"
+              "default": "ethereum",
+              "description": "Chain the transaction was made on"
             },
             "block-timestamp": {
               "description": "Block timestamp (required for bitcoin, tron, ton, starknet, and sui)"
@@ -1965,13 +2268,20 @@
           "description": "Send tokens or native currency",
           "options": {
             "to": {
-              "required": true
+              "type": "string",
+              "required": true,
+              "description": "Recipient address"
             },
             "chain": {
-              "required": true
+              "type": "string",
+              "required": true,
+              "enum": ["evm", "solana", "ethereum", "base"],
+              "description": "Chain to send on"
             },
             "amount": {
-              "required": true
+              "type": "string",
+              "required": true,
+              "description": "Amount to send in human-readable units, e.g. 1.5"
             }
           }
         },
@@ -2136,6 +2446,14 @@
         },
         "install": {
           "description": "Add the Nansen MCP server to a client's config. Client (positional): claude-code, claude-desktop, or cursor. Uses the API key from `nansen login` / NANSEN_API_KEY; re-run after key rotation to update the entry.",
+          "args": [
+            {
+              "name": "client",
+              "required": true,
+              "enum": ["claude-code", "claude-desktop", "cursor"],
+              "description": "MCP client to configure"
+            }
+          ],
           "options": {
             "dry-run": {
               "type": "boolean",
@@ -2149,6 +2467,14 @@
         },
         "uninstall": {
           "description": "Remove the Nansen MCP server entry from a client's config. Client (positional): claude-code, claude-desktop, or cursor.",
+          "args": [
+            {
+              "name": "client",
+              "required": true,
+              "enum": ["claude-code", "claude-desktop", "cursor"],
+              "description": "MCP client to remove the entry from"
+            }
+          ],
           "options": {
             "dry-run": {
               "type": "boolean",

--- a/src/schema.json
+++ b/src/schema.json
@@ -1044,7 +1044,7 @@
                 "token": {
                   "type": "string",
                   "required": true,
-                  "description": "Token contract address (mint address on Solana)"
+                  "description": "Token contract address"
                 }
               }
             },
@@ -1281,9 +1281,9 @@
                   "description": "Maximum 24-hour volume in USD"
                 },
                 "neg-risk": {
-                  "type": "string",
+                  "type": "boolean",
                   "enum": ["true", "false"],
-                  "description": "Only negative-risk markets (true) or only standard markets (false)"
+                  "description": "Only negative-risk markets (true, or the bare flag) or only standard markets (false)"
                 },
                 "min-open-interest": {
                   "type": "number",
@@ -1352,9 +1352,9 @@
                   "description": "Maximum 24-hour volume in USD"
                 },
                 "neg-risk": {
-                  "type": "string",
+                  "type": "boolean",
                   "enum": ["true", "false"],
-                  "description": "Only negative-risk markets (true) or only standard markets (false)"
+                  "description": "Only negative-risk markets (true, or the bare flag) or only standard markets (false)"
                 },
                 "min-open-interest": {
                   "type": "number",


### PR DESCRIPTION
Follow-up to #580 (merged), which surfaced two gaps in `src/schema.json`: 140 options had no description (zsh and fish list them bare), and the `mcp install` client names were prose-only so nothing could complete them.

## What

**Descriptions and types for every option that lacked one (140).** All core research options (`--address`, `--chain`, `--days`, `--token`, `--market-id`, `--timeframe`, the prediction-market screener filters, …) and `wallet send --to/--chain/--amount` were declared as bare `{ "required": true }`, `{ "default": … }`, or `{}`. Each now carries `type` and a one-line `description` written from the handler code (what the value is, units, ranges). `research points` gets a group description. `nansen schema` no longer has undescribed parameters, and zsh/fish completions show a description for every flag.

**Accepted values declared where the code enumerates them.** `wallet send --chain` (`evm|solana|ethereum|base`), `research search --type` (`any|token|entity`), and the prediction-market `--neg-risk` filter (`true|false`) now declare `enum`, so `--help` prints them and completion offers them. `--neg-risk` is typed `boolean` like the other `resolveBooleanOption` flags; the completion generator treats a boolean that also declares an enum as value-taking, so `--neg-risk <TAB>` still offers `true`/`false` while plain booleans such as `--premium-labels` stay valueless.

**Positional completion.** `mcp install` and `mcp uninstall` declare their client as `args: [{ name, required, enum, description }]`. The completion generator reads `args` enums and offers them like subcommands in bash, zsh, and fish, without extending the command path, so `nansen mcp install cursor --<TAB>` still offers `--dry-run`. `--help` output is unchanged (the schema help renderer ignores `args` for now).

**Two corrections found while writing the descriptions:**
- `research token ohlcv --timeframe` declared default `1h`; the CLI and API default to `1d`. Schema now says `1d`.
- `--neg-risk true` was inverted. `parseArgs` JSON-parses `true` into a boolean, and the handler compared it with `=== 'true'`, so `true` sent `neg_risk: false`. Now resolved through the existing `resolveBooleanOption` helper (same as `--premium-labels`), so `--neg-risk`, `--neg-risk true|false`, and `--neg-risk 1|0` all work, and covered by tests. Worth fixing here because this PR is what starts advertising the flag's values.

## How the schema was edited

Line-based, not a JSON rewrite: `JSON.stringify` would have exploded every inline `enum` array into multi-line form and drowned the diff. Only the targeted option blocks changed; a structural comparison against `HEAD` confirms the only altered existing value is the ohlcv default. Key order matches the file's convention (`type`, `default`/`required`/`enum`, `description`).

## Verification

- `npm test` and `npm run lint` clean; `completion.test.js` 50 tests (4 new: positional values in the spec and in each shell, and that the path survives a positional). New `prediction-market-neg-risk.test.js` (6 tests) fails on the previous `cli.js` for the `true` cases and passes with the fix.
- Drove the regenerated scripts in bash 5.3 and macOS bash 3.2, zsh 5.9 (real compsys), and fish 4.9: `mcp install <TAB>` offers the three clients, `mcp install cursor --<TAB>` offers `--dry-run`, `wallet send --chain <TAB>`, `research search --type <TAB>`, and `--neg-risk <TAB>` offer their enums.
- `nansen research token ohlcv --help` now shows `--timeframe (1d)`; `nansen wallet send --help` shows `--chain* [evm|solana|ethereum|base]`.

## Not in this PR

- `generateSubcommandHelp` (used for `nansen research <cat> <sub> --help`) prints `--name (default) [enum]` without descriptions, so the new text reaches `nansen schema` and completions but not that help view. Rendering it there is a small follow-up.
- `wallet send` also accepts `--token`, `--wallet`, `--max`, and `--dry-run` per its hand-written help; the schema still omits them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
