### PR TITLE
fix(cache): isolate response cache by credential and request context

### DIFF
--- a/.changeset/cache-isolation.md
+++ b/.changeset/cache-isolation.md
@@ -1,0 +1,8 @@
+---
+"nansen-cli": patch
+---
+
+Isolate the response cache by credential and request context so cached
+responses can no longer be shared across different API keys or API origins that
+use the same cache directory. Cache keys now include the base URL, HTTP method,
+and a hashed form of the effective credentials, and use SHA-256.

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, it, expect, beforeAll, vi } from 'vitest';
-import { NansenAPI, ErrorCode } from '../api.js';
+import { NansenAPI, ErrorCode, clearCache } from '../api.js';
 
 const LIVE_TEST = process.env.NANSEN_LIVE_TEST === '1';
 const API_KEY = process.env.NANSEN_API_KEY || 'test-key';
@@ -440,6 +440,44 @@ describe('NansenAPI', () => {
     it('should accept custom base URL', () => {
       const customApi = new NansenAPI('test-key', 'https://custom.api.com');
       expect(customApi.baseUrl).toBe('https://custom.api.com');
+    });
+  });
+
+  // =================== Cache Isolation (request-level) ===================
+  // Regression coverage for the `useCache && cacheContext` guards in request()
+  // (the read before fetch and the write after it) — exercised through the
+  // public request() call sites, not just the underlying cache helpers.
+
+  describe('Cache isolation via request()', () => {
+    afterEach(() => {
+      clearCache();
+    });
+
+    it('does not serve one API key\'s cached response to a different API key', async () => {
+      if (LIVE_TEST) return;
+
+      const endpoint = '/api/v1/cache-isolation-test';
+      const body = { probe: true };
+      const apiA = new NansenAPI('key-a', 'https://api.nansen.ai', { cache: { enabled: true } });
+      const apiB = new NansenAPI('key-b', 'https://api.nansen.ai', { cache: { enabled: true } });
+
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ secret: 'A' }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ secret: 'B' }) });
+
+      const resultA = await apiA.request(endpoint, body);
+      expect(resultA.secret).toBe('A');
+
+      // Different identity must miss the cache and hit the network again.
+      const resultB = await apiB.request(endpoint, body);
+      expect(resultB.secret).toBe('B');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      // Same identity as the first call must now be served from cache.
+      const resultACached = await apiA.request(endpoint, body);
+      expect(resultACached.secret).toBe('A');
+      expect(resultACached._meta.fromCache).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -38,7 +38,7 @@ import {
   buildAlertsCommands,
   validateAlertData,
 } from '../commands/alerts.js';
-import { getCachedResponse, setCachedResponse, clearCache, getCacheDir, NansenError, ErrorCode } from '../api.js';
+import { getCachedResponse, setCachedResponse, clearCache, getCacheDir, NansenError, ErrorCode, computeIdentityDigest } from '../api.js';
 import { EVM_CHAINS } from '../chain-ids.js';
 import * as fs from 'fs';
 import * as _path from 'path';
@@ -3371,6 +3371,29 @@ describe('cache isolation by request context', () => {
     setCachedResponse(endpoint, body, { m: 'POST' }, contextA);
     const differentMethod = { ...contextA, method: 'GET' };
     expect(getCachedResponse(endpoint, body, 300, differentMethod)).toBeNull();
+  });
+});
+
+describe('computeIdentityDigest', () => {
+  it('returns distinct digests for distinct API keys', () => {
+    const a = computeIdentityDigest('key-a');
+    const b = computeIdentityDigest('key-b');
+    expect(a).not.toBe(b);
+  });
+
+  it('returns the same digest for the same API key (deterministic)', () => {
+    expect(computeIdentityDigest('key-x')).toBe(computeIdentityDigest('key-x'));
+  });
+
+  it('returns distinct digests for distinct auth headers', () => {
+    const a = computeIdentityDigest(null, { apikey: 'hdr-a' });
+    const b = computeIdentityDigest(null, { apikey: 'hdr-b' });
+    expect(a).not.toBe(b);
+  });
+
+  it('does not include the raw API key in the digest string', () => {
+    const digest = computeIdentityDigest('super-secret-key');
+    expect(digest).not.toContain('super-secret-key');
   });
 });
 

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -3333,6 +3333,47 @@ describe('Response Caching', () => {
   });
 });
 
