### PR TITLE
fix: alerts list --limit/--offset reject invalid input instead of silently misbehaving (#578)

### DIFF
--- a/.changeset/fix-alerts-list-limit-offset.md
+++ b/.changeset/fix-alerts-list-limit-offset.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix `nansen alerts list --limit`/`--offset` silently misbehaving on invalid or edge-case input. `--limit 0` and `--offset 0` were treated as "not set" (falsy check) and silently ignored instead of honored; a non-numeric value like `--limit abc` silently returned zero results (`Array.prototype.slice` coerces `NaN` to `0`) instead of erroring; and a negative `--offset` was silently accepted by `slice()`, which treats negative indices as "from the end" — returning the wrong records instead of rejecting the input. Both flags are now validated as non-negative integers, matching the strict-validation convention already used elsewhere in the CLI (e.g. `--slippage`), and throw a clear `INVALID_PARAMS` error otherwise.

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -776,6 +776,48 @@ describe('alerts list — client-side filtering', () => {
     expect(result[1].id).toBe('3');
   });
 
+  it('should honor --limit 0 (return zero results) instead of treating it as unset', async () => {
+    const { mockApi, cmd } = setup();
+    const result = await cmd(['list'], mockApi, {}, { limit: 0 });
+    expect(result).toHaveLength(0);
+  });
+
+  it('should honor --offset 0 (a no-op, not "unset") without erroring', async () => {
+    const { mockApi, cmd } = setup();
+    const result = await cmd(['list'], mockApi, {}, { offset: 0 });
+    expect(result).toHaveLength(5);
+  });
+
+  it('should reject a non-numeric --limit instead of silently returning zero results', async () => {
+    const { mockApi, cmd } = setup();
+    await expect(cmd(['list'], mockApi, {}, { limit: 'abc' }))
+      .rejects.toThrow('--limit must be a non-negative integer');
+  });
+
+  it('should reject a non-numeric --offset instead of silently no-op-ing', async () => {
+    const { mockApi, cmd } = setup();
+    await expect(cmd(['list'], mockApi, {}, { offset: 'abc' }))
+      .rejects.toThrow('--offset must be a non-negative integer');
+  });
+
+  it('should reject a negative --limit', async () => {
+    const { mockApi, cmd } = setup();
+    await expect(cmd(['list'], mockApi, {}, { limit: -1 }))
+      .rejects.toThrow('--limit must be a non-negative integer');
+  });
+
+  it('should reject a negative --offset instead of silently slicing from the end', async () => {
+    const { mockApi, cmd } = setup();
+    await expect(cmd(['list'], mockApi, {}, { offset: -1 }))
+      .rejects.toThrow('--offset must be a non-negative integer');
+  });
+
+  it('should reject a non-integer --limit (e.g. "2.5")', async () => {
+    const { mockApi, cmd } = setup();
+    await expect(cmd(['list'], mockApi, {}, { limit: '2.5' }))
+      .rejects.toThrow('--limit must be a non-negative integer');
+  });
+
   it('should combine type + chain filters', async () => {
     const { mockApi, cmd } = setup();
     const result = await cmd(['list'], mockApi, {}, { type: 'sm-token-flows', chain: 'base' });

--- a/src/commands/alerts.js
+++ b/src/commands/alerts.js
@@ -606,9 +606,32 @@ USAGE:
             });
           }
 
-          // Pagination (applied after filtering)
-          if (options.offset) alerts = alerts.slice(Number(options.offset));
-          if (options.limit) alerts = alerts.slice(0, Number(options.limit));
+          // Pagination (applied after filtering). Validate strictly rather than
+          // silently misbehaving on bad input:
+          //   - `if (options.offset)` / `if (options.limit)` treat 0 as "not set"
+          //     (falsy), so `--offset 0` / `--limit 0` were silently ignored
+          //     instead of being honored.
+          //   - `Number("abc")` is NaN, and `Array.prototype.slice` coerces a NaN
+          //     argument to 0 — so `--offset abc` silently became a no-op and
+          //     `--limit abc` silently returned zero results, with no error
+          //     telling the caller their input wasn't a number at all.
+          //   - Negative values (`--offset -1`) were accepted and fed straight
+          //     into `slice()`, which treats negative indices as "from the end" —
+          //     silently returning the wrong slice instead of rejecting the input.
+          if (options.offset !== undefined) {
+            const offset = Number(options.offset);
+            if (!Number.isInteger(offset) || offset < 0) {
+              throw new NansenError(`--offset must be a non-negative integer, got "${options.offset}"`, ErrorCode.INVALID_PARAMS);
+            }
+            alerts = alerts.slice(offset);
+          }
+          if (options.limit !== undefined) {
+            const limit = Number(options.limit);
+            if (!Number.isInteger(limit) || limit < 0) {
+              throw new NansenError(`--limit must be a non-negative integer, got "${options.limit}"`, ErrorCode.INVALID_PARAMS);
+            }
+            alerts = alerts.slice(0, limit);
+          }
 
           return alerts;
         },


### PR DESCRIPTION
Fixes #578.

## Problem

`nansen alerts list --limit`/`--offset` silently misbehaved instead of erroring on bad input, which is dangerous for a command whose whole audience is scripts and agents:

- `if (options.offset)` / `if (options.limit)` treat `0` as falsy, so `--limit 0` and `--offset 0` were silently ignored (treated as "not set") instead of honored.
- `Number("abc")` is `NaN`, and `Array.prototype.slice` coerces a `NaN` argument to `0` — so `--offset abc` silently became a no-op and `--limit abc` silently returned **zero** results, with no error telling the caller their input wasn't a number.
- A negative `--offset` (e.g. `-1`) was accepted and fed straight into `slice()`, which treats negative indices as "from the end" — silently returning the wrong records instead of rejecting the input.

## Fix

`--limit` and `--offset` are now validated as non-negative integers (checked with `Number.isInteger`, not just presence), matching the strict client-side validation convention already used elsewhere in the CLI (e.g. `parseSlippageBps` in `bridge.js`, `buildPagination` in `query-options.js`). Invalid input now throws a `NansenError` with `ErrorCode.INVALID_PARAMS` and a message naming the bad value, consistent with how this same handler already rejects `--enabled --disabled` together.

`0` is now correctly distinguished from "unset" via `!== undefined` checks instead of truthiness.

## Testing

```
npm test
```
```
Test Files  1 failed | 65 passed (66)
     Tests  5 failed | 2682 passed | 16 skipped (2703)
```
The 5 failures are pre-existing, in `src/__tests__/doctor.test.js`, and reproduce identically on `main` without this change — they rely on `chmod`-based unreadable-file simulation, which doesn't apply when tests run as root. Unrelated to this fix. 7 new tests added for this fix, all passing.

```
npm run lint
```
Clean, no output.

Manual verification:
```
--limit 0   -> [] (previously returned everything)
--offset 0  -> full list (previously already worked, now explicit)
--limit abc -> throws "--limit must be a non-negative integer, got \"abc\"" (previously silently returned [])
--offset -1 -> throws "--offset must be a non-negative integer, got \"-1\"" (previously silently returned the last record)
```

## Checklist
- [x] `npm test` passes (output above; unrelated pre-existing failures noted)
- [x] `npm run lint` passes
- [x] New code paths have tests (7 added, covering 0, non-numeric, negative, and non-integer values for both flags)
- [x] No `console.log` in core
- [x] Error messages are actionable (name the flag and the bad value)
- [x] Changeset added (`patch` — bug fix, corrects previously-silent wrong behavior)
- [x] `src/schema.json` — no changes needed (no new commands/options, just stricter validation of existing ones)
