### PR TITLE
fix(x402): bind scheme, network, and signing domain before signing

### DIFF
--- a/.changeset/x402-scheme-network-binding.md
+++ b/.changeset/x402-scheme-network-binding.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+x402 auto-pay now signs only for supported schemes and recognized payment networks (exact Solana mainnet CAIP-2 binding), and derives the EIP-712 chain id from the validated network.

--- a/.changeset/x402-scheme-network-binding.md
+++ b/.changeset/x402-scheme-network-binding.md
@@ -2,4 +2,4 @@
 "nansen-cli": patch
 ---
 
-x402 auto-pay now signs only for supported schemes and recognized payment networks (exact Solana mainnet CAIP-2 binding), and derives the EIP-712 chain id from the validated network.
+x402 auto-pay now signs only for supported schemes and recognized payment networks (exact Solana mainnet CAIP-2 binding), and derives the EIP-712 chain id from the validated network. The EIP-712 domain version is now required across all signing backends (local, WalletConnect, Privy) so a missing version can no longer be silently defaulted to a wrong value, while a null/empty remote chain id is treated as unspecified rather than a conflict.

--- a/src/__tests__/privy.test.js
+++ b/src/__tests__/privy.test.js
@@ -427,10 +427,12 @@ describe("createPrivyPaymentSignatures", () => {
     }));
 
     // Use X Layer USDT0 as the second requirement (also in the known-asset allowlist).
+    // extra.chainId must match the network's chain id (196 for X Layer, not 8453 for Base).
     const req2 = {
       ...evmRequirement,
       network: "eip155:196",
       asset: "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+      extra: { ...evmRequirement.extra, chainId: 196 },
     };
     const response = make402Response([evmRequirement, req2]);
     const results = [];

--- a/src/__tests__/walletconnect-x402.test.js
+++ b/src/__tests__/walletconnect-x402.test.js
@@ -113,6 +113,16 @@ describe('buildEIP712TypedData — chain id binding', () => {
     expect(td.domain.chainId).toBe(8453);
   });
 
+  it('treats a null or empty-string extra.chainId as absent, not a conflict', () => {
+    // null/'' mean "unspecified" (Number(null)===0, Number('')===0) and must not
+    // be read as a chain id of 0 conflicting with the network.
+    for (const chainId of [null, '']) {
+      const req = { ...REQUIREMENT, network: 'eip155:8453', extra: { ...REQUIREMENT.extra, chainId } };
+      const td = buildEIP712TypedData({ fromAddress: '0xSender', requirement: req });
+      expect(td.domain.chainId).toBe(8453);
+    }
+  });
+
   it('throws when extra.chainId conflicts with the validated network', () => {
     // remote extra.chainId: 1 on a Base requirement must be rejected — not signed
     const req = { ...REQUIREMENT, network: 'eip155:8453', extra: { ...REQUIREMENT.extra, chainId: 1 } };

--- a/src/__tests__/walletconnect-x402.test.js
+++ b/src/__tests__/walletconnect-x402.test.js
@@ -98,3 +98,55 @@ describe('buildEIP712TypedData — payTo field normalisation', () => {
     expect(td.message.to).toBe('0xSnakeOnly');
   });
 });
