### PR TITLE
fix(mcp): guard saved API key from disclosure to custom verify URLs

### DIFF
--- a/.changeset/mcp-verify-saved-key-guard.md
+++ b/.changeset/mcp-verify-saved-key-guard.md
@@ -1,5 +1,5 @@
 ---
-"nansen-cli": patch
+"nansen-cli": minor
 ---
 
 Security: `nansen mcp verify` no longer sends a saved API key (from `nansen login` / `NANSEN_API_KEY` / config) to a custom `--url` without explicit consent. Forwarding a saved key to a non-default URL now requires `--send-api-key`, and no key is ever sent over plain HTTP to a non-loopback host. An inline `--api-key` is unaffected.

--- a/.changeset/mcp-verify-saved-key-guard.md
+++ b/.changeset/mcp-verify-saved-key-guard.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Security: `nansen mcp verify` no longer sends a saved API key (from `nansen login` / `NANSEN_API_KEY` / config) to a custom `--url` without explicit consent. Forwarding a saved key to a non-default URL now requires `--send-api-key`, and no key is ever sent over plain HTTP to a non-loopback host. An inline `--api-key` is unaffected.

--- a/.changeset/mcp-verify-saved-key-guard.md
+++ b/.changeset/mcp-verify-saved-key-guard.md
@@ -3,3 +3,5 @@
 ---
 
 Security: `nansen mcp verify` no longer sends a saved API key (from `nansen login` / `NANSEN_API_KEY` / config) to a custom `--url` without explicit consent. Forwarding a saved key to a non-default URL now requires `--send-api-key`, and no key is ever sent over plain HTTP to a non-loopback host. An inline `--api-key` is unaffected.
+
+Note: verifying a custom `--url` with a saved key now errors unless `--send-api-key` is passed (previously it warned and proceeded).

--- a/src/__tests__/mcp-verify.test.js
+++ b/src/__tests__/mcp-verify.test.js
@@ -372,6 +372,22 @@ describe('mcp verify', () => {
       expect(fetchFn.mock.calls[1][1].headers['NANSEN-API-KEY']).toBe(API_KEY);
     });
 
