### PR TITLE
fix(cli): validate retry counts

### DIFF
--- a/.changeset/validate-cli-retries.md
+++ b/.changeset/validate-cli-retries.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Reject invalid retry counts before constructing the API client.

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -2715,6 +2715,19 @@ describe('--no-retry and --retries flags', () => {
     expect(NansenAPIClass).not.toHaveBeenCalled();
   });
 
+  it('should reject repeated valued --retries options clearly', async () => {
+    const NansenAPIClass = vi.fn();
+
+    const result = await runCLI(
+      ['smart-money', 'netflow', '--retries', '2', '--retries', '3'],
+      { ...mockDeps(), NansenAPIClass },
+    );
+
+    expect(result.data.error).toBe('--retries may only be specified once');
+    expect(result.data.code).toBe(ErrorCode.INVALID_PARAMS);
+    expect(NansenAPIClass).not.toHaveBeenCalled();
+  });
+
   it.each(['', '   '])('should reject empty --retries value %#', async (value) => {
     const NansenAPIClass = vi.fn();
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -2699,6 +2699,35 @@ describe('--no-retry and --retries flags', () => {
     expect(_exitCode).toBe(1);
   });
 
+  it.each([
+    ['--retries', '2', '--retries'],
+    ['--retries', '--retries', '2'],
+  ])('should reject a valueless repeated --retries occurrence: %s %s %s', async (...retryArgs) => {
+    const NansenAPIClass = vi.fn();
+
+    const result = await runCLI(
+      ['smart-money', 'netflow', ...retryArgs],
+      { ...mockDeps(), NansenAPIClass },
+    );
+
+    expect(result.data.error).toBe('--retries requires a non-negative safe integer value');
+    expect(result.data.code).toBe(ErrorCode.INVALID_PARAMS);
+    expect(NansenAPIClass).not.toHaveBeenCalled();
+  });
+
+  it.each(['', '   '])('should reject empty --retries value %#', async (value) => {
+    const NansenAPIClass = vi.fn();
+
+    const result = await runCLI(
+      ['smart-money', 'netflow', '--retries', value],
+      { ...mockDeps(), NansenAPIClass },
+    );
+
+    expect(result.data.error).toBe('--retries requires a non-negative safe integer value');
+    expect(result.data.code).toBe(ErrorCode.INVALID_PARAMS);
+    expect(NansenAPIClass).not.toHaveBeenCalled();
+  });
+
   it('should validate --retries even when --no-retry overrides it', async () => {
     const NansenAPIClass = vi.fn();
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -2662,6 +2662,78 @@ describe('--no-retry and --retries flags', () => {
     
     expect(capturedOptions.retry.maxRetries).toBe(0);
   });
+
+  it.each(['-1', '1.5', 'NaN', 'Infinity', '9007199254740992'])(
+    'should reject invalid --retries value %s before constructing the API client',
+    async (value) => {
+      const NansenAPIClass = vi.fn();
+
+      const result = await runCLI(
+        ['smart-money', 'netflow', '--retries', value],
+        { ...mockDeps(), NansenAPIClass },
+      );
+
+      expect(result).toMatchObject({
+        type: 'error',
+        data: {
+          error: `--retries must be a non-negative safe integer; received: ${value}`,
+          code: ErrorCode.INVALID_PARAMS,
+        },
+      });
+      expect(NansenAPIClass).not.toHaveBeenCalled();
+      expect(_exitCode).toBe(1);
+    },
+  );
+
+  it('should reject --retries without a value before constructing the API client', async () => {
+    const NansenAPIClass = vi.fn();
+
+    const result = await runCLI(
+      ['smart-money', 'netflow', '--retries'],
+      { ...mockDeps(), NansenAPIClass },
+    );
+
+    expect(result.data.error).toBe('--retries requires a non-negative safe integer value');
+    expect(result.data.code).toBe(ErrorCode.INVALID_PARAMS);
+    expect(NansenAPIClass).not.toHaveBeenCalled();
+    expect(_exitCode).toBe(1);
+  });
+
+  it('should validate --retries even when --no-retry overrides it', async () => {
+    const NansenAPIClass = vi.fn();
+
+    const result = await runCLI(
+      ['smart-money', 'netflow', '--no-retry', '--retries', '-1'],
+      { ...mockDeps(), NansenAPIClass },
+    );
+
+    expect(result.data.error).toBe('--retries must be a non-negative safe integer; received: -1');
+    expect(result.data.code).toBe(ErrorCode.INVALID_PARAMS);
+    expect(NansenAPIClass).not.toHaveBeenCalled();
+  });
+
+  it('should allow the largest safe integer for --retries', async () => {
+    let capturedOptions;
+    const deps = {
+      ...mockDeps(),
+      NansenAPIClass: function MockAPI(key, url, opts) {
+        capturedOptions = opts;
+        this.smartMoneyNetflow = vi.fn().mockResolvedValue({ data: [] });
+      },
+    };
+
+    await runCLI(['smart-money', 'netflow', '--retries', '9007199254740991'], deps);
+
+    expect(capturedOptions.retry.maxRetries).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('should describe retry numeric boundaries in the schema', () => {
+    expect(SCHEMA.globalOptions.retries).toMatchObject({
+      type: 'integer',
+      minimum: 0,
+      maximum: Number.MAX_SAFE_INTEGER,
+    });
+  });
 });
 
 // =================== P2: parseSort with Special Characters ===================

--- a/src/cli.js
+++ b/src/cli.js
@@ -220,17 +220,21 @@ export function parseArgs(args) {
 }
 
 function parseNonNegativeSafeIntegerOption(name, options, flags, defaultValue) {
-  if (options[name] === undefined) {
-    if (flags[name]) {
-      throw new NansenError(
-        `--${name} requires a non-negative safe integer value`,
-        ErrorCode.INVALID_PARAMS,
-      );
-    }
-    return defaultValue;
+  if (flags[name]) {
+    throw new NansenError(
+      `--${name} requires a non-negative safe integer value`,
+      ErrorCode.INVALID_PARAMS,
+    );
   }
+  if (options[name] === undefined) return defaultValue;
 
   const rawValue = options[name];
+  if (typeof rawValue === 'string' && rawValue.trim() === '') {
+    throw new NansenError(
+      `--${name} requires a non-negative safe integer value`,
+      ErrorCode.INVALID_PARAMS,
+    );
+  }
   const value = typeof rawValue === 'string' || typeof rawValue === 'number'
     ? Number(rawValue)
     : NaN;

--- a/src/cli.js
+++ b/src/cli.js
@@ -219,6 +219,30 @@ export function parseArgs(args) {
   return result;
 }
 
+function parseNonNegativeSafeIntegerOption(name, options, flags, defaultValue) {
+  if (options[name] === undefined) {
+    if (flags[name]) {
+      throw new NansenError(
+        `--${name} requires a non-negative safe integer value`,
+        ErrorCode.INVALID_PARAMS,
+      );
+    }
+    return defaultValue;
+  }
+
+  const rawValue = options[name];
+  const value = typeof rawValue === 'string' || typeof rawValue === 'number'
+    ? Number(rawValue)
+    : NaN;
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new NansenError(
+      `--${name} must be a non-negative safe integer; received: ${String(rawValue)}`,
+      ErrorCode.INVALID_PARAMS,
+    );
+  }
+  return value;
+}
+
 // Format a single value for table display
 export function formatValue(val) {
   if (val === null || val === undefined) return '';
@@ -2038,9 +2062,10 @@ export async function runCLI(rawArgs, deps = {}) {
 
   try {
     // Configure retry options
+    const maxRetries = parseNonNegativeSafeIntegerOption('retries', options, flags, 3);
     const retryOptions = flags['no-retry']
       ? { maxRetries: 0 }
-      : { maxRetries: options.retries !== undefined ? (Number.isNaN(parseInt(options.retries, 10)) ? 3 : parseInt(options.retries, 10)) : 3 };
+      : { maxRetries };
 
     // Configure cache options
     const cacheTtl = options['cache-ttl'] !== undefined ? parseInt(options['cache-ttl'], 10) : 300;

--- a/src/cli.js
+++ b/src/cli.js
@@ -229,6 +229,12 @@ function parseNonNegativeSafeIntegerOption(name, options, flags, defaultValue) {
   if (options[name] === undefined) return defaultValue;
 
   const rawValue = options[name];
+  if (Array.isArray(rawValue)) {
+    throw new NansenError(
+      `--${name} may only be specified once`,
+      ErrorCode.INVALID_PARAMS,
+    );
+  }
   if (typeof rawValue === 'string' && rawValue.trim() === '') {
     throw new NansenError(
       `--${name} requires a non-negative safe integer value`,

--- a/src/schema.json
+++ b/src/schema.json
@@ -2540,9 +2540,11 @@
       "description": "Disable automatic retry on rate limits/errors"
     },
     "retries": {
-      "type": "number",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991,
       "default": 3,
-      "description": "Max retry attempts"
+      "description": "Max retry attempts (non-negative safe integer)"
     },
     "format": {
       "type": "string",


### PR DESCRIPTION
## Summary

Fixes #590.

`--retries` was parsed with `parseInt()` and accepted negative, fractional, missing, non-finite, and unsafe-integer inputs. In particular, `--retries -1` skipped the request loop entirely and caused `formatError()` to crash on an undefined error.

## Changes

- parse the complete retries value instead of accepting numeric prefixes
- require a non-negative safe integer
- reject a valueless `--retries` option
- validate malformed `--retries` even when `--no-retry` overrides the effective retry count
- return a structured `INVALID_PARAMS` error before API construction or network activity
- update the schema to publish integer/minimum/maximum constraints
- add invalid, missing, conflicting-option, and boundary regressions
- add a patch changeset

This PR intentionally covers only `--retries`; the separate `--cache-ttl` fix is tracked in #591.

## Regression proof

The final retry tests applied to current `main` before the fix:

```text
Test Files  1 failed (1)
Tests       12 failed | 1 passed | 475 skipped (488)
```

The valid `Number.MAX_SAFE_INTEGER` boundary passed; malformed-value, valueless, `--no-retry` conflict, and schema assertions failed.

With this fix:

```text
Test Files  1 passed (1)
Tests       14 passed | 475 skipped (489)
```

Real CLI verification:

```text
$ nansen research smart-money netflow --retries -1
{"success":false,"error":"--retries must be a non-negative safe integer; received: -1","code":"INVALID_PARAMS","status":null}
exit=1
```

The command ran with a fake API key, temporary HOME, and external network access disabled; no API client/network path was entered.

Full suite, run without the competing parallel suite that had caused unrelated trading-test timeouts:

```text
Test Files  66 passed (66)
Tests       2691 passed | 16 skipped (2707)
```

Additional checks:

- `npm run lint` — passed
- `git diff --check` — passed
- `npm pack --ignore-scripts --dry-run` — passed; 85 package files, no tests included

## Compatibility and risk

- valid existing values such as `0`, `3`, and `7` retain their behavior
- `Number.MAX_SAFE_INTEGER` is accepted exactly
- malformed values that were previously truncated, defaulted, or allowed now fail early
- no command, API method, or response schema changes beyond the documented option constraints

## Checklist

- [x] Tests pass (`npm test`)
- [x] `src/schema.json` updated for the corrected global option contract
- [x] `README.md` updated if new top-level commands or categories were added — none added
- [x] Changeset added (`.changeset/validate-cli-retries.md`)