+
+describe('buildEIP712TypedData — chain id binding', () => {
+  it('derives chain id from the CAIP-2 network field, ignoring extra.chainId when consistent', () => {
+    // extra.chainId agrees with network → allowed, domain.chainId = 8453
+    const req = { ...REQUIREMENT, network: 'eip155:8453', extra: { ...REQUIREMENT.extra, chainId: 8453 } };
+    const td = buildEIP712TypedData({ fromAddress: '0xSender', requirement: req });
+    expect(td.domain.chainId).toBe(8453);
+  });
+
+  it('derives chain id from network when extra.chainId is absent', () => {
+    const req = { ...REQUIREMENT, extra: { name: 'USD Coin', version: '2' } };
+    const td = buildEIP712TypedData({ fromAddress: '0xSender', requirement: req });
+    expect(td.domain.chainId).toBe(8453);
+  });
+
+  it('throws when extra.chainId conflicts with the validated network', () => {
+    // remote extra.chainId: 1 on a Base requirement must be rejected — not signed
+    const req = { ...REQUIREMENT, network: 'eip155:8453', extra: { ...REQUIREMENT.extra, chainId: 1 } };
+    expect(() => buildEIP712TypedData({ fromAddress: '0xSender', requirement: req })).toThrow(
+      /extra\.chainId.*conflicts with.*network/i,
+    );
+  });
+
+  it('throws when network is missing or not an EVM CAIP-2 id', () => {
+    const req = { ...REQUIREMENT, network: 'bogus' };
+    expect(() => buildEIP712TypedData({ fromAddress: '0xSender', requirement: req })).toThrow(
+      /unsupported or missing EVM network/i,
+    );
+  });
+
+  it('throws when extra is missing entirely', () => {
+    const req = { ...REQUIREMENT };
+    delete req.extra;
+    expect(() => buildEIP712TypedData({ fromAddress: '0xSender', requirement: req })).toThrow(
+      /EIP-712 domain name\/version missing/i,
+    );
+  });
+
+  it('throws when extra.name is absent', () => {
+    const req = { ...REQUIREMENT, extra: { version: '2' } };
+    expect(() => buildEIP712TypedData({ fromAddress: '0xSender', requirement: req })).toThrow(
+      /EIP-712 domain name\/version missing/i,
+    );
+  });
+
+  it('throws when extra.version is absent', () => {
+    const req = { ...REQUIREMENT, extra: { name: 'USD Coin' } };
+    expect(() => buildEIP712TypedData({ fromAddress: '0xSender', requirement: req })).toThrow(
+      /EIP-712 domain name\/version missing/i,
+    );
+  });
+});

--- a/src/__tests__/x402-evm.test.js
+++ b/src/__tests__/x402-evm.test.js
@@ -135,12 +135,29 @@ describe('createEvmPaymentPayload', () => {
       asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
       amount: '50000',
       pay_to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
-      extra: {},
+      extra: { version: '2' },
     };
 
     expect(() => createEvmPaymentPayload(
       requirements, wallet.privateKey, wallet.address, 'https://test.com',
-    )).toThrow('name missing');
+    )).toThrow(/name\/version missing/);
+  });
+
+  it('should throw if extra.version is missing (no silent default) — matches walletconnect path', () => {
+    // The EIP-712 domain version varies by token (USDC=2, USDT0/BSC=1); guessing a
+    // default would silently produce an invalid signature, so refuse instead.
+    const wallet = generateEvmWallet();
+    const requirements = {
+      network: 'eip155:8453',
+      asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      amount: '50000',
+      pay_to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      extra: { name: 'USD Coin' },
+    };
+
+    expect(() => createEvmPaymentPayload(
+      requirements, wallet.privateKey, wallet.address, 'https://test.com',
+    )).toThrow(/name\/version missing/);
   });
 });
 

--- a/src/__tests__/x402-policy.test.js
+++ b/src/__tests__/x402-policy.test.js
@@ -19,10 +19,13 @@ const {
   resolvePayTo,
   isPayToAllowed,
   DEFAULT_X402_MAX_AMOUNT_USD,
+  SUPPORTED_X402_SCHEMES,
 } = await import('../x402-policy.js');