+describe('cache isolation by request context', () => {
+  afterEach(() => {
+    clearCache();
+  });
+
+  const endpoint = '/api/v1/some/endpoint';
+  const body = { foo: 'bar' };
+
+  const contextA = {
+    baseUrl: 'https://a.example',
+    method: 'POST',
+    identity: 'identity-a',
+  };
+  const contextB = {
+    baseUrl: 'https://b.example',
+    method: 'POST',
+    identity: 'identity-b',
+  };
+
+  it('does not serve one identity\'s cached response to another', () => {
+    setCachedResponse(endpoint, body, { secret: 'A' }, contextA);
+
+    expect(getCachedResponse(endpoint, body, 300, contextB)).toBeNull();
+
+    const hit = getCachedResponse(endpoint, body, 300, contextA);
+    expect(hit.secret).toBe('A');
+  });
+
+  it('treats a different base URL as a different cache entry', () => {
+    setCachedResponse(endpoint, body, { origin: 'A' }, contextA);
+    const differentOrigin = { ...contextA, baseUrl: 'https://other.example' };
+    expect(getCachedResponse(endpoint, body, 300, differentOrigin)).toBeNull();
+  });
+
+  it('treats a different HTTP method as a different cache entry', () => {
+    setCachedResponse(endpoint, body, { m: 'POST' }, contextA);
+    const differentMethod = { ...contextA, method: 'GET' };
+    expect(getCachedResponse(endpoint, body, 300, differentMethod)).toBeNull();
+  });
+});
+
 // compareSemver's own unit tests live in src/__tests__/semver.test.js
 // (its canonical home, src/semver.js). What belongs here is the CLI
 // command's behavior — that --since is validated and filters correctly —

--- a/src/__tests__/cli.internal.test.js
+++ b/src/__tests__/cli.internal.test.js
@@ -3385,6 +3385,20 @@ describe('computeIdentityDigest', () => {
     expect(computeIdentityDigest('key-x')).toBe(computeIdentityDigest('key-x'));
   });
 
