### PR TITLE
fix: clearer limit-order cancel refund errors + document lookup→cancel race

### DIFF
--- a/.changeset/limit-order-cancel-refund-error-clarity.md
+++ b/.changeset/limit-order-cancel-refund-error-clarity.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+trade limit-order cancel: give distinct, actionable errors when the refund can't be verified — a fully-filled order now says so plainly ("nothing left to refund") instead of sharing the same generic message as unparseable order metadata.

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -1288,7 +1288,7 @@ describe('outcome verification (fail-closed)', () => {
     expect(global.fetch).toHaveBeenCalledTimes(3);
   });
 
-  it('cancel: refuses to sign when the order is found but its remaining refund amount cannot be computed', async () => {
+  it('cancel: refuses to sign (with an unparseable-specific message) when the order amounts cannot be parsed', async () => {
     SIMULATION_RPCS.solana = 'http://sol-sim.test';
     createTestWallet('lo-outcome-cancel-badmeta');
     const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
@@ -1296,7 +1296,7 @@ describe('outcome verification (fail-closed)', () => {
     mockFetchSequence([
       { body: { challenge: 'sign' } },
       { body: { token: 'jwt' } },
-      // order found, but inputAmount is unparseable — remainingRefundAmount can't bind a
+      // order found, but inputAmount is unparseable — classifyCancelRefund can't bind a
       // magnitude, so the verifier would silently downgrade to a bare positive-inflow check.
       // Fail closed instead of signing a withdrawal whose refund size we can't verify.
       { body: { orders: [{ id: 'order-1', inputMint: USDC, inputAmount: 'not-a-number', fills: [] }] } },
@@ -1309,7 +1309,37 @@ describe('outcome verification (fail-closed)', () => {
     await cmds.cancel([], null, {}, { order: 'order-1', wallet: 'lo-outcome-cancel-badmeta' });
 
     expect(exit).toHaveBeenCalledWith(1);
-    expect(logs.some(l => /could not determine its remaining refund amount/i.test(l))).toBe(true);
+    // Distinct from the fully-filled case: this must name the parse failure, not the
+    // generic "could not determine" wording it replaced.
+    expect(logs.some(l => /amounts couldn't be parsed/i.test(l))).toBe(true);
+    // 3 calls: challenge, verify, order lookup — cancelOrderRequest (the 4th) must never fire.
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('cancel: refuses to sign (with a fully-filled-specific message) when nothing is left to refund', async () => {
+    SIMULATION_RPCS.solana = 'http://sol-sim.test';
+    createTestWallet('lo-outcome-cancel-filled');
+    const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+    mockFetchSequence([
+      { body: { challenge: 'sign' } },
+      { body: { token: 'jwt' } },
+      // order found and parseable, but fully filled: fills consume the entire input, so the
+      // remaining refund is 0. That's a normal terminal state, not corrupt metadata — the
+      // user should be told plainly the order can't be cancelled, not shown a parse error.
+      { body: { orders: [{ id: 'order-1', inputMint: USDC, inputAmount: '1000000', fills: [{ inputAmount: '1000000' }] }] } },
+    ]);
+
+    const logs = [];
+    const exit = vi.fn();
+    const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+    await cmds.cancel([], null, {}, { order: 'order-1', wallet: 'lo-outcome-cancel-filled' });
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(logs.some(l => /fully filled/i.test(l) && /nothing left to refund/i.test(l))).toBe(true);
+    // Must NOT misreport this as a parse failure.
+    expect(logs.some(l => /couldn't be parsed/i.test(l))).toBe(false);
     // 3 calls: challenge, verify, order lookup — cancelOrderRequest (the 4th) must never fire.
     expect(global.fetch).toHaveBeenCalledTimes(3);
   });

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -452,21 +452,28 @@ async function findActiveOrder(token, userPubkey, orderId) {
 }
 
 /**
- * The base-unit amount a cancel should refund: the order's input less whatever has
- * already been filled (partial fills consume escrow). Returns undefined if the order's
- * amounts can't be parsed as integers or nothing is left to refund. The cancel command
- * treats an undefined result as fatal (fail closed) rather than signing a withdrawal
- * whose refund magnitude it can't bind.
+ * Classify how much a cancel should refund: the order's input less whatever has
+ * already been filled (partial fills consume escrow). Returns one of:
+ *   { amount: <bigint> }        the unfilled remainder still owed (always > 0)
+ *   { error: 'unparseable' }    the order's amounts couldn't be parsed as integers
+ *   { error: 'fully-filled' }   parsing succeeded but nothing is left to refund
+ *
+ * The two error cases are kept distinct (not collapsed to a single undefined) so the
+ * cancel command can surface an actionable message: 'unparseable' is an unexpected
+ * API-shape problem, 'fully-filled' is a normal user-facing state (the order already
+ * executed). Both are fatal for the caller — a cancel whose refund magnitude can't be
+ * bound must not be signed — but the user needs to know which one they hit.
  */
-function remainingRefundAmount(order) {
+function classifyCancelRefund(order) {
+  let remaining;
   try {
     const total = BigInt(order.inputAmount);
     const filled = (order.fills || []).reduce((sum, f) => sum + BigInt(f.inputAmount ?? 0), 0n);
-    const remaining = total - filled;
-    return remaining > 0n ? remaining : undefined;
+    remaining = total - filled;
   } catch {
-    return undefined;
+    return { error: 'unparseable' };
   }
+  return remaining > 0n ? { amount: remaining } : { error: 'fully-filled' };
 }
 
 // ============= Expiry Parsing =============
@@ -971,18 +978,35 @@ EXAMPLES:
             throw new Error(`Could not find order ${orderId} among your active orders; refusing to verify the cancel's refund asset. It may already be filled/cancelled/expired — check with "nansen trade limit-order list --state active".`);
           }
           cancelInputMint = order.inputMint;
-          cancelRefundAmount = remainingRefundAmount(order);
           // The whole point of the outcome check is to bind the refund's MAGNITUDE. If the
-          // order was found but its remaining refund can't be computed (unparseable amounts,
-          // or nothing left to refund), passing amount: undefined would silently downgrade
-          // the verifier to a bare positive-inflow check — reopening the dust-refund gap for
-          // exactly the malformed metadata we can least trust. Fail closed instead.
-          if (cancelRefundAmount == null) {
-            throw new Error(`Found order ${orderId} but could not determine its remaining refund amount from the order metadata; refusing to sign a cancel whose refund magnitude can't be verified. Check the order with "nansen trade limit-order list --state active".`);
+          // remaining refund can't be pinned to an exact amount, passing amount: undefined
+          // would silently downgrade the verifier to a bare positive-inflow check —
+          // reopening the dust-refund gap for exactly the metadata we can least trust. Fail
+          // closed instead, with a message that distinguishes the two reasons: unparseable
+          // amounts are an unexpected API-shape problem, a fully-filled order is a normal
+          // state the user should just be told about plainly.
+          const refund = classifyCancelRefund(order);
+          if (refund.error === 'unparseable') {
+            throw new Error(`Found order ${orderId} but its input/fill amounts couldn't be parsed from the order metadata; refusing to sign a cancel whose refund magnitude can't be verified. Check the order with "nansen trade limit-order list --state active".`);
           }
+          if (refund.error === 'fully-filled') {
+            throw new Error(`Order ${orderId} appears fully filled — there is nothing left to refund, so it can't be cancelled. Check its status with "nansen trade limit-order list --state active".`);
+          }
+          cancelRefundAmount = refund.amount;
         }
 
         // 3. Request cancellation — get unsigned withdrawal tx
+        //
+        // NOTE (deliberate, do not "fix" by loosening the check): there is a narrow TOCTOU
+        // window between the lookup in step 2 (which pins cancelRefundAmount to the unfilled
+        // remainder seen then) and this cancellation request. If a partial fill lands in
+        // between, the real withdrawal returns LESS than cancelRefundAmount and the outcome
+        // check in step 4 fails closed on a legitimate cancel. That's acceptable: the user
+        // simply retries and the next lookup sees the new remainder. The safe response to a
+        // spurious failure here is a retry, NOT relaxing the exact-magnitude bind — that bind
+        // is what closes the dust-refund redirect (a crafted withdrawal that reroutes most of
+        // the escrow and returns only a token of the right mint), so widening it reopens the
+        // exact gap this verification exists to close.
         log('  Requesting cancellation...');
         const cancelResult = await cancelOrderRequest(token, orderId);
 

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1599,7 +1599,7 @@ export function assertLimitOrderDepositOutcome(sim, { inputMint, amount }) {
  *   `amount` is OMITTED the check falls back to requiring a positive inflow only — this fallback
  *   is DELIBERATELY WEAKER than the magnitude bind and is not a safe default: a caller that can
  *   know the expected refund MUST pass it and fail closed when it is absent (as the cancel
- *   command does — see remainingRefundAmount in limit-order.js), rather than relying on this
+ *   command does — see classifyCancelRefund in limit-order.js), rather than relying on this
  *   bare-inflow path, which admits a dust-refund/redirect it cannot catch. A non-null `amount`
  *   that won't parse to an integer is a call-site bug and throws (never silently degrades).
  * @throws {Error} with `code = 'LIMIT_ORDER_OUTCOME_MISMATCH'` on any failed assertion.


### PR DESCRIPTION
## Summary

Fast-follow to #598 (the limit-order deposit/cancel outcome verification), addressing the two cleanup items from that PR's review. Both are on the Solana **cancel** path, both are non-security (the code already fails closed in every case here) — this is clarity and maintainability only.

## Changes

**1. Distinguish the two "refund can't be determined" cases.** The pre-cancel lookup previously collapsed *unparseable order amounts* and *fully-filled order* into a single `undefined`, and the cancel command surfaced the same generic `could not determine its remaining refund amount` message for both — which doesn't tell the user what actually happened.

- `remainingRefundAmount` → `classifyCancelRefund`, now returning a discriminated result: `{ amount }`, `{ error: 'unparseable' }`, or `{ error: 'fully-filled' }`.
- The cancel command now emits a distinct, actionable message per case: unparseable amounts read as an API-shape problem; a fully-filled order says plainly *"appears fully filled — there is nothing left to refund, so it can't be cancelled."*
- Both still fail closed (a cancel whose refund magnitude can't be bound is never signed). Only the message changes.

**2. Document the lookup→cancel race.** There's a narrow TOCTOU window between the pre-cancel order lookup (which pins the expected remaining refund) and the cancellation request. If a partial fill lands in between, the real withdrawal returns less than expected and the exact-magnitude outcome check fails closed on a *legitimate* cancel (retry succeeds). Added an explicit comment that the correct response is a retry, **not** loosening the magnitude bind — loosening reopens the dust-refund/redirect gap that the check exists to close.

## Test plan
- [x] `npm test` — 2758 pass / 9 skip. New test covers the fully-filled case; the existing unparseable test updated to assert the new parse-specific message (and that fully-filled is *not* misreported as a parse failure).
- [x] `npm run lint`
- [x] Rebased on `main` after #598 merged — diff is only these four files.

_Note: the deposit-side "right amount, wrong destination" binding is a separate, tracked follow-up and intentionally out of scope here._