+const { SOLANA_MAINNET_NETWORK } = await import('../x402-tokens.js');
 
 // Canonical Base USDC requirement for reuse across tests.
 const BASE_USDC_REQUIREMENT = {
+  scheme: 'exact',
   network: 'eip155:8453',
   asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
   amount: '10000', // 0.01 USDC (6 decimals)
@@ -76,6 +79,18 @@ describe('resolveKnownToken', () => {
     const entry = resolveKnownToken('solana-devnet', 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
     expect(entry).toBeNull();
   });
+
+  it('returns null for a well-formed but unknown solana:* CAIP-2 network id', () => {
+    // A solana:* string that is not the known mainnet id must not resolve to any
+    // token — previously the prefix match mapped any solana:* to mainnet.
+    const entry = resolveKnownToken('solana:not-a-real-network-id', 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+    expect(entry).toBeNull();
+  });
+
+  it('returns USDC for exact Solana mainnet CAIP-2 id (regression guard)', () => {
+    const entry = resolveKnownToken(SOLANA_MAINNET_NETWORK, 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+    expect(entry).toMatchObject({ symbol: 'USDC', decimals: 6 });
+  });
 });
 
 describe('resolvePayTo', () => {
@@ -91,6 +106,36 @@ describe('resolvePayTo', () => {
     // Regression: an empty payTo must not be treated as a real recipient —
     // this is the same class of bug resolvePaymentAmount closes for amount.
     expect(resolvePayTo({ payTo: '', pay_to: '0xSnake' })).toBe('0xSnake');
+  });
+});
+
+describe('SUPPORTED_X402_SCHEMES', () => {
+  it('contains only "exact"', () => {
+    expect([...SUPPORTED_X402_SCHEMES]).toEqual(['exact']);
+  });
+});
+
+describe('evaluatePaymentRequirement — scheme gate', () => {
+  it('refuses an unsupported scheme before checking asset/network', () => {
+    const req = { ...BASE_USDC_REQUIREMENT, scheme: 'streaming' };
+    const result = evaluatePaymentRequirement(req);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/unsupported payment scheme/i);
+    expect(result.reason).toContain('"streaming"');
+  });
+
+  it('refuses when scheme is absent', () => {
+    const req = { ...BASE_USDC_REQUIREMENT };
+    delete req.scheme;
+    const result = evaluatePaymentRequirement(req);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/unsupported payment scheme/i);
+    expect(result.reason).toContain('(missing)');
+  });
+
+  it('allows scheme "exact" (regression guard on the happy path)', () => {
+    const result = evaluatePaymentRequirement(BASE_USDC_REQUIREMENT);
+    expect(result.ok).toBe(true);
   });
 });
 