+  it('ignores auth header insertion order', () => {
+    const first = computeIdentityDigest(null, {
+      apikey: 'key-x',
+      authorization: 'Bearer token',
+      'payment-signature': 'signature',
+    });
+    const second = computeIdentityDigest(null, {
+      'payment-signature': 'signature',
+      authorization: 'Bearer token',
+      apikey: 'key-x',
+    });
+    expect(first).toBe(second);
+  });
+
   it('returns distinct digests for distinct auth headers', () => {
     const a = computeIdentityDigest(null, { apikey: 'hdr-a' });
     const b = computeIdentityDigest(null, { apikey: 'hdr-b' });

--- a/src/api.js
+++ b/src/api.js
@@ -688,9 +688,10 @@ export class NansenAPI {
     const useCache = options.cache !== false && this.cacheOptions.enabled;
     const cacheTtl = options.cacheTtl ?? this.cacheOptions.ttl;
     const method = options.method || 'POST';
-    // Only derive the cache context (which includes a SHA-256 identity digest)
-    // when caching is enabled — caching is opt-in and off by default, so the
-    // common path skips this hashing work entirely.
+    // Defer identity hashing to keep the uncached (default) path free of crypto work.
+    // cacheContext is therefore null unless caching is on; the `&& cacheContext`
+    // guards below ensure that null never reaches getCacheKey, where a missing
+    // identity would silently produce a credential-agnostic (shared) cache key.
     const cacheContext = useCache
       ? {
           baseUrl: this.baseUrl,
@@ -699,7 +700,7 @@ export class NansenAPI {
         }
       : null;
 
-    if (useCache) {
+    if (useCache && cacheContext) {
       const cached = getCachedResponse(endpoint, body, cacheTtl, cacheContext);
       if (cached) {
         return cached;
@@ -929,7 +930,7 @@ export class NansenAPI {
       }
 
       // Cache successful response
-      if (useCache) {
+      if (useCache && cacheContext) {
         setCachedResponse(endpoint, body, data, cacheContext);
       }
 

--- a/src/api.js
+++ b/src/api.js
@@ -246,19 +246,37 @@ const DEFAULT_CACHE_TTL = 300; // 5 minutes
 
 import crypto from 'crypto';
 
-/**
- * Generate cache key from endpoint and request body
- */
-function getCacheKey(endpoint, body) {
-  const data = JSON.stringify({ endpoint, body });
-  return crypto.createHash('md5').update(data).digest('hex');
+const AUTH_HEADER_NAMES = ['apikey', 'authorization', 'payment-signature'];
+
+function computeIdentityDigest(apiKey, ...headerSets) {
+  const authHeaders = {};
+  for (const headers of headerSets) {
+    if (!headers) continue;
+    for (const [name, value] of Object.entries(headers)) {
+      const lower = name.toLowerCase();
+      if (AUTH_HEADER_NAMES.includes(lower)) authHeaders[lower] = value;
+    }
+  }
+  const material = JSON.stringify({ apiKey: apiKey ?? null, authHeaders });
+  return crypto.createHash('sha256').update(material).digest('hex');
+}
+
+function getCacheKey(endpoint, body, context = {}) {
+  const data = JSON.stringify({
+    endpoint,
+    body,
+    baseUrl: context.baseUrl ?? null,
+    method: context.method ?? null,
+    identity: context.identity ?? null,
+  });
+  return crypto.createHash('sha256').update(data).digest('hex');
 }
 
 /**
  * Get cached response if valid
  */
-export function getCachedResponse(endpoint, body, ttlSeconds = DEFAULT_CACHE_TTL) {
-  const cacheKey = getCacheKey(endpoint, body);
+export function getCachedResponse(endpoint, body, ttlSeconds = DEFAULT_CACHE_TTL, context = {}) {
+  const cacheKey = getCacheKey(endpoint, body, context);
   const cacheFile = path.join(CACHE_DIR, `${cacheKey}.json`);
   
   if (!fs.existsSync(cacheFile)) {
@@ -286,12 +304,12 @@ export function getCachedResponse(endpoint, body, ttlSeconds = DEFAULT_CACHE_TTL
 /**
  * Save response to cache
  */
-export function setCachedResponse(endpoint, body, data) {
+export function setCachedResponse(endpoint, body, data, context = {}) {
   if (!fs.existsSync(CACHE_DIR)) {
     fs.mkdirSync(CACHE_DIR, { mode: 0o700, recursive: true });
   }
-  
-  const cacheKey = getCacheKey(endpoint, body);
+
+  const cacheKey = getCacheKey(endpoint, body, context);
   const cacheFile = path.join(CACHE_DIR, `${cacheKey}.json`);
   
   const cached = {
@@ -653,20 +671,25 @@ export class NansenAPI {
     // Check cache first (if enabled and not bypassed)
     const useCache = options.cache !== false && this.cacheOptions.enabled;
     const cacheTtl = options.cacheTtl ?? this.cacheOptions.ttl;
-    
+    const method = options.method || 'POST';
+    const cacheContext = {
+      baseUrl: this.baseUrl,
+      method,
+      identity: computeIdentityDigest(this.apiKey, this.defaultHeaders, options.headers),
+    };
+
     if (useCache) {
-      const cached = getCachedResponse(endpoint, body, cacheTtl);
+      const cached = getCachedResponse(endpoint, body, cacheTtl, cacheContext);
       if (cached) {
         return cached;
       }
     }
 
     let lastError;
-    
+
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       let response;
       try {
-        const method = options.method || 'POST';
         const isGet = method === 'GET';
         response = await fetch(url, {
           method,
@@ -886,7 +909,7 @@ export class NansenAPI {
 
       // Cache successful response
       if (useCache) {
-        setCachedResponse(endpoint, body, data);
+        setCachedResponse(endpoint, body, data, cacheContext);
       }
 
       // Attach after caching so the cache stores the payload alone — quota

--- a/src/api.js
+++ b/src/api.js
@@ -688,11 +688,16 @@ export class NansenAPI {
     const useCache = options.cache !== false && this.cacheOptions.enabled;
     const cacheTtl = options.cacheTtl ?? this.cacheOptions.ttl;
     const method = options.method || 'POST';
-    const cacheContext = {
-      baseUrl: this.baseUrl,
-      method,
-      identity: computeIdentityDigest(this.apiKey, this.defaultHeaders, options.headers),
-    };
+    // Only derive the cache context (which includes a SHA-256 identity digest)
+    // when caching is enabled — caching is opt-in and off by default, so the
+    // common path skips this hashing work entirely.
+    const cacheContext = useCache
+      ? {
+          baseUrl: this.baseUrl,
+          method,
+          identity: computeIdentityDigest(this.apiKey, this.defaultHeaders, options.headers),
+        }
+      : null;
 
     if (useCache) {
       const cached = getCachedResponse(endpoint, body, cacheTtl, cacheContext);

--- a/src/api.js
+++ b/src/api.js
@@ -248,7 +248,18 @@ import crypto from 'crypto';
 
 const AUTH_HEADER_NAMES = ['apikey', 'authorization', 'payment-signature'];
 
-function computeIdentityDigest(apiKey, ...headerSets) {
+// payment-signature is intentionally included: it is an auth credential and
+// including it isolates caches between users with different static signatures.
+// This is safe because:
+// (a) User-supplied signatures (--x402-payment-signature) live in defaultHeaders
+//     and are stable across calls, keeping the identity hash stable.
+// (b) Auto-generated signatures from the x402 retry path are added inside
+//     _x402Retry(), which calls fetch() directly and never goes through the
+//     cache check — so they never appear in options.headers here.
+// INVARIANT: do not place a freshly-generated per-request Payment-Signature in
+// options.headers before calling request() — it would produce a unique identity
+// hash on every call and silently disable caching for those requests.
+export function computeIdentityDigest(apiKey, ...headerSets) {
   const authHeaders = {};
   for (const headers of headerSets) {
     if (!headers) continue;

--- a/src/api.js
+++ b/src/api.js
@@ -268,7 +268,12 @@ export function computeIdentityDigest(apiKey, ...headerSets) {
       if (AUTH_HEADER_NAMES.includes(lower)) authHeaders[lower] = value;
     }
   }
-  const material = JSON.stringify({ apiKey: apiKey ?? null, authHeaders });
+  const material = JSON.stringify({
+    apiKey: apiKey ?? null,
+    authHeaders: Object.fromEntries(
+      Object.entries(authHeaders).sort(([a], [b]) => a.localeCompare(b))
+    ),
+  });
   return crypto.createHash('sha256').update(material).digest('hex');
 }
 


### PR DESCRIPTION
## Summary

The opt-in response cache (`--cache`) derived its key from only the endpoint and request body. Because the key ignored who made the request and where it was sent, clients sharing the same `$HOME` (and therefore the same cache directory) could read each other's cached responses — e.g. a response cached under one API key or base URL could be served to a request made under a different one, with no HTTP request.

This change folds every request property that affects authorization or response semantics into the cache key:

- **Base URL / origin** and **HTTP method**
- A **hashed identity** — the API key plus auth-relevant headers (`apikey`, `authorization`, `payment-signature`), digested with SHA-256 so no raw credential appears in a cache filename or the key's pre-image
- Endpoint and body (unchanged)

The key digest also moves from MD5 to SHA-256.

## Notes

- Caching is opt-in and off by default; this only affects `--cache` runs.
- No migration needed — changing the key scheme means old-format entries are never looked up again (they simply become invisible to the new keying), rather than being actively expired by the TTL check. They're inert, harmless leftovers that `nansen cache clear` removes; nothing reads or serves them.
- Cache file contents are unchanged; identity lives only in the key derivation.

## Test plan

- [x] `npm test` passes (2728 passed, 9 skipped)
- [x] `npm run lint` passes
- [x] New regression tests: same endpoint + body under a different identity, base URL, or HTTP method is a cache miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)