+    it('treats an IPv4-mapped IPv6 loopback host as loopback', async () => {
+      env.NANSEN_API_KEY = SAVED_KEY;
+      const fetchFn = vi.fn()
+        .mockResolvedValueOnce(listResponse())
+        .mockResolvedValueOnce(authSuccessResponse());
+
+      const checks = await runChecks(fetchFn, {
+        apiKey: undefined,
+        url: 'http://[::ffff:127.0.0.1]:8787/ra/mcp',
+        sendApiKey: true,
+      });
+
+      expect(findCheck(checks, 'mcp-auth').status).toBe('ok');
+      expect(fetchFn.mock.calls[1][1].headers['NANSEN-API-KEY']).toBe(SAVED_KEY);
+    });
+
     it('withholds the key from an unparseable or non-https custom URL (fail-safe)', async () => {
       const fetchFn = vi.fn().mockResolvedValueOnce(listResponse());
 

--- a/src/__tests__/mcp-verify.test.js
+++ b/src/__tests__/mcp-verify.test.js
@@ -285,6 +285,119 @@ describe('mcp verify', () => {
     expect(fetchFn.mock.calls[1][1].headers['NANSEN-API-KEY']).toBe(API_KEY);
   });
 
+  describe('saved-key disclosure guard', () => {
+    const SAVED_KEY = 'nk_saved_1234567890abcdef';
+
+    it('withholds a saved key from a custom https URL without --send-api-key', async () => {
+      env.NANSEN_API_KEY = SAVED_KEY;
+      const fetchFn = vi.fn().mockResolvedValueOnce(listResponse());
+
+      const checks = await runChecks(fetchFn, { apiKey: undefined, url: 'https://mcp.evil.example/ra/mcp' });
+
+      expect(findCheck(checks, 'mcp-url')).toMatchObject({ status: 'error' });
+      expect(findCheck(checks, 'mcp-url').message).toContain('withheld');
+      expect(findCheck(checks, 'mcp-auth').status).toBe('info');
+      // Only the unauthenticated tools/list ran; no authenticated tools/call.
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      expect(fetchFn.mock.calls.every(([, opts]) => !opts.headers['NANSEN-API-KEY'])).toBe(true);
+    });
+
+    it('withholds a saved key even from a loopback URL without --send-api-key', async () => {
+      env.NANSEN_API_KEY = SAVED_KEY;
+      const fetchFn = vi.fn().mockResolvedValueOnce(listResponse());
+
+      const checks = await runChecks(fetchFn, { apiKey: undefined, url: 'http://127.0.0.1:8787/ra/mcp' });
+
+      expect(findCheck(checks, 'mcp-url')).toMatchObject({ status: 'error' });
+      expect(findCheck(checks, 'mcp-url').message).toContain('withheld');
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a saved key to a custom https URL when --send-api-key is given', async () => {
+      env.NANSEN_API_KEY = SAVED_KEY;
+      const fetchFn = vi.fn()
+        .mockResolvedValueOnce(listResponse())
+        .mockResolvedValueOnce(authSuccessResponse());
+
+      const checks = await runChecks(fetchFn, {
+        apiKey: undefined,
+        url: 'https://mcp.example.dev/ra/mcp',
+        sendApiKey: true,
+      });
+
+      expect(findCheck(checks, 'mcp-url').status).toBe('warn');
+      expect(findCheck(checks, 'mcp-auth').status).toBe('ok');
+      expect(fetchFn.mock.calls[1][1].headers['NANSEN-API-KEY']).toBe(SAVED_KEY);
+    });
+
+    it('allows a saved key over http to a loopback host with --send-api-key', async () => {
+      env.NANSEN_API_KEY = SAVED_KEY;
+      const fetchFn = vi.fn()
+        .mockResolvedValueOnce(listResponse())
+        .mockResolvedValueOnce(authSuccessResponse());
+
+      const checks = await runChecks(fetchFn, {
+        apiKey: undefined,
+        url: 'http://localhost:8787/ra/mcp',
+        sendApiKey: true,
+      });
+
+      expect(findCheck(checks, 'mcp-auth').status).toBe('ok');
+      expect(fetchFn.mock.calls[1][1].headers['NANSEN-API-KEY']).toBe(SAVED_KEY);
+    });
+
+    it('refuses to send any key over plain HTTP to a non-loopback host, even with --send-api-key', async () => {
+      // Uses the explicit API_KEY (runChecks default): the HTTPS hard block
+      // applies to every key, not just saved ones.
+      const fetchFn = vi.fn().mockResolvedValueOnce(listResponse());
+
+      const checks = await runChecks(fetchFn, { url: 'http://mcp.example.dev/ra/mcp', sendApiKey: true });
+
+      expect(findCheck(checks, 'mcp-url')).toMatchObject({ status: 'error' });
+      expect(findCheck(checks, 'mcp-url').message).toMatch(/plain HTTP/i);
+      expect(findCheck(checks, 'mcp-auth').status).toBe('info');
+      expect(fetchFn.mock.calls.every(([, opts]) => !opts.headers['NANSEN-API-KEY'])).toBe(true);
+    });
+
+    it('still sends an explicit --api-key to a custom https URL without --send-api-key', async () => {
+      env.NANSEN_API_KEY = SAVED_KEY;
+      const fetchFn = vi.fn()
+        .mockResolvedValueOnce(listResponse())
+        .mockResolvedValueOnce(authSuccessResponse());
+
+      // apiKey defaults to the explicit API_KEY in runChecks.
+      const checks = await runChecks(fetchFn, { url: 'https://mcp.example.dev/ra/mcp' });
+
+      expect(findCheck(checks, 'mcp-auth').status).toBe('ok');
+      expect(fetchFn.mock.calls[1][1].headers['NANSEN-API-KEY']).toBe(API_KEY);
+    });
+
+    it('threads --send-api-key through the CLI to authorize a saved key', async () => {
+      env.NANSEN_API_KEY = SAVED_KEY;
+      const output = [];
+      const fetchFn = vi.fn()
+        .mockResolvedValueOnce(listResponse())
+        .mockResolvedValueOnce(authSuccessResponse());
+
+      const result = await runCLI(
+        ['mcp', 'verify', '--json', '--url', 'https://mcp.example.dev/ra/mcp', '--send-api-key'],
+        {
+          output: value => output.push(value),
+          errorOutput: () => {},
+          exit: vi.fn(),
+          NansenAPIClass: class {},
+          fetchFn,
+          env,
+          devConfigPath,
+          isTTY: false,
+        },
+      );
+
+      expect(result.type).not.toBe('error');
+      expect(fetchFn.mock.calls[1][1].headers['NANSEN-API-KEY']).toBe(SAVED_KEY);
+    });
+  });
+
   it('formats a report with check lines, fixes, and the verification summary', () => {
     const report = formatMcpVerifyReport([
       { id: 'mcp-api-key', status: 'ok', message: 'API key found (nk_t…cdef)' },

--- a/src/__tests__/mcp-verify.test.js
+++ b/src/__tests__/mcp-verify.test.js
@@ -372,6 +372,18 @@ describe('mcp verify', () => {
       expect(fetchFn.mock.calls[1][1].headers['NANSEN-API-KEY']).toBe(API_KEY);
     });
 
+    it('withholds the key from an unparseable or non-https custom URL (fail-safe)', async () => {
+      const fetchFn = vi.fn().mockResolvedValueOnce(listResponse());
+
+      // An invalid IPv4 octet is rejected by URL parsing, so this exercises the
+      // fail-safe path rather than being (wrongly) classified as loopback.
+      const checks = await runChecks(fetchFn, { url: 'http://127.999.999.999:8787/ra/mcp', sendApiKey: true });
+
+      expect(findCheck(checks, 'mcp-url')).toMatchObject({ status: 'error' });
+      expect(findCheck(checks, 'mcp-url').message).toMatch(/unsupported MCP URL/i);
+      expect(fetchFn.mock.calls.every(([, opts]) => !opts.headers['NANSEN-API-KEY'])).toBe(true);
+    });
+
     it('threads --send-api-key through the CLI to authorize a saved key', async () => {
       env.NANSEN_API_KEY = SAVED_KEY;
       const output = [];

--- a/src/__tests__/mcp-verify.test.js
+++ b/src/__tests__/mcp-verify.test.js
@@ -384,6 +384,30 @@ describe('mcp verify', () => {
       expect(fetchFn.mock.calls.every(([, opts]) => !opts.headers['NANSEN-API-KEY'])).toBe(true);
     });
 
+    it('rejects `--send-api-key false` instead of authorizing on flag presence', async () => {
+      env.NANSEN_API_KEY = SAVED_KEY;
+      const output = [];
+      const fetchFn = vi.fn();
+
+      const result = await runCLI(
+        ['mcp', 'verify', '--json', '--url', 'https://mcp.example.dev/ra/mcp', '--send-api-key', 'false'],
+        {
+          output: value => output.push(value),
+          errorOutput: () => {},
+          exit: vi.fn(),
+          NansenAPIClass: class {},
+          fetchFn,
+          env,
+          devConfigPath,
+          isTTY: false,
+        },
+      );
+
+      expect(result.type).toBe('error');
+      // The command must fail before any network call, so the key is never sent.
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
     it('threads --send-api-key through the CLI to authorize a saved key', async () => {
       env.NANSEN_API_KEY = SAVED_KEY;
       const output = [];

--- a/src/__tests__/mcp-verify.test.js
+++ b/src/__tests__/mcp-verify.test.js
@@ -424,6 +424,33 @@ describe('mcp verify', () => {
       expect(fetchFn).not.toHaveBeenCalled();
     });
 
+    it('never echoes a positional argument (e.g. `--send-api-key "$KEY"`) into the error', async () => {
+      env.NANSEN_API_KEY = SAVED_KEY;
+      const output = [];
+      const fetchFn = vi.fn();
+
+      // A plausible misuse expands the key into extraArgs[0]; the error must not
+      // interpolate it, or the credential lands on stdout (and in logs --json).
+      const result = await runCLI(
+        ['mcp', 'verify', '--json', '--send-api-key', SAVED_KEY],
+        {
+          output: value => output.push(value),
+          errorOutput: () => {},
+          exit: vi.fn(),
+          NansenAPIClass: class {},
+          fetchFn,
+          env,
+          devConfigPath,
+          isTTY: false,
+        },
+      );
+
+      expect(result.type).toBe('error');
+      expect(fetchFn).not.toHaveBeenCalled();
+      expect(JSON.stringify(result)).not.toContain(SAVED_KEY);
+      expect(output.join('\n')).not.toContain(SAVED_KEY);
+    });
+
     it('threads --send-api-key through the CLI to authorize a saved key', async () => {
       env.NANSEN_API_KEY = SAVED_KEY;
       const output = [];

--- a/src/cli.js
+++ b/src/cli.js
@@ -171,6 +171,7 @@ export const VALUELESS_FLAGS = new Set([
   'pretty', 'help', 'version', 'table', 'no-retry', 'cache', 'no-cache', 'stream',
   'enrich', 'full', 'human', 'enabled', 'disabled', 'expert', 'json', 'offline',
   'no-simulate', 'no-verify-outcome', 'no-revoke-excessive-allowance', 'dry-run',
+  'send-api-key',
 ]);
 
 export function parseArgs(args) {

--- a/src/commands/mcp.js
+++ b/src/commands/mcp.js
@@ -219,9 +219,12 @@ export function buildMcpCommands(deps = {}) {
     // `false` as a positional arg while the flag still reads as present, which
     // would authorize the very disclosure the caller meant to decline. Reject
     // any positional args so that footgun fails loudly instead of leaking.
+    // Never echo the argument: a plausible misuse is `--send-api-key "$KEY"`,
+    // which lands the real key in extraArgs[0]; interpolating it would leak the
+    // credential to stdout (and to logs under --json).
     if (extraArgs.length > 0) {
       throw new CommandError(
-        `Unexpected argument: ${extraArgs[0]}. \`nansen mcp verify\` takes no positional arguments — --send-api-key is a valueless flag, do not pass it a value. Usage: nansen mcp verify [--api-key <key>] [--url <url>] [--send-api-key] [--json]`,
+        '`nansen mcp verify` takes no positional arguments — --send-api-key is a valueless flag, do not pass it a value. Usage: nansen mcp verify [--api-key <key>] [--url <url>] [--send-api-key] [--json]',
         'INVALID_PARAMS',
       );
     }

--- a/src/commands/mcp.js
+++ b/src/commands/mcp.js
@@ -36,7 +36,7 @@ const MCP_USAGE = `nansen mcp — Install the Nansen MCP server into a local MCP
 USAGE:
   nansen mcp install <client>     Add the Nansen MCP server to the client's config
   nansen mcp uninstall <client>   Remove the Nansen MCP server from the client's config
-  nansen mcp verify [--api-key <key>] [--url <url>] [--json]
+  nansen mcp verify [--api-key <key>] [--url <url>] [--send-api-key] [--json]
                                   Verify the hosted MCP server and API key
 
 CLIENTS:
@@ -46,6 +46,8 @@ CLIENTS:
 
 OPTIONS:
   --dry-run        Preview the change (key redacted) without writing
+  --send-api-key   Authorize sending your saved API key to a custom --url
+                   (an https:// or loopback host). Not needed for --api-key.
 
 The API key is taken from \`nansen login\` / NANSEN_API_KEY. Re-run install after
 rotating your key to update the entry. Other clients: https://docs.nansen.ai/mcp/connecting`;
@@ -239,6 +241,7 @@ export function buildMcpCommands(deps = {}) {
       env,
       fetchFn,
       devConfigPath,
+      sendApiKey: Boolean(flags['send-api-key']),
     });
     const verified = checks.some(checkItem => checkItem.id === 'mcp-auth' && checkItem.status === 'ok');
     const result = {

--- a/src/commands/mcp.js
+++ b/src/commands/mcp.js
@@ -214,7 +214,17 @@ export function buildMcpCommands(deps = {}) {
     }
   };
 
-  const verify = async (flags, options) => {
+  const verify = async (flags, options, extraArgs = []) => {
+    // --send-api-key is a valueless flag: `--send-api-key false` parses the
+    // `false` as a positional arg while the flag still reads as present, which
+    // would authorize the very disclosure the caller meant to decline. Reject
+    // any positional args so that footgun fails loudly instead of leaking.
+    if (extraArgs.length > 0) {
+      throw new CommandError(
+        `Unexpected argument: ${extraArgs[0]}. \`nansen mcp verify\` takes no positional arguments — --send-api-key is a valueless flag, do not pass it a value. Usage: nansen mcp verify [--api-key <key>] [--url <url>] [--send-api-key] [--json]`,
+        'INVALID_PARAMS',
+      );
+    }
     // A valueless --api-key parses as a flag and would silently fall back to
     // the saved key - the exact false positive this command exists to catch.
     if (flags['api-key']) {
@@ -282,7 +292,7 @@ export function buildMcpCommands(deps = {}) {
       }
 
       if (sub === 'verify') {
-        return verify(flags, options);
+        return verify(flags, options, args.slice(1));
       }
 
       if (sub !== 'install' && sub !== 'uninstall') {

--- a/src/mcp-verify.js
+++ b/src/mcp-verify.js
@@ -12,11 +12,14 @@ class McpRequestError extends Error {
   }
 }
 
+const IPV4_OCTET = '(?:25[0-5]|2[0-4]\\d|1?\\d{1,2})';
+const LOOPBACK_IPV4 = new RegExp(`^127\\.${IPV4_OCTET}\\.${IPV4_OCTET}\\.${IPV4_OCTET}$`);
+
 function isLoopbackHostname(hostname) {
   if (!hostname) return false;
   const host = hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
   if (host === 'localhost' || host === '::1') return true;
-  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host);
+  return LOOPBACK_IPV4.test(host);
 }
 
 /**
@@ -240,6 +243,15 @@ export async function runMcpVerifyChecks({
         'error',
         `Refusing to send the API key over plain HTTP to a non-loopback host (${dest.origin})`,
         'Use an https:// URL. Plain HTTP is only permitted for localhost/loopback development.',
+      );
+    } else if (dest.protocol !== 'https:' && !(dest.protocol === 'http:' && dest.loopback)) {
+      // Anything not provably secure — an unparseable URL or a non-http(s)
+      // scheme — is refused rather than relied on to fail later in fetch.
+      keyWithheld = check(
+        'mcp-url',
+        'error',
+        `Refusing to send the API key to an unsupported MCP URL (${dest.origin})`,
+        'Use an https:// URL, or a loopback http:// URL for local development.',
       );
     } else if (!explicitKey && !sendApiKey) {
       keyWithheld = check(

--- a/src/mcp-verify.js
+++ b/src/mcp-verify.js
@@ -12,6 +12,28 @@ class McpRequestError extends Error {
   }
 }
 
+function isLoopbackHostname(hostname) {
+  if (!hostname) return false;
+  const host = hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
+  if (host === 'localhost' || host === '::1') return true;
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host);
+}
+
+/**
+ * Classify a destination URL for the credential-disclosure guard: its origin
+ * (for messaging), protocol, and whether the host is loopback.
+ */
+function classifyDestination(url) {
+  try {
+    const parsed = new URL(url);
+    return { origin: parsed.origin, protocol: parsed.protocol, loopback: isLoopbackHostname(parsed.hostname) };
+  } catch {
+    // An unparseable URL never reaches an authenticated fetch (tools/list fails
+    // first), so this is only for messaging; treat it as an unsafe destination.
+    return { origin: url, protocol: null, loopback: false };
+  }
+}
+
 function responseContentType(response) {
   return (
     response.headers?.get?.('content-type')
@@ -185,6 +207,7 @@ export async function runMcpVerifyChecks({
   fetchFn = fetch,
   timeoutMs = 30_000,
   devConfigPath,
+  sendApiKey = false,
 } = {}) {
   const checks = [];
   const auth = resolveAuthConfig(env, devConfigPath);
@@ -205,8 +228,30 @@ export async function runMcpVerifyChecks({
     ));
   }
 
+  // A saved key is trusted for the default Nansen endpoint only. Forwarding it
+  // to a caller-supplied URL requires explicit per-invocation consent, and no
+  // key may travel in cleartext to a public host.
+  let keyWithheld = null;
   if (key && url !== DEFAULT_MCP_URL) {
-    checks.push(check('mcp-url', 'warn', `Non-default MCP URL: ${url} — the API key will be sent to this host`));
+    const dest = classifyDestination(url);
+    if (dest.protocol === 'http:' && !dest.loopback) {
+      keyWithheld = check(
+        'mcp-url',
+        'error',
+        `Refusing to send the API key over plain HTTP to a non-loopback host (${dest.origin})`,
+        'Use an https:// URL. Plain HTTP is only permitted for localhost/loopback development.',
+      );
+    } else if (!explicitKey && !sendApiKey) {
+      keyWithheld = check(
+        'mcp-url',
+        'error',
+        `Saved API key withheld from custom MCP URL (${dest.origin})`,
+        `Re-run with --send-api-key to authorize sending your saved key to ${dest.origin}, or pass --api-key <key> to supply one explicitly.`,
+      );
+    } else {
+      checks.push(check('mcp-url', 'warn', `Sending the API key to custom MCP host: ${dest.origin}`));
+    }
+    if (keyWithheld) checks.push(keyWithheld);
   }
 
   let serverReady = false;
@@ -239,6 +284,8 @@ export async function runMcpVerifyChecks({
 
   if (!key) {
     checks.push(skippedAuth('no API key was provided'));
+  } else if (keyWithheld) {
+    checks.push(skippedAuth('the API key was withheld from this custom URL (see above)'));
   } else if (!serverReady) {
     checks.push(skippedAuth('tools/list did not establish server reachability'));
   } else {

--- a/src/mcp-verify.js
+++ b/src/mcp-verify.js
@@ -15,10 +15,16 @@ class McpRequestError extends Error {
 const IPV4_OCTET = '(?:25[0-5]|2[0-4]\\d|1?\\d{1,2})';
 const LOOPBACK_IPV4 = new RegExp(`^127\\.${IPV4_OCTET}\\.${IPV4_OCTET}\\.${IPV4_OCTET}$`);
 
+// IPv4-mapped IPv6 loopback (127.0.0.0/8). Node's URL canonicalizes
+// ::ffff:127.x.x.x to ::ffff:7fNN:NNNN (the 127 becomes the 7f high byte), so
+// match that form; non-loopback mapped addresses fall outside the 7f prefix.
+const LOOPBACK_IPV4_MAPPED = /^::ffff:7f[0-9a-f]{2}:[0-9a-f]{1,4}$/i;
+
 function isLoopbackHostname(hostname) {
   if (!hostname) return false;
   const host = hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
   if (host === 'localhost' || host === '::1') return true;
+  if (LOOPBACK_IPV4_MAPPED.test(host)) return true;
   return LOOPBACK_IPV4.test(host);
 }
 

--- a/src/schema.json
+++ b/src/schema.json
@@ -2435,7 +2435,7 @@
             },
             "send-api-key": {
               "type": "boolean",
-              "description": "Authorize sending your saved API key to a custom --url (must be https:// or a loopback host). Not needed when you pass --api-key explicitly."
+              "description": "Presence-only flag — pass it bare, never with a value (`--send-api-key false` is rejected). Authorizes sending your saved API key to a custom --url (must be https:// or a loopback host). Not needed when you pass --api-key explicitly."
             },
             "json": {
               "type": "boolean",

--- a/src/schema.json
+++ b/src/schema.json
@@ -2431,7 +2431,11 @@
             "url": {
               "type": "string",
               "default": "https://mcp.nansen.ai/ra/mcp",
-              "description": "Hosted MCP server URL"
+              "description": "Hosted MCP server URL. A saved API key is not sent to a non-default URL unless you pass --send-api-key, and never over plain HTTP to a non-loopback host."
+            },
+            "send-api-key": {
+              "type": "boolean",
+              "description": "Authorize sending your saved API key to a custom --url (must be https:// or a loopback host). Not needed when you pass --api-key explicitly."
             },
             "json": {
               "type": "boolean",
@@ -2441,7 +2445,8 @@
           "examples": [
             "npx -y nansen-cli mcp verify",
             "nansen mcp verify --json",
-            "nansen mcp verify --url https://mcp.example.dev/ra/mcp --api-key <key>"
+            "nansen mcp verify --url https://mcp.example.dev/ra/mcp --api-key <key>",
+            "nansen mcp verify --url https://mcp.example.dev/ra/mcp --send-api-key"
           ]
         },
         "install": {


### PR DESCRIPTION
## Problem

`nansen mcp verify --url <custom-url>` forwarded a **saved** API key (from `nansen login` / `NANSEN_API_KEY` / config file) to any user-supplied MCP endpoint in the authenticated `tools/call` request's `NANSEN-API-KEY` header — with only a warning, and over plain HTTP. A user (or automation) induced to verify a malicious URL would disclose their key to whoever controls that host, who could then make Nansen API calls billed to that user.

A saved key is trusted for the default Nansen endpoint only; supplying a custom URL is not itself authorization to send that credential elsewhere.

## Fix

Added a credential-disclosure guard before the authenticated `tools/call`:

- **Consent gate** — a saved key is withheld from a non-default `--url` unless `--send-api-key` is passed. This covers loopback too, so there is no silent drive-by even to `localhost`.
- **HTTPS hard-block** — no key is ever sent over plain `http://` to a non-loopback host, even with `--send-api-key`. Plain HTTP is permitted only for loopback dev endpoints (`localhost`, `127.0.0.0/8`, `::1`).
- An inline `--api-key` is unaffected — supplying it explicitly is itself consent, so the fresh-key workflow is unregressed.

Withheld cases emit an `error` check, skip the authenticated call, and exit non-zero with actionable guidance naming the destination origin and how to authorize it.

## Changes

- `src/mcp-verify.js` — destination classification helpers, `sendApiKey` param, and the two gates.
- `src/commands/mcp.js` — `--send-api-key` flag wired through, usage text updated.
- `src/cli.js` — registered `send-api-key` as a valueless flag.
- `src/schema.json` — documented the flag and added an example.
- `src/__tests__/mcp-verify.test.js` — 7 regression tests (withhold without flag, withhold on loopback, send with flag, loopback-http with flag, HTTP-to-public hard block, inline key still sends, CLI flag threading).

## Testing

- `npm test` — all passing (added 7 tests).
- `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)