### PR TITLE
fix(alerts): prevent duplicate create retries

### DIFF
--- a/.changeset/avoid-duplicate-alert-create.md
+++ b/.changeset/avoid-duplicate-alert-create.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Prevent duplicate alert creation after ambiguous network failures and keep Smart Alert mutations out of the response cache.

--- a/src/__tests__/alert-mutation-cache.test.js
+++ b/src/__tests__/alert-mutation-cache.test.js
@@ -1,0 +1,50 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+let NansenAPI;
+let originalHome;
+let tempHome;
+
+describe('Smart Alert mutation cache isolation', () => {
+  beforeAll(async () => {
+    originalHome = process.env.HOME;
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nansen-alert-cache-test-'));
+    process.env.HOME = tempHome;
+    vi.resetModules();
+    ({ NansenAPI } = await import('../api.js'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  afterAll(() => {
+    process.env.HOME = originalHome;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it.each([
+    ['alertsCreate', [{ name: 'Cache create', type: 'sm-token-flows' }]],
+    ['alertsUpdate', [{ id: 'cache-update', name: 'Updated' }]],
+    ['alertsToggle', [{ id: 'cache-toggle', isEnabled: true }]],
+    ['alertsDelete', ['cache-delete']],
+  ])('%s bypasses the response cache', async (method, args) => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ success: true }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const api = new NansenAPI('test-api-key', 'https://api.nansen.ai', {
+      cache: { enabled: true, ttl: 300 },
+    });
+    await api[method](...args);
+    await api[method](...args);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -3496,6 +3496,25 @@ describe('NansenAPI', () => {
       expect(result).toHaveProperty('id', 'alert-2');
     });
 
+    it('alertsCreate should not retry after an ambiguous network failure', async () => {
+      vi.useFakeTimers();
+      let createdAlerts = 0;
+      mockFetch.mockImplementation(async () => {
+        createdAlerts += 1;
+        throw new Error('response lost after create');
+      });
+
+      const params = { name: 'Test', type: 'sm-token-flows', timeWindow: '1h', channels: [], data: {} };
+      let thrownError;
+      const promise = api.alertsCreate(params).catch(error => { thrownError = error; });
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(thrownError?.message).toContain('response lost after create');
+      expect(createdAlerts).toBe(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
     it('alertsUpdate should PATCH /api/v1/smart-alert', async () => {
       setupMock(MOCK_RESPONSES.alertsUpdate);
       const result = await api.alertsUpdate({ id: 'alert-1', name: 'Updated Alert' });

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -3497,6 +3497,7 @@ describe('NansenAPI', () => {
     });
 
     it('alertsCreate should not retry after an ambiguous network failure', async () => {
+      if (LIVE_TEST) return;
       vi.useFakeTimers();
       let createdAlerts = 0;
       mockFetch.mockImplementation(async () => {

--- a/src/api.js
+++ b/src/api.js
@@ -1725,15 +1725,17 @@ export class NansenAPI {
   }
 
   async alertsCreate(params = {}) {
-    return this.request('/api/v1/smart-alert', params);
+    // Creating an alert is non-idempotent: a lost response after a committed
+    // create must not trigger another request through the generic retry loop.
+    return this.request('/api/v1/smart-alert', params, { cache: false, retry: false });
   }
 
   async alertsUpdate(params = {}) {
-    return this.request('/api/v1/smart-alert', params, { method: 'PATCH' });
+    return this.request('/api/v1/smart-alert', params, { method: 'PATCH', cache: false });
   }
 
   async alertsToggle(params = {}) {
-    return this.request('/api/v1/smart-alert/toggle', params, { method: 'PATCH' });
+    return this.request('/api/v1/smart-alert/toggle', params, { method: 'PATCH', cache: false });
   }
 
   async alertsGet(id) {
@@ -1745,7 +1747,7 @@ export class NansenAPI {
   }
 
   async alertsDelete(alertId) {
-    return this.request(`/api/v1/smart-alert/${encodeURIComponent(alertId)}`, {}, { method: 'DELETE' });
+    return this.request(`/api/v1/smart-alert/${encodeURIComponent(alertId)}`, {}, { method: 'DELETE', cache: false });
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #587.

Smart Alert mutations inherited the generic response cache, and the non-idempotent create path also inherited generic transport/status retries. A lost response could therefore submit the same create up to four times, while a repeated identical mutation could be satisfied from cache without reaching the API.

## Changes

- disable both retry and response caching for `alertsCreate()`
- disable response caching for `alertsUpdate()`, `alertsToggle()`, and `alertsDelete()`
- retain existing retry behavior for update/toggle/delete, whose requests set explicit state or delete a specific resource
- add a focused regression proving an ambiguous create failure produces one fetch attempt
- add parameterized cache regressions for all four mutation methods
- use fake timers so the pre-fix retry regression remains deterministic without waiting for backoff delays
- add a patch changeset

Read-only Smart Alert methods are unchanged.

## Regression proof

With the new tests applied to current `main` before the fix:

```text
Test Files  2 failed (2)
Tests       5 failed | 210 skipped (215)
```

The failures showed:

- `alertsCreate()` made 4 fetch attempts instead of 1 after an ambiguous network failure
- each mutation method made only 1 fetch across 2 identical calls because the second response came from cache

With this fix:

```text
Test Files  2 passed (2)
Tests       5 passed | 210 skipped (215)
```

Full suite:

```text
Test Files  67 passed (67)
Tests       2683 passed | 16 skipped (2699)
Duration    181.21s
```

Additional checks:

- `npm run lint` — passed
- `git diff --check` — passed
- `npm pack --ignore-scripts --dry-run` — passed; 85 package files, no test artifacts included
- `npm audit --omit=dev --json` — 0 production vulnerabilities

All regression tests used a temporary HOME, fake credentials, mocked fetch responses, and no external network access.

## Compatibility and risk

- no public API, CLI, schema, or response-format changes
- a failed create now returns after the first ambiguous failure instead of retrying
- identical mutation calls always reach the API rather than reusing a local cached response
- read-only alert caching and generic retry behavior elsewhere are unchanged
- this does not assume or claim server-side create idempotency; disabling client replay is the safe behavior while no idempotency contract is available

## Checklist

- [x] Tests pass (`npm test`)
- [x] `src/schema.json` updated if new commands or flags were added — no command or flag changes
- [x] `README.md` updated if new top-level commands or categories were added — no command changes
- [x] Changeset added (`.changeset/avoid-duplicate-alert-create.md`)
