### PR TITLE
fix(telemetry): create ~/.nansen 0700 and its id/session files 0600

### DIFF
--- a/.changeset/telemetry-config-dir-permissions.md
+++ b/.changeset/telemetry-config-dir-permissions.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Telemetry now creates `~/.nansen` with mode 0700 and writes its id/session files with mode 0600, matching every other module that writes to that directory. Previously these were the only writes there that used default permissions, so when they were the first to create the directory (for example when authenticating with `NANSEN_API_KEY` instead of `nansen login`) it was left group- and world-readable.

--- a/src/__tests__/telemetry.test.js
+++ b/src/__tests__/telemetry.test.js
@@ -4,6 +4,8 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 // Mock fetch globally before importing the module
 const fetchMock = vi.fn().mockResolvedValue({ ok: true });
@@ -337,6 +339,70 @@ describe('telemetry', () => {
       trackPerpOrderCompleted(baseOutcome);
       expect(fetchMock).not.toHaveBeenCalled();
       delete process.env.DO_NOT_TRACK;
+    });
+  });
+
+  // ~/.nansen also holds the API key and the encrypted wallet keystores, so every
+  // module that writes there creates the directory 0700 and its files 0600. These
+  // two writes run on ordinary commands and can be the ones that create the
+  // directory, so they have to use the same modes — an existing directory keeps
+  // whatever mode its creator gave it.
+  describe('config dir permissions', () => {
+    it('creates the config dir 0700 and the id/session files 0600', async () => {
+      const mkdirCalls = [];
+      const writeCalls = [];
+      const origRead = fs.readFileSync;
+      vi.spyOn(fs, 'readFileSync').mockImplementation((p, ...args) => {
+        if (typeof p === 'string' && (p.includes('telemetry-id') || p.includes('session'))) {
+          throw new Error('ENOENT');
+        }
+        return origRead(p, ...args);
+      });
+      vi.spyOn(fs, 'mkdirSync').mockImplementation((p, opts) => { mkdirCalls.push({ path: p, opts }); });
+      vi.spyOn(fs, 'writeFileSync').mockImplementation((p, data, opts) => { writeCalls.push({ path: p, opts }); });
+
+      ({ getAnonymousId, getSessionId } = await freshImport());
+      getAnonymousId();
+      getSessionId();
+
+      expect(mkdirCalls.length).toBe(2);
+      for (const call of mkdirCalls) {
+        expect(call.opts).toMatchObject({ mode: 0o700, recursive: true });
+      }
+      for (const name of ['telemetry-id', 'session']) {
+        const write = writeCalls.find(c => c.path.includes(name));
+        expect(write, name).toBeTruthy();
+        expect(write.opts, name).toMatchObject({ mode: 0o600 });
+      }
+
+      vi.restoreAllMocks();
+    });
+
+    // POSIX modes are meaningless on Windows — fs.stat reports 0o666 for every file
+    // there, the same reason `nansen doctor` skips its permission checks on win32.
+    it.skipIf(process.platform === 'win32')('leaves nothing group- or world-accessible on disk', async () => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'nansen-telemetry-'));
+      const prevHome = process.env.HOME;
+      const prevUserProfile = process.env.USERPROFILE;
+      process.env.HOME = home;
+      process.env.USERPROFILE = home;
+
+      try {
+        ({ getAnonymousId, getSessionId } = await freshImport());
+        getAnonymousId();
+        getSessionId();
+
+        const dir = path.join(home, '.nansen');
+        // Same predicate doctor.js uses to flag insecure permissions.
+        const insecure = p => (fs.statSync(p).mode & 0o077) !== 0;
+        expect(insecure(dir)).toBe(false);
+        expect(insecure(path.join(dir, 'telemetry-id'))).toBe(false);
+        expect(insecure(path.join(dir, 'session'))).toBe(false);
+      } finally {
+        if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+        if (prevUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = prevUserProfile;
+        fs.rmSync(home, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -28,6 +28,16 @@ const TELEMETRY_URL =
 
 const TIMEOUT_MS = 1000;
 
+// Every other module that writes under ~/.nansen (api.js, wallet.js, keychain.js,
+// trading.js, update-check.js, …) creates directories 0700 and files 0600, because
+// the same directory also holds the API key and the encrypted wallet keystores.
+// Telemetry writes there too, so it uses the same modes: mkdir with recursive:true
+// leaves an existing directory's mode alone, so whichever module creates ~/.nansen
+// first fixes its permissions for good — and on the documented NANSEN_API_KEY path
+// no config is ever saved, so that first writer is this file.
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+
 // ─── opt-out ──────────────────────────────────────────────
 
 /**
@@ -80,8 +90,8 @@ export function getAnonymousId() {
     if (!_anonymousId) {
       _anonymousId = crypto.randomUUID();
       try {
-        fs.mkdirSync(path.dirname(TELEMETRY_ID_FILE), { recursive: true });
-        fs.writeFileSync(TELEMETRY_ID_FILE, _anonymousId, 'utf8');
+        fs.mkdirSync(path.dirname(TELEMETRY_ID_FILE), { mode: DIR_MODE, recursive: true });
+        fs.writeFileSync(TELEMETRY_ID_FILE, _anonymousId, { encoding: 'utf8', mode: FILE_MODE });
       } catch { /* best-effort persist */ }
     }
   }
@@ -118,7 +128,7 @@ export function getSessionId() {
       _sessionId = raw.id;
       // touch timestamp, but only if >1 min elapsed to reduce writes
       if (now - raw.ts > 60_000) {
-        try { fs.writeFileSync(SESSION_FILE, JSON.stringify({ id: _sessionId, ts: now }), 'utf8'); } catch { /* best-effort touch */ }
+        try { fs.writeFileSync(SESSION_FILE, JSON.stringify({ id: _sessionId, ts: now }), { encoding: 'utf8', mode: FILE_MODE }); } catch { /* best-effort touch */ }
       }
       return _sessionId;
     }
@@ -126,8 +136,8 @@ export function getSessionId() {
 
   _sessionId = crypto.randomUUID();
   try {
-    fs.mkdirSync(path.dirname(SESSION_FILE), { recursive: true });
-    fs.writeFileSync(SESSION_FILE, JSON.stringify({ id: _sessionId, ts: now }), 'utf8');
+    fs.mkdirSync(path.dirname(SESSION_FILE), { mode: DIR_MODE, recursive: true });
+    fs.writeFileSync(SESSION_FILE, JSON.stringify({ id: _sessionId, ts: now }), { encoding: 'utf8', mode: FILE_MODE });
   } catch { /* best-effort */ }
   return _sessionId;
 }


### PR DESCRIPTION
## Problem

`~/.nansen` holds the API key (`config.json`) and the encrypted wallet keystores (`wallets/`). Every module that writes there creates directories with `mode: 0o700` and files with `mode: 0o600` — `api.js`, `wallet.js`, `keychain.js`, `privy.js`, `trading.js`, `bridge.js`, `limit-order.js`, `update-check.js`, `cost-cache.js`, `commands/mcp.js`.

`telemetry.js` is the only exception. Its two `mkdirSync` calls and three `writeFileSync` calls use default permissions.

That matters because `mkdirSync(..., { recursive: true })` does not change the mode of a directory that already exists — whichever module creates `~/.nansen` first sets its permissions permanently. Telemetry runs on every non-offline command, so it wins that race whenever no config has been saved yet: most importantly on the documented `NANSEN_API_KEY` env-var path (`AGENTS.md`, and what the MCP/agent setup uses), where `saveConfig()` never runs at all.

Reproduced on Linux with a clean `HOME`, calling only `getAnonymousId()` and `getSessionId()`:

```
umask            : 0022
~/.nansen        : 755
telemetry-id     : 644
session          : 644
after 0o700 mkdir: 755   <- a later mkdir(mode 0o700, recursive) does not fix it
```

`nansen doctor` classifies exactly this as insecure — `isInsecureMode()` in `src/doctor.js` is `(mode & 0o077) !== 0`, and it tells the user to `chmod 700`. So the CLI ends up warning about a state it created itself.

## Fix

Give telemetry's directory and file writes the same modes the rest of the codebase already uses: `0o700` for the directory, `0o600` for `telemetry-id` and `session`.

No behaviour change beyond permissions. The two id files stay exactly where they were, and `mode` is ignored for an already-existing file, so upgrading users are unaffected until the files are recreated.

## Tests

Two regression tests in `src/__tests__/telemetry.test.js`:

- a mock-based one asserting the options passed to `mkdirSync`/`writeFileSync` (runs everywhere);
- a real-filesystem one against a temp `HOME`, asserting nothing is group- or world-accessible using the same `mode & 0o077` predicate `doctor.js` uses. Skipped on Windows, matching the existing `platform !== 'win32'` guard in `doctor.js`.

Both fail on `main` and pass with this change.

## Checklist

- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] New code paths have tests
- [x] No `console.log` in core, no hardcoded secrets
- [x] Changeset added (`patch`)
- [x] `src/schema.json` unchanged — no commands or options added

`npm test`:

```
 Test Files  64 passed (64)
      Tests  2637 passed | 2 skipped (2639)
```