@@ -111,6 +156,20 @@ describe('evaluatePaymentRequirement — allowlist and basic pass', () => {
 
   it('5. unknown network → refused', () => {
     const req = { ...BASE_USDC_REQUIREMENT, network: 'eip155:1' };
+    const result = evaluatePaymentRequirement(req);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/not a recognized/i);
+  });
+
+  it('well-formed solana:* CAIP-2 id that is not mainnet → refused', () => {
+    // Previously any solana:* string was accepted; now only the exact mainnet id is.
+    const req = {
+      scheme: 'exact',
+      network: 'solana:not-a-real-network-id',
+      asset: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      amount: '10000',
+      pay_to: '0xPaymentRecipient',
+    };
     const result = evaluatePaymentRequirement(req);
     expect(result.ok).toBe(false);
     expect(result.reason).toMatch(/not a recognized/i);
@@ -344,6 +403,7 @@ describe('evaluatePaymentRequirement — 18-decimal BSC token conversion', () =>
     // 0.01 USDT on BSC = 10_000_000_000_000_000 base units (18 decimals)
     process.env.NANSEN_X402_MAX_AMOUNT = '1.00';
     const req = {
+      scheme: 'exact',
       network: 'eip155:56',
       asset: '0x55d398326f99059fF775485246999027B3197955', // USDT on BSC
       amount: '10000000000000000', // 0.01 USDT

--- a/src/__tests__/x402-svm.test.js
+++ b/src/__tests__/x402-svm.test.js
@@ -94,12 +94,21 @@ describe('isSvmNetwork', () => {
 });
 
 describe('getSolanaRpcUrl', () => {
-  it('should return mainnet URL by default', () => {
+  it('should return mainnet URL for the canonical mainnet CAIP-2 id', () => {
     expect(getSolanaRpcUrl('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp')).toContain('mainnet');
   });
 
-  it('should return devnet URL', () => {
+  it('should return devnet URL for the canonical devnet CAIP-2 id', () => {
     expect(getSolanaRpcUrl('solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1')).toContain('devnet');
+  });
+
+  it('should return testnet URL for the canonical testnet CAIP-2 id', () => {
+    expect(getSolanaRpcUrl('solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z')).toContain('testnet');
+  });
+
+  it('throws for an unknown solana:* network instead of falling back to mainnet', () => {
+    expect(() => getSolanaRpcUrl('solana:bogus')).toThrow(/Unsupported Solana network/);
+    expect(() => getSolanaRpcUrl('solana:not-a-real-network-id')).toThrow(/Unsupported Solana network/);
   });
 });
 

--- a/src/walletconnect-x402.js
+++ b/src/walletconnect-x402.js
@@ -8,7 +8,6 @@
 import crypto from 'crypto';
 import { NansenError, ErrorCode } from './api.js';
 import { wcExec } from './walletconnect-exec.js';
-import { EVM_CHAIN_IDS } from './chain-ids.js';
 import { evaluatePaymentRequirement, resolvePaymentAmount, resolvePayTo } from './x402-policy.js';
 
 /**
@@ -54,11 +53,32 @@ function parseChainId(network) {
  */
 export function buildEIP712TypedData({ fromAddress, requirement }) {
   const payTo = resolvePayTo(requirement);
-  const { asset, extra, maxTimeoutSeconds } = requirement;
+  const { asset, maxTimeoutSeconds } = requirement;
+  const extra = requirement.extra || {};
   const amount = resolvePaymentAmount(requirement);
 
-  // Determine chain ID: extra.chainId > parsed from network > fallback map > base
-  const chainId = extra.chainId || parseChainId(requirement.network) || EVM_CHAIN_IDS[requirement.chain] || EVM_CHAIN_IDS.base;
+  if (!extra.name || !extra.version) {
+    throw new Error(
+      'Refusing to sign x402 payment: EIP-712 domain name/version missing from requirement.extra.',
+    );
+  }
+
+  // Chain id comes only from the CAIP-2 network the policy validated — not from
+  // a remote extra.chainId override, which could change the signing domain.
+  const chainId = parseChainId(requirement.network);
+  if (chainId === null) {
+    throw new Error(
+      `Refusing to sign x402 payment: unsupported or missing EVM network ${requirement.network}.`,
+    );
+  }
+  // A remote extra.chainId that disagrees with the network is a domain-binding
+  // mismatch — refuse rather than sign under either interpretation.
+  if (extra.chainId !== undefined && Number(extra.chainId) !== chainId) {
+    throw new Error(
+      `Refusing to sign x402 payment: extra.chainId ${extra.chainId} conflicts with ` +
+      `network ${requirement.network} (chain id ${chainId}).`,
+    );
+  }
 
   const now = Math.floor(Date.now() / 1000);
   const nonce = '0x' + crypto.randomBytes(32).toString('hex');

--- a/src/walletconnect-x402.js
+++ b/src/walletconnect-x402.js
@@ -72,8 +72,9 @@ export function buildEIP712TypedData({ fromAddress, requirement }) {
     );
   }
   // A remote extra.chainId that disagrees with the network is a domain-binding
-  // mismatch — refuse rather than sign under either interpretation.
-  if (extra.chainId !== undefined && Number(extra.chainId) !== chainId) {
+  // mismatch — refuse rather than sign under either interpretation. A null or
+  // empty extra.chainId means "unspecified", not a conflict, so treat it as absent.
+  if (extra.chainId != null && extra.chainId !== '' && Number(extra.chainId) !== chainId) {
     throw new Error(
       `Refusing to sign x402 payment: extra.chainId ${extra.chainId} conflicts with ` +
       `network ${requirement.network} (chain id ${chainId}).`,

--- a/src/x402-evm.js
+++ b/src/x402-evm.js
@@ -215,12 +215,16 @@ export function createEvmPaymentPayload(requirements, privateKeyHex, walletAddre
     throw new Error(`Unsupported assetTransferMethod: ${method}`);
   }
 
-  // Token name and version from requirements.extra (set by server/facilitator)
+  // Token name and version from requirements.extra (set by server/facilitator).
+  // Both are required: the EIP-712 domain version varies by token (USDC on Base
+  // is "2", USDT0/BSC tokens are "1"), so guessing a default would silently
+  // produce an invalid signature. Refuse instead — matches the walletconnect/Privy
+  // path in buildEIP712TypedData.
   const tokenName = extra.name;
-  const tokenVersion = extra.version || '1';
+  const tokenVersion = extra.version;
 
-  if (!tokenName) {
-    throw new Error('EIP-712 domain name missing from requirements.extra');
+  if (!tokenName || !tokenVersion) {
+    throw new Error('EIP-712 domain name/version missing from requirements.extra');
   }
 
   // Generate random nonce (32 bytes)

--- a/src/x402-policy.js
+++ b/src/x402-policy.js
@@ -5,12 +5,12 @@
  */
 
 import { EVM_X402_TOKENS, SVM_X402_TOKENS } from './x402-tokens.js';
+import { getWalletConfig } from './wallet.js';
 
 // The only x402 scheme this client can honour. "exact" = a fixed-amount transfer
 // authorization (EIP-3009 / Permit2 on EVM, SPL TransferChecked on SVM). Any other
 // scheme must be refused before signing, not silently accepted.
 export const SUPPORTED_X402_SCHEMES = new Set(['exact']);
-import { getWalletConfig } from './wallet.js';
 
 /**
  * True for the exact Solana CAIP-2 network prefix ("solana:..."), matching

--- a/src/x402-policy.js
+++ b/src/x402-policy.js
@@ -5,6 +5,11 @@
  */
 
 import { EVM_X402_TOKENS, SVM_X402_TOKENS } from './x402-tokens.js';
+
+// The only x402 scheme this client can honour. "exact" = a fixed-amount transfer
+// authorization (EIP-3009 / Permit2 on EVM, SPL TransferChecked on SVM). Any other
+// scheme must be refused before signing, not silently accepted.
+export const SUPPORTED_X402_SCHEMES = new Set(['exact']);
 import { getWalletConfig } from './wallet.js';
 
 /**
@@ -36,7 +41,7 @@ export function resolveKnownToken(network, asset) {
     return table.find(t => t.token.toLowerCase() === asset.toLowerCase()) || null;
   }
   if (isSvmNetworkString(network)) {
-    const table = SVM_X402_TOKENS['solana'];
+    const table = SVM_X402_TOKENS[network];        // exact CAIP-2 key, not the bare 'solana' prefix
     if (!table) return null;
     return table.find(t => t.token === asset) || null;
   }
@@ -130,6 +135,16 @@ export function resolvePayTo(requirement) {
  * allowlist, per-payment USD cap. Never signs; pure decision.
  */
 export function evaluatePaymentRequirement(requirement) {
+  const scheme = requirement.scheme;
+  if (!SUPPORTED_X402_SCHEMES.has(scheme)) {
+    return {
+      ok: false,
+      reason:
+        `Refusing to auto-pay: unsupported payment scheme ${scheme == null ? '(missing)' : `"${scheme}"`}. ` +
+        `Only "exact" is supported. No signature was produced.`,
+    };
+  }
+
   const network = requirement.network;
   const asset = requirement.asset;
   const payTo = resolvePayTo(requirement);

--- a/src/x402-svm.js
+++ b/src/x402-svm.js
@@ -7,6 +7,7 @@ import crypto from 'crypto';
 import { base58Encode, base58DecodePubkey } from './wallet.js';
 import { encodeCompactU16, deriveATA as _deriveATA } from './transfer.js';
 import { resolvePaymentAmount, resolvePayTo } from './x402-policy.js';
+import { SOLANA_MAINNET_NETWORK } from './x402-tokens.js';
 
 // ============= Constants =============
 
@@ -329,7 +330,11 @@ export async function fetchRecentBlockhash(rpcUrl = 'https://api.mainnet-beta.so
  * Get RPC URL for a Solana network identifier.
  */
 export function getSolanaRpcUrl(network) {
-  if (network === 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp') return 'https://api.mainnet-beta.solana.com';
+  if (network === SOLANA_MAINNET_NETWORK) return 'https://api.mainnet-beta.solana.com';
+  // Devnet/testnet resolve for tooling (e.g. balance checks), but the x402 pay
+  // path never reaches them: SVM_X402_TOKENS is mainnet-only, so the policy layer
+  // refuses a devnet/testnet requirement before signing. Adding a non-mainnet
+  // token entry would silently enable signing here — revisit this gate if you do.
   if (network === 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1') return 'https://api.devnet.solana.com';
   if (network === 'solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z') return 'https://api.testnet.solana.com';
   throw new Error(`Unsupported Solana network for x402: ${network}`);

--- a/src/x402-svm.js
+++ b/src/x402-svm.js
@@ -329,13 +329,10 @@ export async function fetchRecentBlockhash(rpcUrl = 'https://api.mainnet-beta.so
  * Get RPC URL for a Solana network identifier.
  */
 export function getSolanaRpcUrl(network) {
-  if (network.includes('devnet') || network === 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1') {
-    return 'https://api.devnet.solana.com';
-  }
-  if (network.includes('testnet') || network === 'solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z') {
-    return 'https://api.testnet.solana.com';
-  }
-  return 'https://api.mainnet-beta.solana.com';
+  if (network === 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp') return 'https://api.mainnet-beta.solana.com';
+  if (network === 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1') return 'https://api.devnet.solana.com';
+  if (network === 'solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z') return 'https://api.testnet.solana.com';
+  throw new Error(`Unsupported Solana network for x402: ${network}`);
 }
 
 /**

--- a/src/x402-tokens.js
+++ b/src/x402-tokens.js
@@ -21,9 +21,14 @@ export const EVM_X402_TOKENS = {
   ],
 };
 
-// Known payment tokens on Solana.
+// Canonical Solana mainnet CAIP-2 id.
+// x402 payment tokens are mainnet mints, so mainnet is the only valid payment network.
+export const SOLANA_MAINNET_NETWORK = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+
+// Known payment tokens on Solana, keyed by exact CAIP-2 network (symmetric with EVM_X402_TOKENS).
+// Unknown or devnet/testnet solana:* ids resolve to no token and are refused by the policy.
 export const SVM_X402_TOKENS = {
-  solana: [
+  [SOLANA_MAINNET_NETWORK]: [
     { token: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', symbol: 'USDC', decimals: 6 },
   ],
 };


### PR DESCRIPTION
## Summary

- Refuse any payment scheme other than `"exact"` at the policy layer, blocking all signing paths before any key material is touched
- Key the SVM token table by exact CAIP-2 id (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`) so unknown `solana:*` network strings resolve to no token and are refused
- Derive the EIP-712 `domain.chainId` only from the validated CAIP-2 `network` field; reject a conflicting remote `extra.chainId` instead of letting it silently override
- Harden `getSolanaRpcUrl` to throw on unknown networks rather than falling back to mainnet

## Test plan

- [ ] `npm test` passes (2730 tests)
- [ ] `npm run lint` passes
- [ ] New unit tests cover: unsupported/missing scheme refused, unknown `solana:*` CAIP-2 id refused, conflicting `extra.chainId` throws, missing `extra.name`/`extra.version` throws, `getSolanaRpcUrl` throws on unknown network
- [ ] Existing happy-path tests for Base USDC, Solana mainnet USDC, and BSC tokens all still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)