### PR TITLE
fix: wallet list writes only JSON to stdout (#154)

### DIFF
--- a/.changeset/fix-wallet-list-stdout-json.md
+++ b/.changeset/fix-wallet-list-stdout-json.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix `nansen wallet list` to emit only the JSON envelope on stdout, matching every other command. It previously wrote its human-readable summary directly to stdout via `console.log` and returned no data, so `nansen wallet list | jq .` had nothing valid to parse. The human-readable summary (and the "No wallets found" message) now goes to stderr, and stdout carries `{"success":true,"data":{"wallets":[...],"defaultWallet":...}}` — which also means `--pretty`, `--table`, and `--csv` now work on `wallet list` for free, consistent with the rest of the CLI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Entry point is `src/index.js`.
 - **ESM only** — `import`/`export`, no TypeScript, no transpilation
 - **BigInt for token amounts** — never floating point
 - **Research commands** — return data objects, CLI layer formats via `formatOutput()` to stdout
-- **Operational commands** (trade, wallet, login) — print human-readable text via `log()` to stdout, return `undefined`
+- **Operational commands** (trade, wallet, login) — generally print human-readable text via `log()` to stdout and return `undefined`. Exception: `wallet list` returns `{wallets, defaultWallet}` so the standard dispatcher wraps it in the JSON envelope and agents can parse it via `nansen wallet list | jq .`; its human-readable summary goes to stderr instead (see #154).
 - **No interactive prompts in core** — use env vars (`NANSEN_WALLET_PASSWORD`, `NANSEN_API_KEY`)
 - **Actionable errors** — `"Not logged in. Run: nansen login"` not `"Authentication failed"`
 

--- a/src/__tests__/wallet.test.js
+++ b/src/__tests__/wallet.test.js
@@ -700,12 +700,66 @@ describe('Wallet list/show CLI output for provider', () => {
       }));
 
     const { buildWalletCommands } = await import('../wallet.js');
-    const output = [];
-    const cmds = buildWalletCommands({ log: (m) => output.push(m), exit: () => {} });
+    const errOutput = [];
+    const cmds = buildWalletCommands({ errorOutput: (m) => errOutput.push(m), exit: () => {} });
     await cmds.wallet(['list'], null, {}, {});
 
-    const joined = output.join('\n');
+    // Human-readable summary (with provider tag) goes to stderr, not stdout.
+    const joined = errOutput.join('\n');
     expect(joined).toContain('privy');
+  });
+});
+
+describe('Wallet list stdout/stderr separation (issue #154)', () => {
+  it('list returns JSON-serializable data instead of printing to stdout', async () => {
+    const walletsDir = path.join(tempDir, '.nansen', 'wallets');
+    fs.mkdirSync(walletsDir, { recursive: true });
+    fs.writeFileSync(path.join(walletsDir, 'config.json'),
+      JSON.stringify({ defaultWallet: 'w1', passwordHash: null }));
+    fs.writeFileSync(path.join(walletsDir, 'w1.json'),
+      JSON.stringify({
+        name: 'w1', provider: 'local',
+        evm: { address: '0xAddr' },
+        solana: { address: 'SolAddr' },
+        createdAt: '2026-01-01T00:00:00Z',
+      }));
+
+    const { buildWalletCommands } = await import('../wallet.js');
+    const stdout = [];
+    const stderrOut = [];
+    const cmds = buildWalletCommands({
+      log: (m) => stdout.push(m),
+      errorOutput: (m) => stderrOut.push(m),
+      exit: () => {},
+    });
+    const result = await cmds.wallet(['list'], null, {}, {});
+
+    // Nothing written to stdout (log) — the CLI dispatcher is responsible for
+    // printing the JSON envelope from the returned value.
+    expect(stdout).toHaveLength(0);
+    // Human summary went to stderr instead.
+    expect(stderrOut.join('\n')).toContain('w1');
+    // The returned value is exactly what should be JSON-serialized to stdout.
+    expect(result).toEqual({
+      wallets: [expect.objectContaining({ name: 'w1', isDefault: true })],
+      defaultWallet: 'w1',
+    });
+  });
+
+  it('list with no wallets still returns structured data, message goes to stderr', async () => {
+    const { buildWalletCommands } = await import('../wallet.js');
+    const stdout = [];
+    const stderrOut = [];
+    const cmds = buildWalletCommands({
+      log: (m) => stdout.push(m),
+      errorOutput: (m) => stderrOut.push(m),
+      exit: () => {},
+    });
+    const result = await cmds.wallet(['list'], null, {}, {});
+
+    expect(stdout).toHaveLength(0);
+    expect(stderrOut.join('\n')).toContain('No wallets found');
+    expect(result).toEqual({ wallets: [], defaultWallet: null });
   });
 });
 

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -583,7 +583,7 @@ export async function deleteWallet(name, password) {
  * Build wallet command handlers for integration into CLI.
  */
 export function buildWalletCommands(deps = {}) {
-  const { log = console.log } = deps;
+  const { log = console.log, errorOutput = console.error } = deps;
 
   return {
     'wallet': async (args, apiInstance, flags, options) => {
@@ -720,19 +720,23 @@ export function buildWalletCommands(deps = {}) {
 
         'list': async () => {
           const result = listWallets();
+          // Human-readable summary goes to stderr only — stdout carries just the
+          // JSON envelope (returned below), consistent with every other command,
+          // so `nansen wallet list | jq .` and similar scripting doesn't break.
           if (result.wallets.length === 0) {
-            log('No wallets found. Create one with: nansen wallet create');
-            return;
+            errorOutput('No wallets found. Create one with: nansen wallet create');
+          } else {
+            errorOutput('');
+            for (const w of result.wallets) {
+              const star = w.isDefault ? ' ★' : '';
+              const providerTag = w.provider === 'privy' ? ' (privy)' : '';
+              errorOutput(`  ${w.name}${star}${providerTag}`);
+              errorOutput(`    EVM:    ${w.evm}`);
+              errorOutput(`    Solana: ${w.solana}`);
+              errorOutput('');
+            }
           }
-          log('');
-          for (const w of result.wallets) {
-            const star = w.isDefault ? ' ★' : '';
-            const providerTag = w.provider === 'privy' ? ' (privy)' : '';
-            log(`  ${w.name}${star}${providerTag}`);
-            log(`    EVM:    ${w.evm}`);
-            log(`    Solana: ${w.solana}`);
-            log('');
-          }
+          return result;
         },
 
         'show': async () => {


### PR DESCRIPTION
Fixes #154.

## Problem

`nansen wallet list` wrote its human-readable summary directly to stdout via `console.log` and returned `undefined`, so the CLI's normal `{success, data}` JSON envelope was never emitted. `nansen wallet list | jq .` had nothing valid to parse — breaking scripting/agent use, which this CLI is explicitly built for.

## Fix

- The `list` handler now returns the `listWallets()` result instead of `undefined`, so the existing CLI dispatcher wraps it in the standard `{"success":true,"data":{...}}` envelope and prints it to stdout — consistent with every other command.
- The human-readable summary (and the "No wallets found" message) now goes to `stderr` via the `errorOutput` dep, so a human running it interactively still gets the friendly view, but stdout stays clean JSON.
- As a side effect, `--pretty`, `--table`, and `--csv` now work on `wallet list` too, since they're handled generically by `formatOutput` once the command returns data instead of short-circuiting.
- Updated the existing Privy-provider test to assert against `errorOutput` instead of `log`, and added two new tests covering the stdout/stderr split for both the populated and empty-wallet cases.

## Testing

```
npm test
```
```
Test Files  1 failed | 65 passed (66)
     Tests  5 failed | 2675 passed | 16 skipped (2696)
```
The 5 failures are all pre-existing, in `src/__tests__/doctor.test.js`, and reproduce identically on `main` without this change — they rely on `chmod`-based unreadable-file simulation, which doesn't apply when tests run as root. Unrelated to this fix.

```
npm run lint
```
Clean, no output.

Manual verification:
```
$ nansen wallet list | jq .
{
  "success": true,
  "data": { "wallets": [...], "defaultWallet": "..." }
}
```
Human-readable summary confirmed on stderr, not stdout.

## Checklist
- [x] `npm test` passes (output above; unrelated pre-existing failures noted)
- [x] `npm run lint` passes
- [x] New code paths have tests
- [x] No `console.log` in core (uses injected `log`/`errorOutput` deps)
- [x] Changeset added (`patch` — bug fix, user-facing output behavior change)
- [x] `src/schema.json` — no changes needed (no new commands/options)
