### PR TITLE
fix(keychain): secure credentials fallback writes

### DIFF
--- a/.changeset/tighten-credentials-permissions.md
+++ b/.changeset/tighten-credentials-permissions.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Tighten POSIX permissions when rewriting the fallback wallet credentials file and refuse non-regular credential paths.

--- a/src/__tests__/keychain.test.js
+++ b/src/__tests__/keychain.test.js
@@ -72,6 +72,38 @@ describe('keychain', () => {
       expect(content).toContain('NANSEN_WALLET_PASSWORD_B64=');
       const b64 = content.match(/NANSEN_WALLET_PASSWORD_B64=(.+)/)[1].trim();
       expect(Buffer.from(b64, 'base64').toString('utf8')).toBe('mypassword');
+      if (originalPlatform !== 'win32') {
+        expect(fs.statSync(credPath).mode & 0o777).toBe(0o600);
+      }
+    });
+
+    it.skipIf(process.platform === 'win32')('should tighten permissions when rewriting an existing credentials file on POSIX', () => {
+      setPlatform('linux');
+      execFileSync.mockImplementation(() => { throw new Error('secret-tool unavailable'); });
+
+      const credDir = path.join(tempDir, '.nansen', 'wallets');
+      const credPath = path.join(credDir, '.credentials');
+      fs.mkdirSync(credDir, { recursive: true });
+      fs.writeFileSync(credPath, 'old credentials\n', { mode: 0o644 });
+
+      expect(storePassword('replacement-password')).toEqual({ stored: true, method: 'file' });
+      expect(fs.statSync(credPath).mode & 0o777).toBe(0o600);
+      expect(retrievePassword()).toEqual({ password: 'replacement-password', source: 'file' });
+    });
+
+    it.skipIf(process.platform === 'win32')('should refuse to overwrite a credentials symlink on POSIX', () => {
+      setPlatform('linux');
+      execFileSync.mockImplementation(() => { throw new Error('secret-tool unavailable'); });
+
+      const credDir = path.join(tempDir, '.nansen', 'wallets');
+      const credPath = path.join(credDir, '.credentials');
+      const targetPath = path.join(tempDir, 'symlink-target');
+      fs.mkdirSync(credDir, { recursive: true });
+      fs.writeFileSync(targetPath, 'leave unchanged\n');
+      fs.symlinkSync(targetPath, credPath);
+
+      expect(storePassword('replacement-password')).toEqual({ stored: false, method: 'none' });
+      expect(fs.readFileSync(targetPath, 'utf8')).toBe('leave unchanged\n');
     });
 
     it('should fall back to .credentials on unsupported platform', () => {

--- a/src/__tests__/keychain.test.js
+++ b/src/__tests__/keychain.test.js
@@ -84,7 +84,11 @@ describe('keychain', () => {
       const credDir = path.join(tempDir, '.nansen', 'wallets');
       const credPath = path.join(credDir, '.credentials');
       fs.mkdirSync(credDir, { recursive: true });
-      fs.writeFileSync(credPath, 'old credentials\n', { mode: 0o644 });
+      fs.writeFileSync(credPath, 'old credentials\n');
+      // writeFileSync's mode is filtered by the process umask, so set and
+      // verify the insecure starting state explicitly.
+      fs.chmodSync(credPath, 0o644);
+      expect(fs.statSync(credPath).mode & 0o777).toBe(0o644);
 
       expect(storePassword('replacement-password')).toEqual({ stored: true, method: 'file' });
       expect(fs.statSync(credPath).mode & 0o777).toBe(0o600);

--- a/src/keychain.js
+++ b/src/keychain.js
@@ -151,8 +151,33 @@ function credentialsFileWrite(password) {
       fs.mkdirSync(dir, { mode: 0o700, recursive: true });
     }
     const encoded = Buffer.from(password, 'utf8').toString('base64');
-    fs.writeFileSync(filePath, `NANSEN_WALLET_PASSWORD_B64=${encoded}\n`, { mode: 0o600 });
-    return true;
+    const content = `NANSEN_WALLET_PASSWORD_B64=${encoded}\n`;
+
+    // Windows does not implement POSIX modes or O_NOFOLLOW consistently.
+    if (process.platform === 'win32') {
+      fs.writeFileSync(filePath, content, { mode: 0o600 });
+      return true;
+    }
+
+    let fd;
+    try {
+      const flags = fs.constants.O_WRONLY
+        | fs.constants.O_CREAT
+        | fs.constants.O_NOFOLLOW
+        | fs.constants.O_NONBLOCK;
+      fd = fs.openSync(filePath, flags, 0o600);
+      if (!fs.fstatSync(fd).isFile()) throw new Error('Credentials path is not a regular file');
+
+      // Opening an existing file does not apply the requested mode. Tighten it
+      // before replacing the secret, then enforce the final mode after writing.
+      fs.fchmodSync(fd, 0o600);
+      fs.ftruncateSync(fd, 0);
+      fs.writeFileSync(fd, content, 'utf8');
+      fs.fchmodSync(fd, 0o600);
+      return true;
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd);
+    }
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

Fixes #585.

The wallet-password `.credentials` fallback previously used `fs.writeFileSync(path, ..., { mode: 0o600 })`. On POSIX, the mode option applies only when creating a file, so an existing `0644` file remained broadly readable. The same path-based write also followed a final-component symlink and overwrote its target.

## Changes

- use a POSIX file-descriptor write path with `O_NOFOLLOW` to reject credential symlinks
- use `O_NONBLOCK` and verify the opened descriptor is a regular file before modifying it
- enforce `0600` before truncating/writing an existing credential file and again after writing
- close the descriptor on every success or failure path
- preserve the existing Windows fallback, where POSIX mode and `O_NOFOLLOW` semantics are not portable
- add regression coverage for newly created permissions, existing `0644` files, symlink rejection, target preservation, and normal retrieval
- add a patch changeset

## Security properties

The POSIX path validates the opened descriptor rather than doing a separate path check followed by a path-based write. This keeps the final-component symlink check and subsequent write attached to the same opened object.

The scope remains local: this prevents unsafe fallback-file state from preserving broad permissions or redirecting the credential write through a symlink.

## Regression proof

With the new tests applied to the original implementation:

```text
Test Files  1 failed (1)
Tests       2 failed | 23 passed (25)
```

The failures showed:

- existing mode remained decimal `420` (`0644`) instead of `384` (`0600`)
- the symlink write returned `{ stored: true, method: 'file' }` instead of failing

With this fix:

```text
Test Files  1 passed (1)
Tests       25 passed (25)
```

Full suite:

```text
Test Files  66 passed (66)
Tests       2680 passed | 16 skipped (2696)
Duration    156.67s
```

Additional checks:

- `npm run lint` — passed
- `git diff --check` — passed
- `npm pack --ignore-scripts --dry-run` — passed; 85 package files, no test or audit artifacts included

All security regressions used a temporary HOME, fake passwords, mocked OS-keychain failure, and no external network access.

## Compatibility and risk

- no public API, command, schema, or credential format changes
- normal fallback creation and retrieval remain covered
- unsupported POSIX credential path types now fail closed
- Windows keeps the prior file-write behavior because the POSIX descriptor guarantees are not portable there

## Checklist

- [x] Tests pass (`npm test`)
- [x] `src/schema.json` updated if new commands or flags were added — no command or flag changes
- [x] `README.md` updated if new top-level commands or categories were added — no command changes
- [x] Changeset added (`.changeset/tighten-credentials-permissions.md`)
