### PR TITLE
fix(cache): keep a cached array response an array

### DIFF
--- a/.changeset/cached-array-response-shape.md
+++ b/.changeset/cached-array-response-shape.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix `--cache` reshaping a cached array response into an object. Endpoints that return a top-level JSON array were object-spread on a cache hit, so `[a, b]` came back as `{ 0: a, 1: b }` and every `Array.isArray()` branch downstream stopped matching — the first call printed rows and the second printed nothing. Cached arrays now stay arrays, and primitive response bodies are returned untouched instead of being exploded into character maps.

--- a/src/__tests__/api-cache.test.js
+++ b/src/__tests__/api-cache.test.js
@@ -1,0 +1,102 @@
+/**
+ * Response cache tests — `nansen --cache`.
+ *
+ * The cache has to hand back exactly what the network handed back. A cached
+ * response that changes shape is worse than no cache at all: the first call
+ * renders and the second one silently does not.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+let tempHome;
+let prevHome;
+let prevUserProfile;
+
+/**
+ * api.js resolves the cache directory from HOME at import time, so the temp
+ * home has to be in place before the module is loaded.
+ */
+async function freshApi(payload, options = {}) {
+  vi.resetModules();
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => JSON.parse(JSON.stringify(payload)),
+  })));
+  const { NansenAPI } = await import('../api.js');
+  return new NansenAPI('test-key', 'https://api.nansen.ai', {
+    cache: { enabled: true, ttl: 300 },
+    ...options,
+  });
+}
+
+beforeEach(() => {
+  tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nansen-api-cache-'));
+  prevHome = process.env.HOME;
+  prevUserProfile = process.env.USERPROFILE;
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+  if (prevUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = prevUserProfile;
+  fs.rmSync(tempHome, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+});
+
+describe('response cache preserves the payload shape', () => {
+  it('returns a top-level array as an array on a cache hit', async () => {
+    const rows = [{ symbol: 'ETH', volume: 1 }, { symbol: 'SOL', volume: 2 }];
+    const api = await freshApi(rows);
+
+    const live = await api.request('/api/v1/demo', { chain: 'ethereum' });
+    const cached = await api.request('/api/v1/demo', { chain: 'ethereum' });
+
+    expect(Array.isArray(live)).toBe(true);
+    // Object-spreading the cached array used to yield { 0: …, 1: … }, which
+    // every Array.isArray() branch in the output formatters then skipped.
+    expect(Array.isArray(cached)).toBe(true);
+    expect(cached).toHaveLength(2);
+    expect([...cached]).toEqual(rows);
+    expect(cached._meta.fromCache).toBe(true);
+    expect(cached._meta.cacheAge).toBeTypeOf('number');
+  });
+
+  it('serves the cache on the second call rather than refetching', async () => {
+    const api = await freshApi([{ symbol: 'ETH' }]);
+
+    await api.request('/api/v1/demo', {});
+    await api.request('/api/v1/demo', {});
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('still merges _meta into an object response', async () => {
+    const body = { data: [{ symbol: 'ETH' }], total: 1 };
+    const api = await freshApi(body);
+
+    await api.request('/api/v1/demo', {});
+    const cached = await api.request('/api/v1/demo', {});
+
+    expect(Array.isArray(cached)).toBe(false);
+    expect(cached.data).toEqual(body.data);
+    expect(cached.total).toBe(1);
+    expect(cached._meta.fromCache).toBe(true);
+  });
+
+  it('hands back a primitive response untouched', async () => {
+    const api = await freshApi('plain-text-body');
+
+    await api.request('/api/v1/demo', {});
+    const cached = await api.request('/api/v1/demo', {});
+
+    // A string cannot carry the marker; spreading one used to explode it into
+    // { 0: 'p', 1: 'l', … }.
+    expect(cached).toBe('plain-text-body');
+  });
+});

--- a/src/api.js
+++ b/src/api.js
@@ -264,7 +264,22 @@ export function getCachedResponse(endpoint, body, ttlSeconds = DEFAULT_CACHE_TTL
       return null;
     }
     
-    return { ...cached.data, _meta: { ...cached.data._meta, fromCache: true, cacheAge: Math.round(age) } };
+    // Re-attach the cache marker without reshaping the payload. Object-spreading
+    // a top-level array turns it into { 0: …, 1: … }, so a cached array came back
+    // as an object and every Array.isArray() branch downstream (the table/CSV/
+    // markdown formatters in cli.js, alertsGet) stopped recognising it — the first
+    // call rendered rows and the second rendered nothing. Arrays therefore get
+    // _meta hung off the array itself, exactly as the live request path does when
+    // it records retriedAttempts, and primitives are handed back untouched
+    // because a non-object cannot carry the marker at all.
+    const meta = { ...cached.data?._meta, fromCache: true, cacheAge: Math.round(age) };
+    if (Array.isArray(cached.data)) {
+      const rows = cached.data.slice();
+      rows._meta = meta;
+      return rows;
+    }
+    if (cached.data === null || typeof cached.data !== 'object') return cached.data;
+    return { ...cached.data, _meta: meta };
   } catch (_e) {
     // Invalid cache file, delete it
     try { fs.unlinkSync(cacheFile); } catch { /* ignore */ }


### PR DESCRIPTION
## Problem

`getCachedResponse()` re-attached the cache marker by object-spreading the stored payload:

```js
return { ...cached.data, _meta: { ...cached.data._meta, fromCache: true, cacheAge: Math.round(age) } };
```

Spreading a **top-level array** into an object literal produces `{ 0: …, 1: … }`, so a cached array came back as an object.

A bare JSON array is a first-class response shape here — the table, CSV and markdown formatters in `src/cli.js` all test `Array.isArray(data)` before any other branch (`cli.js:243`, `:315`, `:408`), and `alertsGet()` does the same (`api.js:1743`). Once the array became an object it matched none of those branches and fell through to the end.

So with `--cache` on, the first call printed rows and the second call — served from cache within the TTL — printed nothing. `alertsGet()` degraded the same way: `Array.isArray(result)` false, then `result.alerts` and `result.data` both undefined, so it returned `[]` and reported the alert as missing while it still existed.

Spreading a string body had the same effect in miniature: `'plain-text-body'` came back as `{ 0: 'p', 1: 'l', 2: 'a', … }`.

## Reproduction

Against the unmodified code, with caching on (`nansen --cache …`) and an endpoint returning a bare array:

```
1st call (network)     isArray=true  length=2         [{"symbol":"ETH"},{"symbol":"SOL"}]
2nd call (cache hit)   isArray=false length=undefined {"0":{"symbol":"ETH"},"1":{"symbol":"SOL"},"_meta":…}

formatter rows -> 1st: array of 2
formatter rows -> 2nd: NOTHING (falls through every branch)
```

## Fix

Re-attach the marker without reshaping the payload:

- an **array** keeps its identity and carries `_meta` as a property on the array, exactly as the live request path already does when it records `retriedAttempts`;
- an **object** is spread as before, so nothing changes for the common case;
- a **primitive** (or `null`) is returned untouched, since a non-object cannot carry the marker at all — this also matches the guard the live path uses before attaching response metadata.

A side effect worth calling out: `--json` output on a cache hit is now byte-identical to the same call served from the network. Previously the cached form serialised as `{"0":…,"1":…,"_meta":…}` while the live form serialised as `[…]`.

## Tests

New `src/__tests__/api-cache.test.js` covering the four shapes through the real `request()` path with a mocked `fetch` and a temp `HOME`:

- a cached top-level array is still an array, with the right rows and `_meta.fromCache`
- the second call is served from cache rather than refetched (`fetch` called once)
- an object response still gets `_meta` merged in
- a primitive response comes back untouched

Reverting only the `src/api.js` hunk makes the array test and the primitive test fail, so both are genuine regression tests:

```
× returns a top-level array as an array on a cache hit
× hands back a primitive response untouched
AssertionError: expected false to be true
AssertionError: expected { '0': 'p', '1': 'l', '2': 'a', …(13) } to be 'plain-text-body'
Tests  2 failed | 2 passed (4)
```

With the fix applied: `Test Files 1 passed (1)`, `Tests 4 passed (4)`.

`npm run lint` passes clean.

On the full `npm test` run this branch shows the same failure set as unmodified `main` — 2641 passing here against 2637 on `main`, the difference being exactly the four new tests. No existing test changes status because of this patch.

## Checklist

- [x] `npm test` — no test changes status vs `main`; the new file passes 4/4
- [x] `npm run lint` passes
- [x] New code path has tests
- [x] No `console.log` in core, no hardcoded secrets
- [x] Changeset added (`patch`, user-facing bug fix)
- [ ] `src/schema.json` — not applicable, no commands or options changed
