### PR TITLE
fix(cli): validate cache TTL values

### DIFF
--- a/.changeset/validate-cli-cache-ttl.md
+++ b/.changeset/validate-cli-cache-ttl.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Reject invalid cache TTL values before constructing the API client.

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -3526,6 +3526,19 @@ describe('--cache flag integration', () => {
     expect(NansenAPIClass).not.toHaveBeenCalled();
   });
 
+  it('should reject repeated valued --cache-ttl options clearly', async () => {
+    const NansenAPIClass = vi.fn();
+
+    const result = await runCLI(
+      ['smart-money', 'netflow', '--cache', '--cache-ttl', '60', '--cache-ttl', '120'],
+      { ...mockDeps(), NansenAPIClass },
+    );
+
+    expect(result.data.error).toBe('--cache-ttl may only be specified once');
+    expect(result.data.code).toBe(ErrorCode.INVALID_PARAMS);
+    expect(NansenAPIClass).not.toHaveBeenCalled();
+  });
+
   it.each(['', '   '])('should reject empty --cache-ttl value %#', async (value) => {
     const NansenAPIClass = vi.fn();
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -3474,6 +3474,81 @@ describe('--cache flag integration', () => {
     expect(capturedOptions.cache.ttl).toBe(60);
   });
 
+  it.each(['-1', '1.5', 'NaN', 'Infinity', '9007199254740992'])(
+    'should reject invalid --cache-ttl value %s before constructing the API client',
+    async (value) => {
+      const NansenAPIClass = vi.fn();
+
+      const result = await runCLI(
+        ['smart-money', 'netflow', '--cache', '--cache-ttl', value],
+        { ...mockDeps(), NansenAPIClass },
+      );
+
+      expect(result).toMatchObject({
+        type: 'error',
+        data: {
+          error: `--cache-ttl must be a non-negative safe integer; received: ${value}`,
+          code: ErrorCode.INVALID_PARAMS,
+        },
+      });
+      expect(NansenAPIClass).not.toHaveBeenCalled();
+      expect(_exitCode).toBe(1);
+    },
+  );
+
+  it('should reject --cache-ttl without a value before constructing the API client', async () => {
+    const NansenAPIClass = vi.fn();
+
+    const result = await runCLI(
+      ['smart-money', 'netflow', '--cache', '--cache-ttl'],
+      { ...mockDeps(), NansenAPIClass },
+    );
+
+    expect(result.data.error).toBe('--cache-ttl requires a non-negative safe integer value');
+    expect(result.data.code).toBe(ErrorCode.INVALID_PARAMS);
+    expect(NansenAPIClass).not.toHaveBeenCalled();
+    expect(_exitCode).toBe(1);
+  });
+
+  it('should validate --cache-ttl even when --no-cache overrides it', async () => {
+    const NansenAPIClass = vi.fn();
+
+    const result = await runCLI(
+      ['smart-money', 'netflow', '--no-cache', '--cache-ttl', '-1'],
+      { ...mockDeps(), NansenAPIClass },
+    );
+
+    expect(result.data.error).toBe('--cache-ttl must be a non-negative safe integer; received: -1');
+    expect(result.data.code).toBe(ErrorCode.INVALID_PARAMS);
+    expect(NansenAPIClass).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['0', 0],
+    ['9007199254740991', Number.MAX_SAFE_INTEGER],
+  ])('should allow --cache-ttl boundary value %s', async (value, expected) => {
+    let capturedOptions;
+    const deps = {
+      ...mockDeps(),
+      NansenAPIClass: function MockAPI(key, url, opts) {
+        capturedOptions = opts;
+        this.smartMoneyNetflow = vi.fn().mockResolvedValue({ data: [] });
+      },
+    };
+
+    await runCLI(['smart-money', 'netflow', '--cache', '--cache-ttl', value], deps);
+
+    expect(capturedOptions.cache.ttl).toBe(expected);
+  });
+
+  it('should describe cache TTL numeric boundaries in the schema', () => {
+    expect(SCHEMA.globalOptions['cache-ttl']).toMatchObject({
+      type: 'integer',
+      minimum: 0,
+      maximum: Number.MAX_SAFE_INTEGER,
+    });
+  });
+
   it('should not enable cache by default', async () => {
     let capturedOptions;
     const deps = {

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -3510,6 +3510,47 @@ describe('--cache flag integration', () => {
     expect(_exitCode).toBe(1);
   });
 
+  it.each([
+    ['--cache-ttl', '60', '--cache-ttl'],
+    ['--cache-ttl', '--cache-ttl', '60'],
+  ])('should reject a valueless repeated --cache-ttl occurrence: %s %s %s', async (...ttlArgs) => {
+    const NansenAPIClass = vi.fn();
+
+    const result = await runCLI(
+      ['smart-money', 'netflow', '--cache', ...ttlArgs],
+      { ...mockDeps(), NansenAPIClass },
+    );
+
+    expect(result.data.error).toBe('--cache-ttl requires a non-negative safe integer value');
+    expect(result.data.code).toBe(ErrorCode.INVALID_PARAMS);
+    expect(NansenAPIClass).not.toHaveBeenCalled();
+  });
+
+  it.each(['', '   '])('should reject empty --cache-ttl value %#', async (value) => {
+    const NansenAPIClass = vi.fn();
+
+    const result = await runCLI(
+      ['smart-money', 'netflow', '--cache', '--cache-ttl', value],
+      { ...mockDeps(), NansenAPIClass },
+    );
+
+    expect(result.data.error).toBe('--cache-ttl requires a non-negative safe integer value');
+    expect(result.data.code).toBe(ErrorCode.INVALID_PARAMS);
+    expect(NansenAPIClass).not.toHaveBeenCalled();
+  });
+
+  it('should validate --cache-ttl even when cache is not enabled', async () => {
+    const NansenAPIClass = vi.fn();
+
+    const result = await runCLI(
+      ['smart-money', 'netflow', '--cache-ttl', 'Infinity'],
+      { ...mockDeps(), NansenAPIClass },
+    );
+
+    expect(result.data.code).toBe(ErrorCode.INVALID_PARAMS);
+    expect(NansenAPIClass).not.toHaveBeenCalled();
+  });
+
   it('should validate --cache-ttl even when --no-cache overrides it', async () => {
     const NansenAPIClass = vi.fn();
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -220,17 +220,21 @@ export function parseArgs(args) {
 }
 
 function parseNonNegativeSafeIntegerOption(name, options, flags, defaultValue) {
-  if (options[name] === undefined) {
-    if (flags[name]) {
-      throw new NansenError(
-        `--${name} requires a non-negative safe integer value`,
-        ErrorCode.INVALID_PARAMS,
-      );
-    }
-    return defaultValue;
+  if (flags[name]) {
+    throw new NansenError(
+      `--${name} requires a non-negative safe integer value`,
+      ErrorCode.INVALID_PARAMS,
+    );
   }
+  if (options[name] === undefined) return defaultValue;
 
   const rawValue = options[name];
+  if (typeof rawValue === 'string' && rawValue.trim() === '') {
+    throw new NansenError(
+      `--${name} requires a non-negative safe integer value`,
+      ErrorCode.INVALID_PARAMS,
+    );
+  }
   const value = typeof rawValue === 'string' || typeof rawValue === 'number'
     ? Number(rawValue)
     : NaN;

--- a/src/cli.js
+++ b/src/cli.js
@@ -229,6 +229,12 @@ function parseNonNegativeSafeIntegerOption(name, options, flags, defaultValue) {
   if (options[name] === undefined) return defaultValue;
 
   const rawValue = options[name];
+  if (Array.isArray(rawValue)) {
+    throw new NansenError(
+      `--${name} may only be specified once`,
+      ErrorCode.INVALID_PARAMS,
+    );
+  }
   if (typeof rawValue === 'string' && rawValue.trim() === '') {
     throw new NansenError(
       `--${name} requires a non-negative safe integer value`,

--- a/src/cli.js
+++ b/src/cli.js
@@ -219,6 +219,30 @@ export function parseArgs(args) {
   return result;
 }
 
+function parseNonNegativeSafeIntegerOption(name, options, flags, defaultValue) {
+  if (options[name] === undefined) {
+    if (flags[name]) {
+      throw new NansenError(
+        `--${name} requires a non-negative safe integer value`,
+        ErrorCode.INVALID_PARAMS,
+      );
+    }
+    return defaultValue;
+  }
+
+  const rawValue = options[name];
+  const value = typeof rawValue === 'string' || typeof rawValue === 'number'
+    ? Number(rawValue)
+    : NaN;
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new NansenError(
+      `--${name} must be a non-negative safe integer; received: ${String(rawValue)}`,
+      ErrorCode.INVALID_PARAMS,
+    );
+  }
+  return value;
+}
+
 // Format a single value for table display
 export function formatValue(val) {
   if (val === null || val === undefined) return '';
@@ -1179,7 +1203,7 @@ export function buildCommands(deps = {}) {
           log('CACHE OPTIONS (for any command):');
           log('  --cache               Enable caching for this session');
           log('  --no-cache            Bypass cache for this request');
-          log('  --cache-ttl <seconds> Set cache TTL (default: 300)');
+          log('  --cache-ttl <seconds> Set non-negative safe integer cache TTL (default: 300)');
         }
       };
       
@@ -2043,10 +2067,10 @@ export async function runCLI(rawArgs, deps = {}) {
       : { maxRetries: options.retries !== undefined ? (Number.isNaN(parseInt(options.retries, 10)) ? 3 : parseInt(options.retries, 10)) : 3 };
 
     // Configure cache options
-    const cacheTtl = options['cache-ttl'] !== undefined ? parseInt(options['cache-ttl'], 10) : 300;
+    const cacheTtl = parseNonNegativeSafeIntegerOption('cache-ttl', options, flags, 300);
     const cacheOptions = {
       enabled: flags['cache'] && !flags['no-cache'],
-      ttl: Number.isNaN(cacheTtl) ? 300 : cacheTtl
+      ttl: cacheTtl
     };
 
     const defaultHeaders = {};

--- a/src/schema.json
+++ b/src/schema.json
@@ -2544,6 +2544,13 @@
       "default": 3,
       "description": "Max retry attempts"
     },
+    "cache-ttl": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991,
+      "default": 300,
+      "description": "Cache TTL in seconds (non-negative safe integer; 0 disables cache reads)"
+    },
     "format": {
       "type": "string",
       "enum": [


### PR DESCRIPTION
## Summary

Fixes #591.

`--cache-ttl` was parsed with `parseInt()` and accepted negative, fractional, missing, non-finite, and unsafe-integer inputs. The option was also absent from the global command schema.

## Changes

- parse the complete cache-TTL value instead of accepting numeric prefixes
- require a non-negative safe integer
- reject a valueless `--cache-ttl` option
- validate malformed TTL values even when `--no-cache` disables effective cache reads
- return a structured `INVALID_PARAMS` error before API construction or network activity
- add the option's integer/minimum/maximum/default contract to `schema.json`
- update cache help text with the numeric contract
- add invalid, missing, conflicting-option, and boundary regressions
- add a patch changeset

This PR intentionally covers only `--cache-ttl`; the separate `--retries` fix is tracked in #590.

## Regression proof

The final cache-TTL tests applied to current `main` before the fix:

```text
Test Files  1 failed (1)
Tests       13 failed | 2 passed | 475 skipped (490)
```

The valid `0` and `Number.MAX_SAFE_INTEGER` boundaries passed; malformed-value, valueless, `--no-cache` conflict, and schema assertions failed.

With this fix:

```text
Test Files  1 passed (1)
Tests       16 passed | 475 skipped (491)
```

Real CLI verification:

```text
$ nansen research smart-money netflow --cache --cache-ttl Infinity
{"success":false,"error":"--cache-ttl must be a non-negative safe integer; received: Infinity","code":"INVALID_PARAMS","status":null}
exit=1
```

The command ran with a fake API key, temporary HOME, and external network access disabled; no API client/network path was entered.

Full suite, run without the competing parallel suite that had caused unrelated trading-test timeouts:

```text
Test Files  66 passed (66)
Tests       2693 passed | 16 skipped (2709)
```

Additional checks:

- `npm run lint` — passed
- `git diff --check` — passed
- `npm pack --ignore-scripts --dry-run` — passed; 85 package files, no tests included

## Compatibility and risk

- valid existing TTL values retain their behavior
- `0` continues to disable cache reads
- `Number.MAX_SAFE_INTEGER` is accepted exactly
- malformed values that were previously truncated, defaulted, or allowed now fail early
- no command or API method changes; the schema now documents the option already accepted by the CLI

## Checklist

- [x] Tests pass (`npm test`)
- [x] `src/schema.json` updated for the corrected global option contract
- [x] `README.md` updated if new top-level commands or categories were added — none added
- [x] Changeset added (`.changeset/validate-cli-cache-ttl.md`)
