### PR TITLE
Bind limit-order deposits to vault destination

### DIFF
--- a/.changeset/bind-limit-order-vault-destination.md
+++ b/.changeset/bind-limit-order-vault-destination.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Reject limit-order deposits whose wallet-authorized SPL transfer does not target the user's vault token account.

--- a/.changeset/bind-limit-order-vault-destination.md
+++ b/.changeset/bind-limit-order-vault-destination.md
@@ -2,4 +2,4 @@
 "nansen-cli": patch
 ---
 
-Reject limit-order deposits whose wallet-authorized SPL transfer does not target the user's vault token account.
+Bind limit-order deposits to the trusted vault destination: reject any deposit whose wallet-sourced transfer (SPL token or native SOL) does not land in a token account this same transaction creates via CreateAccountWithSeed seeded off the user's vault. Covers both the SPL-token and native-SOL deposit paths.

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ node_modules/
 .idea/
 coverage/
 
+# Local git worktrees — scratch checkouts for parallel work, never committed.
+/.worktrees/
+
 # Internal planning / handoff / notes — contain internal ticket IDs and names.
 # nansen-cli is a public repo; these must never be committed. Kept in the working
 # tree so local agents (Claude, Codex, …) can read them.

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -31,8 +31,7 @@ import {
   cancelOrderRequest,
   confirmCancelOrder,
 } from '../limit-order.js';
-import { createWallet, base58Decode, base58Encode, generateSolanaWallet } from '../wallet.js';
-import { deriveATA } from '../transfer.js';
+import { createWallet, base58Decode, generateSolanaWallet } from '../wallet.js';
 import { SIMULATION_RPCS } from '../rpc-urls.js';
 
 let originalHome;
@@ -1174,15 +1173,18 @@ describe('buildLimitOrderCommands', () => {
 // handler's internal call.
 describe('outcome verification (fail-closed)', () => {
 
-  it('create: refuses to sign a deposit transfer that does not target the vault token account', async () => {
+  it('create: refuses to sign a deposit whose input transfer is not bound to a vault-seeded account', async () => {
     const wallet = createTestWallet('lo-destination-deposit-drain');
     const vaultPubkey = generateSolanaWallet().address;
     const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
-    const nonVaultAta = generateSolanaWallet().address;
+    // A crafted deposit that moves the input token to an attacker account with no
+    // System::CreateAccountWithSeed(base = vault) — so nothing binds the funds to
+    // the trusted vault. Must fail closed before signing.
+    const nonVaultAcct = generateSolanaWallet().address;
     const depositTx = buildTokenTransferCheckedTx({
       walletPubkey: wallet.solana,
       mint: USDC,
-      destination: nonVaultAta,
+      destination: nonVaultAcct,
     });
 
     mockFetchSequence([
@@ -1203,10 +1205,9 @@ describe('outcome verification (fail-closed)', () => {
       wallet: 'lo-destination-deposit-drain',
     });
 
-    const expectedVaultAta = base58Encode(deriveATA(vaultPubkey, USDC, 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'));
-    expect(nonVaultAta).not.toBe(expectedVaultAta);
     expect(exit).toHaveBeenCalledWith(1);
     expect(logs.some(l => /LIMIT_ORDER_DESTINATION_MISMATCH/i.test(l))).toBe(true);
+    // Fail-closed before the createOrder call (4 fetches: challenge, verify, vault, craft).
     expect(global.fetch).toHaveBeenCalledTimes(4);
   });
 

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -31,7 +31,8 @@ import {
   cancelOrderRequest,
   confirmCancelOrder,
 } from '../limit-order.js';
-import { createWallet, base58Decode, generateSolanaWallet } from '../wallet.js';
+import { createWallet, base58Decode, base58Encode, generateSolanaWallet } from '../wallet.js';
+import { deriveATA } from '../transfer.js';
 import { SIMULATION_RPCS } from '../rpc-urls.js';
 
 let originalHome;
@@ -239,9 +240,9 @@ describe('API client', () => {
   });
 
   it('getVault sends correct query params', async () => {
-    mockFetchResponse({ vaultPubkey: 'vault123', userPubkey: 'pub1' });
+    mockFetchResponse({ vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' });
     const result = await getVault('jwt-token', 'pub1');
-    expect(result.vaultPubkey).toBe('vault123');
+    expect(result.vaultPubkey).toBe('11111111111111111111111111111111');
 
     const [url, opts] = global.fetch.mock.calls[0];
     expect(url).toContain('userPubkey=pub1');
@@ -610,7 +611,7 @@ describe('buildLimitOrderCommands', () => {
       mockFetchSequence([
         { body: { challenge: 'sign this' } },
         { body: { token: 'jwt-123' } },
-        { body: { vaultPubkey: 'vault123', userPubkey: 'pub1' } },
+        { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' } },
         { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-req-1' } },
         { body: { id: 'order-slip', txSignature: 'sig-slip' }, status: 201 },
       ]);
@@ -663,7 +664,7 @@ describe('buildLimitOrderCommands', () => {
       mockFetchSequence([
         { body: { challenge: 'sign this' } },
         { body: { token: 'jwt-123' } },
-        { body: { vaultPubkey: 'vault1', userPubkey: 'pub1' } },
+        { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' } },
         { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } },
         { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },
       ]);
@@ -724,7 +725,7 @@ describe('buildLimitOrderCommands', () => {
       mockFetchSequence([
         { body: { challenge: 'sign this' } },          // [0] auth/challenge
         { body: { token: 'jwt-123' } },                 // [1] auth/verify
-        { body: { vaultPubkey: 'vault1', userPubkey: 'pub1' } }, // [2] vault check
+        { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' } }, // [2] vault check
         { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } }, // [3] deposit/craft
         { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },    // [4] createOrder
       ]);
@@ -835,7 +836,7 @@ describe('buildLimitOrderCommands', () => {
       mockFetchSequence([
         { body: { challenge: 'sign this' } },
         { body: { token: 'jwt-123' } },
-        { body: { vaultPubkey: 'vault123', userPubkey: 'pub1' } },
+        { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' } },
         { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-req-1' } },
         { body: { id: 'order-abc', txSignature: 'sig-xyz' }, status: 201 },
       ]);
@@ -874,7 +875,7 @@ describe('buildLimitOrderCommands', () => {
         { body: { challenge: 'sign this' } },
         { body: { token: 'jwt-123' } },
         { body: { message: 'Vault not found' }, status: 404 }, // getVault returns no vault
-        { body: { vaultPubkey: 'newVault', userPubkey: 'pub1' }, status: 201 }, // registerVault
+        { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' }, status: 201 }, // registerVault
         { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } },
         { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },
       ]);
@@ -1143,6 +1144,43 @@ describe('buildLimitOrderCommands', () => {
 // count, since a module-local signTransaction spy can't intercept the
 // handler's internal call.
 describe('outcome verification (fail-closed)', () => {
+
+  it('create: refuses to sign a deposit transfer that does not target the vault token account', async () => {
+    const wallet = createTestWallet('lo-destination-deposit-drain');
+    const vaultPubkey = generateSolanaWallet().address;
+    const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+    const nonVaultAta = generateSolanaWallet().address;
+    const depositTx = buildTokenTransferCheckedTx({
+      walletPubkey: wallet.solana,
+      mint: USDC,
+      destination: nonVaultAta,
+    });
+
+    mockFetchSequence([
+      { body: { challenge: 'sign this' } },
+      { body: { token: 'jwt-123' } },
+      { body: { vaultPubkey, userPubkey: wallet.solana } },
+      { body: { transaction: depositTx, requestId: 'dep-req-1' } },
+      { body: { id: 'order-should-not-submit', txSignature: 'sig-unused' }, status: 201 },
+    ]);
+
+    const logs = [];
+    const exit = vi.fn();
+    const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
+
+    await cmds.create([], null, {}, {
+      from: 'USDC', to: 'SOL', amount: '1',
+      'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
+      wallet: 'lo-destination-deposit-drain',
+    });
+
+    const expectedVaultAta = base58Encode(deriveATA(vaultPubkey, USDC, 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'));
+    expect(nonVaultAta).not.toBe(expectedVaultAta);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(logs.some(l => /LIMIT_ORDER_DESTINATION_MISMATCH/i.test(l))).toBe(true);
+    expect(global.fetch).toHaveBeenCalledTimes(4);
+  });
+
   it('create: refuses to sign a deposit whose simulated outflow exceeds the requested amount (repro)', async () => {
     SIMULATION_RPCS.solana = 'http://sol-sim.test';
     const wallet = createTestWallet('lo-outcome-deposit-drain');
@@ -1151,7 +1189,7 @@ describe('outcome verification (fail-closed)', () => {
     mockFetchSequence([
       { body: { challenge: 'sign this' } },
       { body: { token: 'jwt-123' } },
-      { body: { vaultPubkey: 'vault123', userPubkey: 'pub1' } },
+      { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' } },
       { body: { transaction: depositTx, requestId: 'dep-req-1' } },
       // sim: getMultipleAccounts — pre-state for the wallet's native account.
       { body: { result: { value: [solanaNativeAccountInfo(2_000_000_000)] } } },
@@ -1352,7 +1390,7 @@ describe('outcome verification (fail-closed)', () => {
     mockFetchSequence([
       { body: { challenge: 'sign this' } },
       { body: { token: 'jwt-123' } },
-      { body: { vaultPubkey: 'vault123', userPubkey: 'pub1' } },
+      { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' } },
       { body: { transaction: depositTx, requestId: 'dep-req-1' } },
       // sim: getMultipleAccounts fails outright (transport/RPC error) — must
       // degrade (warn + proceed), not block a legitimate deposit.
@@ -1512,6 +1550,25 @@ function buildLimitOrderTx({ walletPubkey, extraWritableKey } = {}) {
   const blockhash = Buffer.alloc(32, 0x03);
   const numInstructions = Buffer.from([0x00]);
   const message = Buffer.concat([header, numKeys, keyBytes, blockhash, numInstructions]);
+  return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), message]).toString('base64');
+}
+
+function buildTokenTransferCheckedTx({ walletPubkey, mint, destination }) {
+  const sourceAta = generateSolanaWallet().address;
+  const TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+  const keys = [walletPubkey, sourceAta, mint, destination, TOKEN_PROGRAM];
+  const header = Buffer.from([1, 0, 1]);
+  const numKeys = Buffer.from([keys.length]);
+  const keyBytes = Buffer.concat(keys.map((k) => base58Decode(k)));
+  const blockhash = Buffer.alloc(32, 0x03);
+  const numInstructions = Buffer.from([0x01]);
+  // TransferChecked: [source, mint, destination, authority]
+  const data = Buffer.from([12, 64, 66, 15, 0, 0, 0, 0, 0, 6]);
+  const instruction = Buffer.concat([
+    Buffer.from([4, 4, 1, 2, 3, 0, data.length]),
+    data,
+  ]);
+  const message = Buffer.concat([header, numKeys, keyBytes, blockhash, numInstructions, instruction]);
   return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), message]).toString('base64');
 }
 

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -889,6 +889,35 @@ describe('buildLimitOrderCommands', () => {
       // Should have made 6 API calls (challenge, verify, getVault, registerVault, craftDeposit, createOrder)
       expect(global.fetch).toHaveBeenCalledTimes(6);
     });
+
+    it('recovers vault address by re-fetching when register reports "already registered"', async () => {
+      createTestWallet('lo-vault-race');
+
+      const logs = [];
+      const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit: vi.fn() });
+
+      // getVault initially misses, registerVault loses the race, second getVault recovers the address.
+      mockFetchSequence([
+        { body: { challenge: 'sign this' } },
+        { body: { token: 'jwt-123' } },
+        { body: { message: 'Vault not found' }, status: 404 }, // [1] getVault: miss
+        { body: { message: 'vault already registered' }, status: 409 }, // [2] registerVault: race lost
+        { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' } }, // [3] getVault retry: recovered
+        { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } },
+        { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },
+      ]);
+
+      await cmds.create([], null, {}, {
+        from: 'SOL', to: 'USDC', amount: '1', 'trigger-mint': 'SOL', 'trigger-condition': 'below', 'trigger-price': '80',
+        wallet: 'lo-vault-race',
+      });
+
+      // Did not fail with the "cannot determine vault address" guard.
+      expect(logs.some(l => l.includes('Could not determine'))).toBe(false);
+      expect(logs.some(l => l.includes('Limit order created'))).toBe(true);
+      // challenge, verify, getVault, registerVault, getVault-retry, craftDeposit, createOrder
+      expect(global.fetch).toHaveBeenCalledTimes(7);
+    });
   });
 
   // ---- list ----

--- a/src/__tests__/limit-order.test.js
+++ b/src/__tests__/limit-order.test.js
@@ -31,8 +31,13 @@ import {
   cancelOrderRequest,
   confirmCancelOrder,
 } from '../limit-order.js';
-import { createWallet, base58Decode, generateSolanaWallet } from '../wallet.js';
+import { createWallet, base58Decode, base58Encode, generateSolanaWallet } from '../wallet.js';
 import { SIMULATION_RPCS } from '../rpc-urls.js';
+
+const TEST_USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const TEST_WSOL_MINT = 'So11111111111111111111111111111111111111112';
+const TEST_VAULT_PUBKEY = '11111111111111111111111111111111';
+const TEST_TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
 
 let originalHome;
 let tempDir;
@@ -602,7 +607,7 @@ describe('buildLimitOrderCommands', () => {
     });
 
     it('accepts valid slippage-bps and forwards it to createOrder', async () => {
-      createTestWallet('lo-create-slip');
+      const wallet = createTestWallet('lo-create-slip');
       const logs = [];
       const exit = vi.fn();
       const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
@@ -611,7 +616,7 @@ describe('buildLimitOrderCommands', () => {
         { body: { challenge: 'sign this' } },
         { body: { token: 'jwt-123' } },
         { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' } },
-        { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-req-1' } },
+        { body: { transaction: buildFakeBase64Tx({ walletPubkey: wallet.solana }), requestId: 'dep-req-1' } },
         { body: { id: 'order-slip', txSignature: 'sig-slip' }, status: 201 },
       ]);
 
@@ -655,7 +660,7 @@ describe('buildLimitOrderCommands', () => {
     });
 
     it('accepts valid Solana mint address', async () => {
-      createTestWallet('lo-addr-test');
+      const wallet = createTestWallet('lo-addr-test');
       const logs = [];
       const exit = vi.fn();
       const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
@@ -664,7 +669,7 @@ describe('buildLimitOrderCommands', () => {
         { body: { challenge: 'sign this' } },
         { body: { token: 'jwt-123' } },
         { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' } },
-        { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } },
+        { body: { transaction: buildFakeBase64Tx({ walletPubkey: wallet.solana }), requestId: 'dep-1' } },
         { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },
       ]);
 
@@ -715,7 +720,7 @@ describe('buildLimitOrderCommands', () => {
      */
     async function createAndGetInputAmount(amountStr, fromToken = 'SOL') {
       const walletName = `lo-amt-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-      createTestWallet(walletName);
+      const wallet = createTestWallet(walletName);
       const logs = [];
       const exit = vi.fn();
       const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit });
@@ -725,7 +730,7 @@ describe('buildLimitOrderCommands', () => {
         { body: { challenge: 'sign this' } },          // [0] auth/challenge
         { body: { token: 'jwt-123' } },                 // [1] auth/verify
         { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' } }, // [2] vault check
-        { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } }, // [3] deposit/craft
+        { body: { transaction: buildFakeBase64Tx({ walletPubkey: wallet.solana, inputMint: fromToken === 'USDC' ? TEST_USDC_MINT : TEST_WSOL_MINT }), requestId: 'dep-1' } }, // [3] deposit/craft
         { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },    // [4] createOrder
       ]);
 
@@ -824,7 +829,7 @@ describe('buildLimitOrderCommands', () => {
     });
 
     it('executes full create flow with local wallet', async () => {
-      createTestWallet('lo-create-test');
+      const wallet = createTestWallet('lo-create-test');
 
       const logs = [];
       const exit = vi.fn();
@@ -836,7 +841,7 @@ describe('buildLimitOrderCommands', () => {
         { body: { challenge: 'sign this' } },
         { body: { token: 'jwt-123' } },
         { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' } },
-        { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-req-1' } },
+        { body: { transaction: buildFakeBase64Tx({ walletPubkey: wallet.solana }), requestId: 'dep-req-1' } },
         { body: { id: 'order-abc', txSignature: 'sig-xyz' }, status: 201 },
       ]);
 
@@ -864,7 +869,7 @@ describe('buildLimitOrderCommands', () => {
     });
 
     it('auto-registers vault when not found', async () => {
-      createTestWallet('lo-vault-test');
+      const wallet = createTestWallet('lo-vault-test');
 
       const logs = [];
       const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit: vi.fn() });
@@ -875,7 +880,7 @@ describe('buildLimitOrderCommands', () => {
         { body: { token: 'jwt-123' } },
         { body: { message: 'Vault not found' }, status: 404 }, // getVault returns no vault
         { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' }, status: 201 }, // registerVault
-        { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } },
+        { body: { transaction: buildFakeBase64Tx({ walletPubkey: wallet.solana }), requestId: 'dep-1' } },
         { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },
       ]);
 
@@ -890,7 +895,7 @@ describe('buildLimitOrderCommands', () => {
     });
 
     it('recovers vault address by re-fetching when register reports "already registered"', async () => {
-      createTestWallet('lo-vault-race');
+      const wallet = createTestWallet('lo-vault-race');
 
       const logs = [];
       const cmds = buildLimitOrderCommands({ log: (m) => logs.push(m), exit: vi.fn() });
@@ -902,7 +907,7 @@ describe('buildLimitOrderCommands', () => {
         { body: { message: 'Vault not found' }, status: 404 }, // [1] getVault: miss
         { body: { message: 'vault already registered' }, status: 409 }, // [2] registerVault: race lost
         { body: { vaultPubkey: '11111111111111111111111111111111', userPubkey: 'pub1' } }, // [3] getVault retry: recovered
-        { body: { transaction: buildFakeBase64Tx(), requestId: 'dep-1' } },
+        { body: { transaction: buildFakeBase64Tx({ walletPubkey: wallet.solana }), requestId: 'dep-1' } },
         { body: { id: 'order-1', txSignature: 'sig-1' }, status: 201 },
       ]);
 
@@ -1564,23 +1569,91 @@ describe('outcome verification (fail-closed)', () => {
 
 // ============= Helpers =============
 
-/**
- * Build a minimal parseable legacy Solana transaction whose first account key
- * is the real wallet pubkey (writable, the only required signer) so
- * simulateSolanaAssetChanges can locate and track it. `extraWritableKey`, when
- * given, is a second writable non-signer account (used to simulate a token
- * account the wallet owns). Zero instructions — the outcome tests only care
- * about the mocked pre/post account snapshots, not the instruction contents.
- */
-function buildLimitOrderTx({ walletPubkey, extraWritableKey } = {}) {
-  const keys = extraWritableKey ? [walletPubkey, extraWritableKey] : [walletPubkey];
-  const header = Buffer.from([1, 0, 0]); // 1 required signer (wallet), 0 readonly signed, 0 readonly unsigned
+function testSeededAccount(base, seed, owner = TEST_TOKEN_PROGRAM) {
+  return base58Encode(crypto.createHash('sha256')
+    .update(Buffer.concat([base58Decode(base), Buffer.from(seed, 'utf8'), base58Decode(owner)]))
+    .digest());
+}
+
+function createWithSeedInstructionData(base, seed, owner = TEST_TOKEN_PROGRAM, { lamports = 2039280, space = 165 } = {}) {
+  const seedBytes = Buffer.from(seed, 'utf8');
+  const idx = Buffer.alloc(4); idx.writeUInt32LE(3);
+  const seedLen = Buffer.alloc(8); seedLen.writeBigUInt64LE(BigInt(seedBytes.length));
+  const lam = Buffer.alloc(8); lam.writeBigUInt64LE(BigInt(lamports));
+  const sp = Buffer.alloc(8); sp.writeBigUInt64LE(BigInt(space));
+  return Buffer.concat([idx, base58Decode(base), seedLen, seedBytes, lam, sp, base58Decode(owner)]);
+}
+
+function initializeAccount3InstructionData(owner) {
+  return Buffer.concat([Buffer.from([18]), base58Decode(owner)]);
+}
+
+function systemTransferInstructionData(lamports = 1000000000) {
+  const idx = Buffer.alloc(4); idx.writeUInt32LE(2);
+  const lam = Buffer.alloc(8); lam.writeBigUInt64LE(BigInt(lamports));
+  return Buffer.concat([idx, lam]);
+}
+
+function buildStaticDepositTx({
+  walletPubkey = generateSolanaWallet().address,
+  inputMint = TEST_WSOL_MINT,
+  vaultPubkey = TEST_VAULT_PUBKEY,
+  extraWritableKey,
+} = {}) {
+  const seed = 'test-order-seed';
+  const seededAcct = testSeededAccount(vaultPubkey, seed);
+  const isNative = inputMint === TEST_WSOL_MINT;
+  const sourceAta = extraWritableKey || (isNative ? null : generateSolanaWallet().address);
+  const keys = sourceAta
+    ? [walletPubkey, sourceAta, inputMint, seededAcct, TEST_TOKEN_PROGRAM, TEST_VAULT_PUBKEY]
+    : [walletPubkey, seededAcct, inputMint, TEST_TOKEN_PROGRAM, TEST_VAULT_PUBKEY];
+  const idxOf = (key) => {
+    const existing = keys.indexOf(key);
+    if (existing >= 0) return existing;
+    keys.push(key);
+    return keys.length - 1;
+  };
+  const tokenProgramIdx = idxOf(TEST_TOKEN_PROGRAM);
+  const systemProgramIdx = idxOf(TEST_VAULT_PUBKEY);
+  const vaultIdx = idxOf(vaultPubkey);
+  const seededIdx = idxOf(seededAcct);
+  const mintIdx = idxOf(inputMint);
+  const walletIdx = idxOf(walletPubkey);
+
+  const instructions = [
+    { programIdIndex: systemProgramIdx, accountIndexes: [walletIdx, seededIdx, vaultIdx], data: createWithSeedInstructionData(vaultPubkey, seed) },
+    { programIdIndex: tokenProgramIdx, accountIndexes: [seededIdx, mintIdx], data: initializeAccount3InstructionData(vaultPubkey) },
+  ];
+  if (isNative && !sourceAta) {
+    instructions.push({ programIdIndex: systemProgramIdx, accountIndexes: [walletIdx, seededIdx], data: systemTransferInstructionData() });
+  } else {
+    const sourceIdx = idxOf(sourceAta);
+    instructions.push({ programIdIndex: tokenProgramIdx, accountIndexes: [sourceIdx, mintIdx, seededIdx, walletIdx], data: Buffer.from([12, 64, 66, 15, 0, 0, 0, 0, 0, 6]) });
+  }
+
+  const writableCount = sourceAta ? 2 : 1;
+  const header = Buffer.from([1, 0, Math.max(0, keys.length - writableCount)]);
   const numKeys = Buffer.from([keys.length]);
   const keyBytes = Buffer.concat(keys.map((k) => base58Decode(k)));
   const blockhash = Buffer.alloc(32, 0x03);
-  const numInstructions = Buffer.from([0x00]);
-  const message = Buffer.concat([header, numKeys, keyBytes, blockhash, numInstructions]);
+  const encodedInstructions = instructions.map((ix) => Buffer.concat([
+    Buffer.from([ix.programIdIndex, ix.accountIndexes.length, ...ix.accountIndexes, ix.data.length]),
+    ix.data,
+  ]));
+  const message = Buffer.concat([header, numKeys, keyBytes, blockhash, Buffer.from([instructions.length]), ...encodedInstructions]);
   return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), message]).toString('base64');
+}
+
+/**
+ * Build a parseable legacy Solana transaction whose first account key is the
+ * real wallet pubkey (writable, the only required signer) so
+ * simulateSolanaAssetChanges can locate and track it. extraWritableKey, when
+ * given, is a second writable non-signer account (used to simulate a token
+ * account the wallet owns). The instruction contents are a statically valid
+ * limit-order deposit so destination validation can pass before outcome checks.
+ */
+function buildLimitOrderTx({ walletPubkey, extraWritableKey, inputMint = TEST_WSOL_MINT, vaultPubkey = TEST_VAULT_PUBKEY } = {}) {
+  return buildStaticDepositTx({ walletPubkey, extraWritableKey, inputMint, vaultPubkey });
 }
 
 function buildTokenTransferCheckedTx({ walletPubkey, mint, destination }) {
@@ -1619,26 +1692,8 @@ function solanaTokenAccountInfo({ mint, owner, amount }) {
 }
 
 /**
- * Build a minimal valid base64-encoded Solana VersionedTransaction.
- * This is a simplified fake for testing — just needs to be parseable
- * by signSolanaTransaction (compact-u16 sig count + 64-byte sig slot + message).
+ * Build a valid parseable limit-order deposit transaction for command tests.
  */
-function buildFakeBase64Tx() {
-  // A valid, parseable legacy transaction with a single benign instruction:
-  // 1 signature slot, then a legacy message [header][2 account keys][blockhash]
-  // [1 instruction referencing a non-SPL program]. It must actually parse —
-  // assertSolanaInstructionsSafe (run before signing on this path) now rejects
-  // unparseable transactions rather than silently ignoring them.
-  const sigCount = Buffer.from([0x01]);
-  const emptySig = Buffer.alloc(64, 0);
-  const header = Buffer.from([1, 0, 1]); // 1 signer (writable), 1 readonly unsigned (the program)
-  const numKeys = Buffer.from([0x02]);
-  const signerKey = Buffer.alloc(32, 0x01); // account index 0 = signer / fee payer
-  const programKey = Buffer.alloc(32, 0x02); // account index 1 = an arbitrary (non-SPL) program
-  const blockhash = Buffer.alloc(32, 0x03);
-  const numInstructions = Buffer.from([0x01]);
-  // instruction: programIdIndex=1, 1 account (index 0), 1 data byte
-  const instruction = Buffer.from([0x01, 0x01, 0x00, 0x01, 0x00]);
-  const message = Buffer.concat([header, numKeys, signerKey, programKey, blockhash, numInstructions, instruction]);
-  return Buffer.concat([sigCount, emptySig, message]).toString('base64');
+function buildFakeBase64Tx({ walletPubkey, inputMint = TEST_WSOL_MINT, vaultPubkey = TEST_VAULT_PUBKEY } = {}) {
+  return buildStaticDepositTx({ walletPubkey, inputMint, vaultPubkey });
 }

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -4,7 +4,8 @@ import path from 'path';
 import os from 'os';
 import { validateQuoteInput, fetchNativeBalance, fetchTokenBalance, validateBalance, resolvePercentAmount, validateGasBalance, GASLESS_MIN_TRADE_USD, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertInputWithinMax, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, assertSolanaSwapOutcome, assertLimitOrderDepositOutcome, assertLimitOrderCancelOutcome, assertLimitOrderDepositDestination, MAX_UINT256, needsAllowanceRevoke } from '../trade-validation.js';
 import { SOL_SENTINEL } from '../solana-simulation.js';
-import { base58Decode, generateSolanaWallet } from '../wallet.js';
+import crypto from 'crypto';
+import { base58Decode, base58Encode, generateSolanaWallet } from '../wallet.js';
 
 describe('validateQuoteInput', () => {
   const validSolana = {
@@ -2398,8 +2399,15 @@ describe('assertLimitOrderCancelOutcome', () => {
 });
 
 describe('assertLimitOrderDepositDestination', () => {
+  // Jupiter Trigger V2 funds each order through a per-order token account created
+  // in-tx via System::CreateAccountWithSeed(base = vault, seed, owner = TokenProg)
+  // — NOT the canonical ATA. These tests reproduce that real shape (confirmed by a
+  // live create round-trip) so the check is exercised against what actually lands
+  // on-chain, not a fabricated ATA transfer.
   const TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+  const SYSTEM_PROGRAM = '11111111111111111111111111111111';
   const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+  const WSOL = 'So11111111111111111111111111111111111111112';
 
   function encodeCompactU16(value) {
     if (value < 0x80) return Buffer.from([value]);
@@ -2424,63 +2432,160 @@ describe('assertLimitOrderDepositDestination', () => {
     return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), messageBytes]).toString('base64');
   }
 
-  it('allows a wallet-authorized TransferChecked into the vault token account', () => {
-    const wallet = generateSolanaWallet().address;
+  // Pubkey::create_with_seed(base, seed, owner) = base58(sha256(base || seed || owner)).
+  function seededAccount(base, seed, owner = TOKEN_PROGRAM) {
+    return base58Encode(crypto.createHash('sha256')
+      .update(Buffer.concat([base58Decode(base), Buffer.from(seed, 'utf8'), base58Decode(owner)]))
+      .digest());
+  }
+
+  // System::CreateAccountWithSeed instruction data (bincode layout).
+  function createWithSeedData(base, seed, owner = TOKEN_PROGRAM, { lamports = 2039280, space = 165 } = {}) {
+    const seedBytes = Buffer.from(seed, 'utf8');
+    const idx = Buffer.alloc(4); idx.writeUInt32LE(3);
+    const seedLen = Buffer.alloc(8); seedLen.writeBigUInt64LE(BigInt(seedBytes.length));
+    const lam = Buffer.alloc(8); lam.writeBigUInt64LE(BigInt(lamports));
+    const sp = Buffer.alloc(8); sp.writeBigUInt64LE(BigInt(space));
+    return Buffer.concat([idx, base58Decode(base), seedLen, seedBytes, lam, sp, base58Decode(owner)]);
+  }
+
+  // System::Transfer(lamports) instruction data.
+  function systemTransferData(lamports = 100000000) {
+    const idx = Buffer.alloc(4); idx.writeUInt32LE(2);
+    const lam = Buffer.alloc(8); lam.writeBigUInt64LE(BigInt(lamports));
+    return Buffer.concat([idx, lam]);
+  }
+
+  // Build a realistic SPL-input deposit: CreateAccountWithSeed(base=vault) then a
+  // wallet-authorized transfer of `mint` into the seeded account.
+  function splDeposit({ wallet, vault, mint, seed = 'order-seed-abc', dest, transferKind = 'checked', createBase }) {
+    const seededBase = createBase || vault;
+    const seededAcct = seededAccount(seededBase, seed);
+    const destination = dest || seededAcct;
     const sourceAta = generateSolanaWallet().address;
-    const vaultAta = generateSolanaWallet().address;
-    const tx = buildTransaction({
-      accountKeys: [wallet, sourceAta, USDC, vaultAta, TOKEN_PROGRAM],
-      instructions: [
-        { programIdIndex: 4, accountIndexes: [1, 2, 3, 0], data: Buffer.from([12, 0, 0, 0, 0, 0, 0, 0, 0, 6]) },
-      ],
-    });
-    expect(assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultTokenAccount: vaultAta }))
+    const keys = [wallet, sourceAta, mint, seededAcct, TOKEN_PROGRAM, SYSTEM_PROGRAM, seededBase];
+    const idxOf = (k) => { const i = keys.indexOf(k); return i >= 0 ? i : (keys.push(k) - 1); };
+    const destIdx = idxOf(destination);
+    const instructions = [
+      // CreateAccountWithSeed: [payer, created(=seededAcct), base]
+      { programIdIndex: keys.indexOf(SYSTEM_PROGRAM), accountIndexes: [0, keys.indexOf(seededAcct), keys.indexOf(seededBase)], data: createWithSeedData(seededBase, seed) },
+    ];
+    if (transferKind === 'checked') {
+      // TransferChecked: [source, mint, dest, authority]
+      instructions.push({ programIdIndex: keys.indexOf(TOKEN_PROGRAM), accountIndexes: [1, 2, destIdx, 0], data: Buffer.from([12, 0, 0, 0, 0, 0, 0, 0, 0, 6]) });
+    } else {
+      // Transfer: [source, dest, authority]
+      instructions.push({ programIdIndex: keys.indexOf(TOKEN_PROGRAM), accountIndexes: [1, destIdx, 0], data: Buffer.from([3, 64, 66, 15, 0, 0, 0, 0, 0]) });
+    }
+    return buildTransaction({ accountKeys: keys, instructions });
+  }
+
+  // Build a realistic native-SOL deposit: CreateAccountWithSeed(base=vault) then a
+  // wallet System::Transfer of lamports into the seeded (wrapped-SOL) account.
+  function nativeDeposit({ wallet, vault, seed = 'order-seed-sol', dest, createBase }) {
+    const seededBase = createBase || vault;
+    const seededAcct = seededAccount(seededBase, seed);
+    const destination = dest || seededAcct;
+    const keys = [wallet, seededAcct, TOKEN_PROGRAM, SYSTEM_PROGRAM, seededBase];
+    const idxOf = (k) => { const i = keys.indexOf(k); return i >= 0 ? i : (keys.push(k) - 1); };
+    const destIdx = idxOf(destination);
+    const instructions = [
+      { programIdIndex: keys.indexOf(SYSTEM_PROGRAM), accountIndexes: [0, keys.indexOf(seededAcct), keys.indexOf(seededBase)], data: createWithSeedData(seededBase, seed) },
+      // System::Transfer: [from, to]
+      { programIdIndex: keys.indexOf(SYSTEM_PROGRAM), accountIndexes: [0, destIdx], data: systemTransferData() },
+    ];
+    return buildTransaction({ accountKeys: keys, instructions });
+  }
+
+  it('allows a TransferChecked into the vault-seeded deposit account', () => {
+    const wallet = generateSolanaWallet().address;
+    const vault = generateSolanaWallet().address;
+    const tx = splDeposit({ wallet, vault, mint: USDC });
+    expect(assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultOwner: vault }))
       .toEqual({ verified: true });
   });
 
-  it('rejects a wallet-authorized TransferChecked to a non-vault destination', () => {
+  it('allows a native System::Transfer into the vault-seeded deposit account', () => {
     const wallet = generateSolanaWallet().address;
-    const sourceAta = generateSolanaWallet().address;
-    const vaultAta = generateSolanaWallet().address;
-    const nonVaultAta = generateSolanaWallet().address;
-    const tx = buildTransaction({
-      accountKeys: [wallet, sourceAta, USDC, nonVaultAta, vaultAta, TOKEN_PROGRAM],
-      instructions: [
-        { programIdIndex: 5, accountIndexes: [1, 2, 3, 0], data: Buffer.from([12, 0, 0, 0, 0, 0, 0, 0, 0, 6]) },
-      ],
-    });
-    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultTokenAccount: vaultAta }))
-      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*instead of vault token account/i);
+    const vault = generateSolanaWallet().address;
+    const tx = nativeDeposit({ wallet, vault });
+    expect(assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: WSOL, vaultOwner: vault }))
+      .toEqual({ verified: true });
   });
 
-  it('rejects a wallet-authorized TransferChecked for the wrong mint', () => {
+  it('rejects a TransferChecked to an account not seeded off the vault (the drain the ticket describes)', () => {
     const wallet = generateSolanaWallet().address;
-    const sourceAta = generateSolanaWallet().address;
+    const vault = generateSolanaWallet().address;
+    const attacker = generateSolanaWallet().address;
+    // Deposit account is seeded off the ATTACKER, not the trusted vault.
+    const tx = splDeposit({ wallet, vault, mint: USDC, createBase: attacker });
+    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultOwner: vault }))
+      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*vault-seeded deposit account/i);
+  });
+
+  it('rejects a TransferChecked whose destination is not the seeded account', () => {
+    const wallet = generateSolanaWallet().address;
+    const vault = generateSolanaWallet().address;
+    const elsewhere = generateSolanaWallet().address;
+    const tx = splDeposit({ wallet, vault, mint: USDC, dest: elsewhere });
+    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultOwner: vault }))
+      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*vault-seeded deposit account/i);
+  });
+
+  it('rejects a native System::Transfer whose destination is not the seeded account', () => {
+    const wallet = generateSolanaWallet().address;
+    const vault = generateSolanaWallet().address;
+    const elsewhere = generateSolanaWallet().address;
+    const tx = nativeDeposit({ wallet, vault, dest: elsewhere });
+    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: WSOL, vaultOwner: vault }))
+      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*native transfer[\s\S]*vault-seeded deposit account/i);
+  });
+
+  it('rejects a TransferChecked for the wrong mint', () => {
+    const wallet = generateSolanaWallet().address;
+    const vault = generateSolanaWallet().address;
     const wrongMint = generateSolanaWallet().address;
-    const vaultAta = generateSolanaWallet().address;
-    const tx = buildTransaction({
-      accountKeys: [wallet, sourceAta, wrongMint, vaultAta, TOKEN_PROGRAM],
-      instructions: [
-        { programIdIndex: 4, accountIndexes: [1, 2, 3, 0], data: Buffer.from([12, 0, 0, 0, 0, 0, 0, 0, 0, 6]) },
-      ],
-    });
-    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultTokenAccount: vaultAta }))
+    const tx = splDeposit({ wallet, vault, mint: wrongMint });
+    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultOwner: vault }))
       .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*instead of deposit mint/i);
   });
 
-  it('rejects a wallet-authorized Transfer to a non-vault destination', () => {
+  it('rejects a classic Transfer to an account not seeded off the vault', () => {
     const wallet = generateSolanaWallet().address;
+    const vault = generateSolanaWallet().address;
+    const elsewhere = generateSolanaWallet().address;
+    const tx = splDeposit({ wallet, vault, mint: USDC, dest: elsewhere, transferKind: 'plain' });
+    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultOwner: vault }))
+      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*vault-seeded deposit account/i);
+  });
+
+  it('rejects when CreateAccountWithSeed target does not match its base/seed/owner derivation', () => {
+    const wallet = generateSolanaWallet().address;
+    const vault = generateSolanaWallet().address;
+    const seed = 'order-seed-xyz';
+    const realSeeded = seededAccount(vault, seed);
+    const spoofed = generateSolanaWallet().address; // != realSeeded
     const sourceAta = generateSolanaWallet().address;
-    const nonVaultAta = generateSolanaWallet().address;
-    const vaultAta = generateSolanaWallet().address;
+    // The instruction claims to create `spoofed` but its data derives `realSeeded`.
+    const keys = [wallet, sourceAta, USDC, spoofed, TOKEN_PROGRAM, SYSTEM_PROGRAM, vault];
     const tx = buildTransaction({
-      accountKeys: [wallet, sourceAta, nonVaultAta, vaultAta, TOKEN_PROGRAM],
+      accountKeys: keys,
       instructions: [
-        { programIdIndex: 4, accountIndexes: [1, 2, 0], data: Buffer.from([3, 64, 66, 15, 0, 0, 0, 0, 0]) },
+        { programIdIndex: 5, accountIndexes: [0, 3, 6], data: createWithSeedData(vault, seed) },
+        { programIdIndex: 4, accountIndexes: [1, 2, 3, 0], data: Buffer.from([12, 0, 0, 0, 0, 0, 0, 0, 0, 6]) },
       ],
     });
-    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultTokenAccount: vaultAta }))
-      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*instead of vault token account/i);
+    expect(realSeeded).not.toBe(spoofed);
+    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultOwner: vault }))
+      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*does not match its base\/seed\/owner/i);
+  });
+
+  it('throws when the vault owner is not provided', () => {
+    const wallet = generateSolanaWallet().address;
+    const vault = generateSolanaWallet().address;
+    const tx = splDeposit({ wallet, vault, mint: USDC });
+    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC }))
+      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*missing vault owner/i);
   });
 });
 

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { validateQuoteInput, fetchNativeBalance, fetchTokenBalance, validateBalance, resolvePercentAmount, validateGasBalance, GASLESS_MIN_TRADE_USD, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertInputWithinMax, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, assertSolanaSwapOutcome, assertLimitOrderDepositOutcome, assertLimitOrderCancelOutcome, MAX_UINT256, needsAllowanceRevoke } from '../trade-validation.js';
+import { validateQuoteInput, fetchNativeBalance, fetchTokenBalance, validateBalance, resolvePercentAmount, validateGasBalance, GASLESS_MIN_TRADE_USD, encodeApproveCalldata, assertValidApprovalSpender, assertQuoteMatchesRequest, assertInputWithinMax, assertSwapCalldataNotBareTransfer, assertSwapOutcome, assertSolanaInstructionsSafe, assertSolanaSwapOutcome, assertLimitOrderDepositOutcome, assertLimitOrderCancelOutcome, assertLimitOrderDepositDestination, MAX_UINT256, needsAllowanceRevoke } from '../trade-validation.js';
 import { SOL_SENTINEL } from '../solana-simulation.js';
 import { base58Decode, generateSolanaWallet } from '../wallet.js';
 
@@ -2394,6 +2394,93 @@ describe('assertLimitOrderCancelOutcome', () => {
     const sim = { deltas: { [USDC]: 1n } };
     expect(() => assertLimitOrderCancelOutcome(sim, { inputMint: USDC, amount: 'not-a-number' }))
       .toThrow(/LIMIT_ORDER_OUTCOME_MISMATCH[\s\S]*is not an integer/i);
+  });
+});
+
+describe('assertLimitOrderDepositDestination', () => {
+  const TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+  const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+  function encodeCompactU16(value) {
+    if (value < 0x80) return Buffer.from([value]);
+    if (value < 0x4000) return Buffer.from([(value & 0x7f) | 0x80, (value >> 7) & 0x7f]);
+    return Buffer.from([(value & 0x7f) | 0x80, ((value >> 7) & 0x7f) | 0x80, (value >> 14) & 0x03]);
+  }
+
+  function buildTransaction({ accountKeys, instructions }) {
+    const parts = [Buffer.from([1, 0, accountKeys.length - 1])];
+    parts.push(encodeCompactU16(accountKeys.length));
+    for (const k of accountKeys) parts.push(base58Decode(k));
+    parts.push(base58Decode(accountKeys[0]));
+    parts.push(encodeCompactU16(instructions.length));
+    for (const ix of instructions) {
+      parts.push(Buffer.from([ix.programIdIndex]));
+      parts.push(encodeCompactU16(ix.accountIndexes.length));
+      for (const idx of ix.accountIndexes) parts.push(Buffer.from([idx]));
+      parts.push(encodeCompactU16(ix.data.length));
+      parts.push(ix.data);
+    }
+    const messageBytes = Buffer.concat(parts);
+    return Buffer.concat([Buffer.from([1]), Buffer.alloc(64), messageBytes]).toString('base64');
+  }
+
+  it('allows a wallet-authorized TransferChecked into the vault token account', () => {
+    const wallet = generateSolanaWallet().address;
+    const sourceAta = generateSolanaWallet().address;
+    const vaultAta = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, sourceAta, USDC, vaultAta, TOKEN_PROGRAM],
+      instructions: [
+        { programIdIndex: 4, accountIndexes: [1, 2, 3, 0], data: Buffer.from([12, 0, 0, 0, 0, 0, 0, 0, 0, 6]) },
+      ],
+    });
+    expect(assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultTokenAccount: vaultAta }))
+      .toEqual({ verified: true });
+  });
+
+  it('rejects a wallet-authorized TransferChecked to a non-vault destination', () => {
+    const wallet = generateSolanaWallet().address;
+    const sourceAta = generateSolanaWallet().address;
+    const vaultAta = generateSolanaWallet().address;
+    const nonVaultAta = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, sourceAta, USDC, nonVaultAta, vaultAta, TOKEN_PROGRAM],
+      instructions: [
+        { programIdIndex: 5, accountIndexes: [1, 2, 3, 0], data: Buffer.from([12, 0, 0, 0, 0, 0, 0, 0, 0, 6]) },
+      ],
+    });
+    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultTokenAccount: vaultAta }))
+      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*instead of vault token account/i);
+  });
+
+  it('rejects a wallet-authorized TransferChecked for the wrong mint', () => {
+    const wallet = generateSolanaWallet().address;
+    const sourceAta = generateSolanaWallet().address;
+    const wrongMint = generateSolanaWallet().address;
+    const vaultAta = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, sourceAta, wrongMint, vaultAta, TOKEN_PROGRAM],
+      instructions: [
+        { programIdIndex: 4, accountIndexes: [1, 2, 3, 0], data: Buffer.from([12, 0, 0, 0, 0, 0, 0, 0, 0, 6]) },
+      ],
+    });
+    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultTokenAccount: vaultAta }))
+      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*instead of deposit mint/i);
+  });
+
+  it('rejects a wallet-authorized Transfer to a non-vault destination', () => {
+    const wallet = generateSolanaWallet().address;
+    const sourceAta = generateSolanaWallet().address;
+    const nonVaultAta = generateSolanaWallet().address;
+    const vaultAta = generateSolanaWallet().address;
+    const tx = buildTransaction({
+      accountKeys: [wallet, sourceAta, nonVaultAta, vaultAta, TOKEN_PROGRAM],
+      instructions: [
+        { programIdIndex: 4, accountIndexes: [1, 2, 0], data: Buffer.from([3, 64, 66, 15, 0, 0, 0, 0, 0]) },
+      ],
+    });
+    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultTokenAccount: vaultAta }))
+      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*instead of vault token account/i);
   });
 });
 

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -2449,6 +2449,11 @@ describe('assertLimitOrderDepositDestination', () => {
     return Buffer.concat([idx, base58Decode(base), seedLen, seedBytes, lam, sp, base58Decode(owner)]);
   }
 
+  // SPL Token::InitializeAccount3 instruction data: [18, owner pubkey].
+  function initializeAccount3Data(owner) {
+    return Buffer.concat([Buffer.from([18]), base58Decode(owner)]);
+  }
+
   // System::Transfer(lamports) instruction data.
   function systemTransferData(lamports = 100000000) {
     const idx = Buffer.alloc(4); idx.writeUInt32LE(2);
@@ -2458,7 +2463,7 @@ describe('assertLimitOrderDepositDestination', () => {
 
   // Build a realistic SPL-input deposit: CreateAccountWithSeed(base=vault) then a
   // wallet-authorized transfer of `mint` into the seeded account.
-  function splDeposit({ wallet, vault, mint, seed = 'order-seed-abc', dest, transferKind = 'checked', createBase }) {
+  function splDeposit({ wallet, vault, mint, seed = 'order-seed-abc', dest, transferKind = 'checked', createBase, tokenOwner }) {
     const seededBase = createBase || vault;
     const seededAcct = seededAccount(seededBase, seed);
     const destination = dest || seededAcct;
@@ -2469,6 +2474,8 @@ describe('assertLimitOrderDepositDestination', () => {
     const instructions = [
       // CreateAccountWithSeed: [payer, created(=seededAcct), base]
       { programIdIndex: keys.indexOf(SYSTEM_PROGRAM), accountIndexes: [0, keys.indexOf(seededAcct), keys.indexOf(seededBase)], data: createWithSeedData(seededBase, seed) },
+      // InitializeAccount3: [account, mint], owner in data.
+      { programIdIndex: keys.indexOf(TOKEN_PROGRAM), accountIndexes: [keys.indexOf(seededAcct), 2], data: initializeAccount3Data(tokenOwner || vault) },
     ];
     if (transferKind === 'checked') {
       // TransferChecked: [source, mint, dest, authority]
@@ -2482,7 +2489,7 @@ describe('assertLimitOrderDepositDestination', () => {
 
   // Build a realistic native-SOL deposit: CreateAccountWithSeed(base=vault) then a
   // wallet System::Transfer of lamports into the seeded (wrapped-SOL) account.
-  function nativeDeposit({ wallet, vault, seed = 'order-seed-sol', dest, createBase }) {
+  function nativeDeposit({ wallet, vault, seed = 'order-seed-sol', dest, createBase, tokenOwner }) {
     const seededBase = createBase || vault;
     const seededAcct = seededAccount(seededBase, seed);
     const destination = dest || seededAcct;
@@ -2491,6 +2498,8 @@ describe('assertLimitOrderDepositDestination', () => {
     const destIdx = idxOf(destination);
     const instructions = [
       { programIdIndex: keys.indexOf(SYSTEM_PROGRAM), accountIndexes: [0, keys.indexOf(seededAcct), keys.indexOf(seededBase)], data: createWithSeedData(seededBase, seed) },
+      // InitializeAccount3: [account, mint], owner in data.
+      { programIdIndex: keys.indexOf(TOKEN_PROGRAM), accountIndexes: [keys.indexOf(seededAcct), idxOf(WSOL)], data: initializeAccount3Data(tokenOwner || vault) },
       // System::Transfer: [from, to]
       { programIdIndex: keys.indexOf(SYSTEM_PROGRAM), accountIndexes: [0, destIdx], data: systemTransferData() },
     ];
@@ -2530,6 +2539,34 @@ describe('assertLimitOrderDepositDestination', () => {
     const tx = splDeposit({ wallet, vault, mint: USDC, dest: elsewhere });
     expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultOwner: vault }))
       .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*vault-seeded deposit account/i);
+  });
+
+  it('rejects a TransferChecked into a vault-seeded account initialized with attacker authority', () => {
+    const wallet = generateSolanaWallet().address;
+    const vault = generateSolanaWallet().address;
+    const attacker = generateSolanaWallet().address;
+    const tx = splDeposit({ wallet, vault, mint: USDC, tokenOwner: attacker });
+    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultOwner: vault }))
+      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*authority[\s\S]*expected vault owner/i);
+  });
+
+  it('rejects a TransferChecked into a vault-seeded account without a matching initializer', () => {
+    const wallet = generateSolanaWallet().address;
+    const vault = generateSolanaWallet().address;
+    const seed = 'order-seed-no-init';
+    const seededAcct = seededAccount(vault, seed);
+    const sourceAta = generateSolanaWallet().address;
+    const keys = [wallet, sourceAta, USDC, seededAcct, TOKEN_PROGRAM, SYSTEM_PROGRAM, vault];
+    const tx = buildTransaction({
+      accountKeys: keys,
+      instructions: [
+        { programIdIndex: 5, accountIndexes: [0, 3, 6], data: createWithSeedData(vault, seed) },
+        { programIdIndex: 4, accountIndexes: [1, 2, 3, 0], data: Buffer.from([12, 0, 0, 0, 0, 0, 0, 0, 0, 6]) },
+      ],
+    });
+
+    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultOwner: vault }))
+      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*trusted vault authority/i);
   });
 
   it('rejects a native System::Transfer whose destination is not the seeded account', () => {
@@ -2572,6 +2609,7 @@ describe('assertLimitOrderDepositDestination', () => {
       accountKeys: keys,
       instructions: [
         { programIdIndex: 5, accountIndexes: [0, 3, 6], data: createWithSeedData(vault, seed) },
+        { programIdIndex: 4, accountIndexes: [3, 2], data: initializeAccount3Data(vault) },
         { programIdIndex: 4, accountIndexes: [1, 2, 3, 0], data: Buffer.from([12, 0, 0, 0, 0, 0, 0, 0, 0, 6]) },
       ],
     });

--- a/src/__tests__/trade-validation.test.js
+++ b/src/__tests__/trade-validation.test.js
@@ -2522,6 +2522,24 @@ describe('assertLimitOrderDepositDestination', () => {
       .toEqual({ verified: true });
   });
 
+  it('rejects when no wallet-authorized deposit transfer is present', () => {
+    const wallet = generateSolanaWallet().address;
+    const vault = generateSolanaWallet().address;
+    const seed = 'order-seed-no-transfer';
+    const seededAcct = seededAccount(vault, seed);
+    const keys = [wallet, seededAcct, USDC, TOKEN_PROGRAM, SYSTEM_PROGRAM, vault];
+    const tx = buildTransaction({
+      accountKeys: keys,
+      instructions: [
+        { programIdIndex: 4, accountIndexes: [0, 1, 5], data: createWithSeedData(vault, seed) },
+        { programIdIndex: 3, accountIndexes: [1, 2], data: initializeAccount3Data(vault) },
+      ],
+    });
+
+    expect(() => assertLimitOrderDepositDestination(tx, { walletAddress: wallet, inputMint: USDC, vaultOwner: vault }))
+      .toThrow(/LIMIT_ORDER_DESTINATION_MISMATCH[\s\S]*no wallet-authorized deposit transfer/i);
+  });
+
   it('rejects a TransferChecked to an account not seeded off the vault (the drain the ticket describes)', () => {
     const wallet = generateSolanaWallet().address;
     const vault = generateSolanaWallet().address;

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -9,7 +9,7 @@
 import fs from 'fs';
 import path from 'path';
 import { base58Encode, exportWallet, getWalletConfig, showWallet } from './wallet.js';
-import { signEd25519, base58Decode, parseAmount, getTokenInfo, deriveATA } from './transfer.js';
+import { signEd25519, base58Decode, parseAmount, getTokenInfo } from './transfer.js';
 import { signSolanaTransaction, resolveTokenAddress } from './trading.js';
 import {
   assertSolanaInstructionsSafe,
@@ -34,7 +34,6 @@ const TRADING_API_URL = process.env.NANSEN_TRADING_API_URL || 'https://trading-a
 const LO_PREFIX = '/limit-order/v2';
 const SOLSCAN_TX_URL = 'https://solscan.io/tx/';
 const WSOL_MINT = 'So11111111111111111111111111111111111111112';
-const TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
 
 // ============= JWT Auth & Caching (Local File) =============
 
@@ -359,11 +358,6 @@ function getLocalWalletPrivateKey(walletName) {
   const effectiveName = walletName || config.defaultWallet;
   const exported = exportWallet(effectiveName, password);
   return exported.solana.privateKey;
-}
-
-function deriveVaultTokenAccount(vaultPubkey, inputMint, tokenProgram = TOKEN_PROGRAM) {
-  const mint = inputMint === '11111111111111111111111111111111' ? WSOL_MINT : inputMint;
-  return base58Encode(deriveATA(vaultPubkey, mint, tokenProgram));
 }
 
 // ============= Transaction Signing =============
@@ -699,7 +693,6 @@ EXAMPLES:
       // Amount is always in human-readable token units (e.g. 1.5 = 1.5 SOL)
       // Converted to base units (lamports) internally
       let amountBaseUnits;
-      let fromTokenProgram;
       try {
         const num = Number(amount);
         if (isNaN(num) || num <= 0) {
@@ -711,15 +704,9 @@ EXAMPLES:
         let decimals;
         if (fromInfo) {
           decimals = fromInfo.decimals;
-          // Every current entry is a classic Token Program mint, so the default
-          // holds. Carry an explicit tokenProgram if a future Token-2022 entry is
-          // added — otherwise deriveVaultTokenAccount would compute the wrong ATA
-          // and fail-close every deposit for that mint.
-          fromTokenProgram = fromInfo.tokenProgram || TOKEN_PROGRAM;
         } else {
           const tokenInfo = await getTokenInfo(CHAIN_RPCS.solana, from);
           decimals = tokenInfo.decimals;
-          fromTokenProgram = tokenInfo.tokenProgram || TOKEN_PROGRAM;
         }
         amountBaseUnits = String(parseAmount(String(amount), decimals));
       } catch (err) {
@@ -829,7 +816,6 @@ EXAMPLES:
         if (!vaultPubkey) {
           throw new Error('Could not determine your limit-order vault address; refusing to sign a deposit whose destination cannot be verified.');
         }
-        const vaultTokenAccount = deriveVaultTokenAccount(vaultPubkey, from, fromTokenProgram);
 
         // 4. Craft deposit transaction
         log('  Crafting deposit transaction...');
@@ -843,19 +829,19 @@ EXAMPLES:
         // 5. Sign deposit transaction
         // Three pre-signing defenses run here. The generic static gate rejects
         // delegate grants, authority changes, close-to-stranger, and excessive
-        // priority fees. The limit-order destination gate then binds visible
-        // wallet-authorized SPL transfers to the vault token account. Finally,
-        // balance-delta outcome verification binds magnitude: the input token
-        // must leave the wallet by exactly `amount` (± fee/rent slack for native
-        // SOL) and no other token may leave.
-        // Verified live: a real SOL→USDC create round-trip clears both gates (the
-        // API-crafted deposit is a SOL-wrap transfer into the vault plus a
-        // temp-WSOL close-to-self).
+        // priority fees. The limit-order destination gate then binds every
+        // wallet-sourced transfer (SPL for token deposits, native System::Transfer
+        // for SOL) to a token account this same tx creates via
+        // CreateAccountWithSeed seeded off the trusted vault owner — the real
+        // Jupiter Trigger V2 deposit shape, confirmed by a live create round-trip.
+        // Finally, balance-delta outcome verification binds magnitude: the input
+        // token must leave the wallet by exactly `amount` (± fee/rent slack for
+        // native SOL) and no other token may leave.
         assertSolanaInstructionsSafe(deposit.transaction, { walletAddress: pubkey });
         assertLimitOrderDepositDestination(deposit.transaction, {
           walletAddress: pubkey,
           inputMint: from,
-          vaultTokenAccount,
+          vaultOwner: vaultPubkey,
         });
         const depositOutcome = await verifyLimitOrderOutcome({
           kind: 'deposit', walletAddress: pubkey, txBase64: deposit.transaction,

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -699,7 +699,7 @@ EXAMPLES:
       // Amount is always in human-readable token units (e.g. 1.5 = 1.5 SOL)
       // Converted to base units (lamports) internally
       let amountBaseUnits;
-      let fromTokenProgram = TOKEN_PROGRAM;
+      let fromTokenProgram;
       try {
         const num = Number(amount);
         if (isNaN(num) || num <= 0) {
@@ -711,6 +711,11 @@ EXAMPLES:
         let decimals;
         if (fromInfo) {
           decimals = fromInfo.decimals;
+          // Every current entry is a classic Token Program mint, so the default
+          // holds. Carry an explicit tokenProgram if a future Token-2022 entry is
+          // added — otherwise deriveVaultTokenAccount would compute the wrong ATA
+          // and fail-close every deposit for that mint.
+          fromTokenProgram = fromInfo.tokenProgram || TOKEN_PROGRAM;
         } else {
           const tokenInfo = await getTokenInfo(CHAIN_RPCS.solana, from);
           decimals = tokenInfo.decimals;
@@ -807,6 +812,18 @@ EXAMPLES:
           } catch (regErr) {
             // Vault may already exist — ignore "already registered" errors
             if (!/already registered/i.test(regErr.message)) throw regErr;
+          }
+          // Registration either reported "already registered" or returned no
+          // address. The vault exists in both cases, so fetch it to recover the
+          // address rather than failing the deposit below with a misleading
+          // "cannot determine vault address".
+          if (!vaultPubkey) {
+            try {
+              const vaultInfo = await getVault(token, pubkey);
+              vaultPubkey = vaultInfo?.vaultPubkey || vaultInfo?.vaultAddress;
+            } catch {
+              // Still unknown — fall through to the guard below.
+            }
           }
         }
         if (!vaultPubkey) {

--- a/src/limit-order.js
+++ b/src/limit-order.js
@@ -9,10 +9,11 @@
 import fs from 'fs';
 import path from 'path';
 import { base58Encode, exportWallet, getWalletConfig, showWallet } from './wallet.js';
-import { signEd25519, base58Decode, parseAmount, getTokenInfo } from './transfer.js';
+import { signEd25519, base58Decode, parseAmount, getTokenInfo, deriveATA } from './transfer.js';
 import { signSolanaTransaction, resolveTokenAddress } from './trading.js';
 import {
   assertSolanaInstructionsSafe,
+  assertLimitOrderDepositDestination,
   assertLimitOrderDepositOutcome,
   assertLimitOrderCancelOutcome,
   NATIVE_FEE_RENT_SLACK_LAMPORTS,
@@ -33,6 +34,7 @@ const TRADING_API_URL = process.env.NANSEN_TRADING_API_URL || 'https://trading-a
 const LO_PREFIX = '/limit-order/v2';
 const SOLSCAN_TX_URL = 'https://solscan.io/tx/';
 const WSOL_MINT = 'So11111111111111111111111111111111111111112';
+const TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
 
 // ============= JWT Auth & Caching (Local File) =============
 
@@ -357,6 +359,11 @@ function getLocalWalletPrivateKey(walletName) {
   const effectiveName = walletName || config.defaultWallet;
   const exported = exportWallet(effectiveName, password);
   return exported.solana.privateKey;
+}
+
+function deriveVaultTokenAccount(vaultPubkey, inputMint, tokenProgram = TOKEN_PROGRAM) {
+  const mint = inputMint === '11111111111111111111111111111111' ? WSOL_MINT : inputMint;
+  return base58Encode(deriveATA(vaultPubkey, mint, tokenProgram));
 }
 
 // ============= Transaction Signing =============
@@ -692,6 +699,7 @@ EXAMPLES:
       // Amount is always in human-readable token units (e.g. 1.5 = 1.5 SOL)
       // Converted to base units (lamports) internally
       let amountBaseUnits;
+      let fromTokenProgram = TOKEN_PROGRAM;
       try {
         const num = Number(amount);
         if (isNaN(num) || num <= 0) {
@@ -706,6 +714,7 @@ EXAMPLES:
         } else {
           const tokenInfo = await getTokenInfo(CHAIN_RPCS.solana, from);
           decimals = tokenInfo.decimals;
+          fromTokenProgram = tokenInfo.tokenProgram || TOKEN_PROGRAM;
         }
         amountBaseUnits = String(parseAmount(String(amount), decimals));
       } catch (err) {
@@ -782,21 +791,28 @@ EXAMPLES:
         // 3. Check vault, auto-register if needed
         // Backend returns { vaultPubkey: "..." } when vault exists, or throws/returns empty when not
         let hasVault = false;
+        let vaultPubkey;
         try {
           const vaultInfo = await getVault(token, pubkey);
-          hasVault = !!(vaultInfo?.vaultPubkey || vaultInfo?.vaultAddress);
+          vaultPubkey = vaultInfo?.vaultPubkey || vaultInfo?.vaultAddress;
+          hasVault = !!vaultPubkey;
         } catch {
           // No vault found
         }
         if (!hasVault) {
           log('  Registering vault for first-time use...');
           try {
-            await registerVault(token);
+            const vaultInfo = await registerVault(token);
+            vaultPubkey = vaultInfo?.vaultPubkey || vaultInfo?.vaultAddress;
           } catch (regErr) {
             // Vault may already exist — ignore "already registered" errors
             if (!/already registered/i.test(regErr.message)) throw regErr;
           }
         }
+        if (!vaultPubkey) {
+          throw new Error('Could not determine your limit-order vault address; refusing to sign a deposit whose destination cannot be verified.');
+        }
+        const vaultTokenAccount = deriveVaultTokenAccount(vaultPubkey, from, fromTokenProgram);
 
         // 4. Craft deposit transaction
         log('  Crafting deposit transaction...');
@@ -808,21 +824,22 @@ EXAMPLES:
         });
 
         // 5. Sign deposit transaction
-        // Two layers of pre-signing defense, same as the swap path. First, the
-        // static gate: the legitimate deposit moves the input token into the
-        // already-registered vault (step 3) with an SPL Transfer/TransferChecked —
-        // which this gate does not classify — plus, when selling native SOL, a
-        // temp-WSOL CloseAccount whose rent returns to the wallet (permitted).
-        // Neither trips the delegate/authority/close-to-stranger checks, so this
-        // does not reject a well-formed deposit; it only fires if the crafted tx
-        // additionally grants a delegate, reassigns authority, or closes to a
-        // stranger. Second, balance-delta outcome verification below binds the
-        // deposit's magnitude: the input token must leave the wallet by exactly
-        // `amount` (± fee/rent slack for native SOL) and no other token may leave.
+        // Three pre-signing defenses run here. The generic static gate rejects
+        // delegate grants, authority changes, close-to-stranger, and excessive
+        // priority fees. The limit-order destination gate then binds visible
+        // wallet-authorized SPL transfers to the vault token account. Finally,
+        // balance-delta outcome verification binds magnitude: the input token
+        // must leave the wallet by exactly `amount` (± fee/rent slack for native
+        // SOL) and no other token may leave.
         // Verified live: a real SOL→USDC create round-trip clears both gates (the
         // API-crafted deposit is a SOL-wrap transfer into the vault plus a
         // temp-WSOL close-to-self).
         assertSolanaInstructionsSafe(deposit.transaction, { walletAddress: pubkey });
+        assertLimitOrderDepositDestination(deposit.transaction, {
+          walletAddress: pubkey,
+          inputMint: from,
+          vaultTokenAccount,
+        });
         const depositOutcome = await verifyLimitOrderOutcome({
           kind: 'deposit', walletAddress: pubkey, txBase64: deposit.transaction,
           inputMint: from, amount: amountBaseUnits, log,

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -4,8 +4,10 @@
  * bad amounts) before any network call.
  */
 
+import crypto from 'crypto';
 import { validateAddress } from './api.js';
 import { CHAIN_RPCS } from './rpc-urls.js';
+import { base58Encode } from './wallet.js';
 import { parseTransactionMessage, resolveStaticAccount } from './solana-tx.js';
 import { SOL_SENTINEL } from './solana-simulation.js';
 import { EVM_NATIVE_SENTINEL } from './swap-simulation.js';
@@ -26,6 +28,11 @@ const SPL_SET_AUTHORITY = 6;
 const SPL_CLOSE_ACCOUNT = 9;
 const SPL_TRANSFER_CHECKED = 12;
 const SPL_APPROVE_CHECKED = 13;
+
+const SYSTEM_PROGRAM = '11111111111111111111111111111111';
+const SYSTEM_INSTR_TRANSFER = 2;
+const SYSTEM_INSTR_CREATE_ACCOUNT_WITH_SEED = 3;
+const WSOL_MINT = 'So11111111111111111111111111111111111111112';
 
 const COMPUTE_BUDGET_PROGRAM = 'ComputeBudget111111111111111111111111111111';
 const COMPUTE_BUDGET_SET_UNIT_LIMIT = 2;
@@ -1853,14 +1860,30 @@ export function assertSolanaInstructionsSafe(txBase64, { walletAddress } = {}) {
 }
 
 /**
- * Statically bind a limit-order deposit's wallet-authorized SPL transfer to
- * the vault token account for the deposited mint. This closes the destination
- * gap that balance-delta simulation cannot see: a tx can spend exactly the
- * requested amount from the wallet while sending it to a non-vault token
- * account. This check is intentionally limit-order-specific; generic swaps
- * cannot require a single destination.
+ * Statically bind a limit-order deposit's wallet-sourced outflow to a token
+ * account provably derived from the trusted vault owner. This closes the
+ * destination gap balance-delta simulation cannot see: a tx can spend exactly
+ * the requested amount from the wallet while sending it to an attacker's
+ * account.
+ *
+ * The real on-chain shape (confirmed by a live create round-trip) is NOT the
+ * vault's canonical ATA. Jupiter Trigger V2 funds each order through a fresh
+ * per-order token account created in the same transaction via
+ * System::CreateAccountWithSeed(base = vaultOwner, seed = <per-order>,
+ * owner = Token program), then:
+ *   - SPL input  → TransferChecked / Transfer of the input token into it, or
+ *   - native SOL → System::Transfer of lamports into it, then SyncNative.
+ * So the destination is per-order and changes every craft; we can't pin a fixed
+ * address. Instead we recompute create_with_seed(base, seed, owner) from the
+ * transaction's own CreateAccountWithSeed instruction, require base == the
+ * trusted vaultOwner, and bind every wallet-sourced transfer to that recomputed
+ * account. This is stronger than an ATA equality check: the destination is
+ * provably seeded off the vault the backend told us to deposit into.
+ *
+ * This check is intentionally limit-order-specific; generic swaps cannot
+ * require a single destination.
  */
-export function assertLimitOrderDepositDestination(txBase64, { walletAddress, inputMint, vaultTokenAccount } = {}) {
+export function assertLimitOrderDepositDestination(txBase64, { walletAddress, inputMint, vaultOwner } = {}) {
   const fail = (detail) => {
     const e = new Error(`Limit-order deposit destination mismatch (LIMIT_ORDER_DESTINATION_MISMATCH): ${detail} Refusing to sign.`);
     e.code = 'LIMIT_ORDER_DESTINATION_MISMATCH';
@@ -1869,7 +1892,7 @@ export function assertLimitOrderDepositDestination(txBase64, { walletAddress, in
 
   if (!walletAddress) throw fail('missing signing wallet address.');
   if (!inputMint) throw fail('missing deposit input mint.');
-  if (!vaultTokenAccount) throw fail('missing vault token account.');
+  if (!vaultOwner) throw fail('missing vault owner address.');
 
   const parsed = parseTransactionMessage(txBase64);
   const accountAt = (ix, position) => resolveStaticAccount(parsed, ix.accountIndexes[position]);
@@ -1881,42 +1904,77 @@ export function assertLimitOrderDepositDestination(txBase64, { walletAddress, in
     return false;
   };
 
-  const expectedMint = SOLANA_NATIVE_SOL_ALIASES.has(inputMint)
-    ? 'So11111111111111111111111111111111111111112'
-    : inputMint;
+  // Pass 1: collect the token accounts this transaction creates via
+  // System::CreateAccountWithSeed seeded off the trusted vault owner. These are
+  // the only destinations a legitimate deposit may target.
+  const vaultSeededAccounts = new Set();
+  for (const ix of parsed.instructions) {
+    if (resolveStaticAccount(parsed, ix.programIdIndex) !== SYSTEM_PROGRAM) continue;
+    if (ix.data.length < 4 || ix.data.readUInt32LE(0) !== SYSTEM_INSTR_CREATE_ACCOUNT_WITH_SEED) continue;
+    // Layout: u32 index | 32 base | u64 seedLen | seed | u64 lamports | u64 space | 32 owner
+    let off = 4;
+    const need = (n) => { if (off + n > ix.data.length) throw fail('malformed CreateAccountWithSeed instruction.'); };
+    need(32); const base = ix.data.subarray(off, off + 32); off += 32;
+    need(8); const seedLen = Number(ix.data.readBigUInt64LE(off)); off += 8;
+    need(seedLen); const seed = ix.data.subarray(off, off + seedLen); off += seedLen;
+    need(16); off += 16; // skip lamports (u64) + space (u64)
+    need(32); const owner = ix.data.subarray(off, off + 32);
+    if (base58Encode(base) !== vaultOwner) continue; // not seeded off our vault
+    if (!SPL_TOKEN_PROGRAMS.has(base58Encode(owner))) continue; // not a token account
+    // create_with_seed(base, seed, owner) = base58(sha256(base || seed || owner)).
+    const derived = base58Encode(crypto.createHash('sha256').update(Buffer.concat([base, seed, owner])).digest());
+    // The account the instruction creates (index 1) must equal the recomputed
+    // address; a mismatch means a malformed/crafted instruction — fail closed.
+    const created = accountAt(ix, 1);
+    if (created !== null && created !== derived) {
+      throw fail('CreateAccountWithSeed target does not match its base/seed/owner derivation.');
+    }
+    vaultSeededAccounts.add(derived);
+  }
 
+  const expectedMint = SOLANA_NATIVE_SOL_ALIASES.has(inputMint) ? WSOL_MINT : inputMint;
+  const requireSeeded = (destination, label) => {
+    if (!vaultSeededAccounts.has(destination)) {
+      throw fail(`wallet-authorized ${label} sends funds to ${destination || 'an address only resolvable via an address lookup table'} instead of a vault-seeded deposit account.`);
+    }
+  };
+
+  // Pass 2: every wallet-sourced transfer of value must land in a vault-seeded
+  // account. Covers both deposit shapes — SPL token transfers and the native-SOL
+  // System::Transfer that funds a wrapped-SOL order account.
   for (const ix of parsed.instructions) {
     const programId = resolveStaticAccount(parsed, ix.programIdIndex);
     if (!programId) {
       throw fail('transaction invokes a program only resolvable via an address lookup table, so transfer destinations cannot be verified.');
     }
-    if (!SPL_TOKEN_PROGRAMS.has(programId) || ix.data.length === 0) continue;
 
+    if (programId === SYSTEM_PROGRAM) {
+      if (ix.data.length < 4 || ix.data.readUInt32LE(0) !== SYSTEM_INSTR_TRANSFER) continue;
+      // System::Transfer accounts: [from (signer), to]. `from` must be a signer,
+      // so it can never be ALT-resolved; null means a malformed tx — fail closed.
+      const from = accountAt(ix, 0);
+      if (from === null) throw fail('native transfer source is unresolvable (malformed transaction).');
+      if (from !== walletAddress) continue; // not our funds
+      requireSeeded(accountAt(ix, 1), 'native transfer');
+      continue;
+    }
+
+    if (!SPL_TOKEN_PROGRAMS.has(programId) || ix.data.length === 0) continue;
     const discriminator = ix.data[0];
     if (discriminator === SPL_TRANSFER) {
-      // Classic Transfer does not encode the mint in its account list, so we can
-      // only bind the destination — not the mint — without an extra RPC lookup.
-      // This is not a weakness: vaultTokenAccount is the deposit mint's own ATA
-      // (derived per-mint upstream), so a legitimate deposit lands here, and the
-      // balance-delta simulation still bounds the amount and token that leave the
-      // wallet. Do not add a mint check here — the classic Transfer cannot supply
-      // one; use TransferChecked (below) if mint binding at the instruction level
-      // is required.
+      // Classic Transfer carries no mint in its account list, so we bind only the
+      // destination. Not a weakness: the destination is a vault-seeded account and
+      // the balance-delta gate still bounds which token and how much leave the
+      // wallet. Use TransferChecked (below) for instruction-level mint binding.
       if (!walletAuthorizes(ix, 2)) continue;
-      const destination = accountAt(ix, 1);
-      if (destination !== vaultTokenAccount) {
-        throw fail(`wallet-authorized token transfer sends funds to ${destination || 'an address only resolvable via an address lookup table'} instead of vault token account ${vaultTokenAccount}.`);
-      }
+      requireSeeded(accountAt(ix, 1), 'token transfer');
     } else if (discriminator === SPL_TRANSFER_CHECKED) {
       if (!walletAuthorizes(ix, 3)) continue;
       const mint = accountAt(ix, 1);
-      const destination = accountAt(ix, 2);
       if (!tokensEqual(mint, expectedMint, 'solana')) {
         throw fail(`wallet-authorized TransferChecked uses mint ${mint || 'an address only resolvable via an address lookup table'} instead of deposit mint ${expectedMint}.`);
       }
-      if (destination !== vaultTokenAccount) {
-        throw fail(`wallet-authorized TransferChecked sends funds to ${destination || 'an address only resolvable via an address lookup table'} instead of vault token account ${vaultTokenAccount}.`);
-      }
+      requireSeeded(accountAt(ix, 2), 'TransferChecked');
     }
   }
 

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -20,9 +20,11 @@ const SPL_TOKEN_PROGRAMS = new Set([
   'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
   'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
 ]);
+const SPL_TRANSFER = 3;
 const SPL_APPROVE = 4;
 const SPL_SET_AUTHORITY = 6;
 const SPL_CLOSE_ACCOUNT = 9;
+const SPL_TRANSFER_CHECKED = 12;
 const SPL_APPROVE_CHECKED = 13;
 
 const COMPUTE_BUDGET_PROGRAM = 'ComputeBudget111111111111111111111111111111';
@@ -1484,8 +1486,9 @@ export function assertSolanaSwapOutcome(request, quote, sim, { slippage, sibling
  *      within `amount` ± NATIVE_FEE_RENT_SLACK_LAMPORTS for a native-SOL input
  *      (two-sided: upper bound caps the drain, lower bound rejects a partial reroute), and
  *   2. no token OTHER than the input leaves the wallet (native-SOL dust tolerated).
- * NOTE: this bounds MAGNITUDE, not destination — a full-`amount` transfer to a non-vault
- * address still passes; that is closed by the vault-destination binding (fast-follow).
+ * NOTE: this bounds MAGNITUDE, not destination. The create command pairs it with
+ * assertLimitOrderDepositDestination so a wallet-authorized SPL transfer of the
+ * deposited asset must land in the vault's token account.
  * There is no output leg — the deposit funds the vault, nothing returns to the wallet.
  *
  * @param {{deltas: Record<string, bigint|string|number>}} sim - simulateSolanaAssetChanges result
@@ -1847,4 +1850,67 @@ export function assertSolanaInstructionsSafe(txBase64, { walletAddress } = {}) {
   }
 
   return parsed;
+}
+
+/**
+ * Statically bind a limit-order deposit's wallet-authorized SPL transfer to
+ * the vault token account for the deposited mint. This closes the destination
+ * gap that balance-delta simulation cannot see: a tx can spend exactly the
+ * requested amount from the wallet while sending it to a non-vault token
+ * account. This check is intentionally limit-order-specific; generic swaps
+ * cannot require a single destination.
+ */
+export function assertLimitOrderDepositDestination(txBase64, { walletAddress, inputMint, vaultTokenAccount } = {}) {
+  const fail = (detail) => {
+    const e = new Error(`Limit-order deposit destination mismatch (LIMIT_ORDER_DESTINATION_MISMATCH): ${detail} Refusing to sign.`);
+    e.code = 'LIMIT_ORDER_DESTINATION_MISMATCH';
+    return e;
+  };
+
+  if (!walletAddress) throw fail('missing signing wallet address.');
+  if (!inputMint) throw fail('missing deposit input mint.');
+  if (!vaultTokenAccount) throw fail('missing vault token account.');
+
+  const parsed = parseTransactionMessage(txBase64);
+  const accountAt = (ix, position) => resolveStaticAccount(parsed, ix.accountIndexes[position]);
+  const walletAuthorizes = (ix, authorityPos) => {
+    if (accountAt(ix, authorityPos) === null) return true;
+    for (let i = authorityPos; i < ix.accountIndexes.length; i++) {
+      if (accountAt(ix, i) === walletAddress) return true;
+    }
+    return false;
+  };
+
+  const expectedMint = SOLANA_NATIVE_SOL_ALIASES.has(inputMint)
+    ? 'So11111111111111111111111111111111111111112'
+    : inputMint;
+
+  for (const ix of parsed.instructions) {
+    const programId = resolveStaticAccount(parsed, ix.programIdIndex);
+    if (!programId) {
+      throw fail('transaction invokes a program only resolvable via an address lookup table, so transfer destinations cannot be verified.');
+    }
+    if (!SPL_TOKEN_PROGRAMS.has(programId) || ix.data.length === 0) continue;
+
+    const discriminator = ix.data[0];
+    if (discriminator === SPL_TRANSFER) {
+      if (!walletAuthorizes(ix, 2)) continue;
+      const destination = accountAt(ix, 1);
+      if (destination !== vaultTokenAccount) {
+        throw fail(`wallet-authorized token transfer sends funds to ${destination || 'an address only resolvable via an address lookup table'} instead of vault token account ${vaultTokenAccount}.`);
+      }
+    } else if (discriminator === SPL_TRANSFER_CHECKED) {
+      if (!walletAuthorizes(ix, 3)) continue;
+      const mint = accountAt(ix, 1);
+      const destination = accountAt(ix, 2);
+      if (!tokensEqual(mint, expectedMint, 'solana')) {
+        throw fail(`wallet-authorized TransferChecked uses mint ${mint || 'an address only resolvable via an address lookup table'} instead of deposit mint ${expectedMint}.`);
+      }
+      if (destination !== vaultTokenAccount) {
+        throw fail(`wallet-authorized TransferChecked sends funds to ${destination || 'an address only resolvable via an address lookup table'} instead of vault token account ${vaultTokenAccount}.`);
+      }
+    }
+  }
+
+  return { verified: true };
 }

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1894,6 +1894,14 @@ export function assertLimitOrderDepositDestination(txBase64, { walletAddress, in
 
     const discriminator = ix.data[0];
     if (discriminator === SPL_TRANSFER) {
+      // Classic Transfer does not encode the mint in its account list, so we can
+      // only bind the destination — not the mint — without an extra RPC lookup.
+      // This is not a weakness: vaultTokenAccount is the deposit mint's own ATA
+      // (derived per-mint upstream), so a legitimate deposit lands here, and the
+      // balance-delta simulation still bounds the amount and token that leave the
+      // wallet. Do not add a mint check here — the classic Transfer cannot supply
+      // one; use TransferChecked (below) if mint binding at the instruction level
+      // is required.
       if (!walletAuthorizes(ix, 2)) continue;
       const destination = accountAt(ix, 1);
       if (destination !== vaultTokenAccount) {

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -1989,6 +1989,7 @@ export function assertLimitOrderDepositDestination(txBase64, { walletAddress, in
       throw fail(`vault-seeded token account authority is ${initialized.owner} instead of expected vault owner ${vaultOwner}.`);
     }
   };
+  let sawValidDepositTransfer = false;
 
   for (const ix of parsed.instructions) {
     const programId = resolveStaticAccount(parsed, ix.programIdIndex);
@@ -2005,6 +2006,7 @@ export function assertLimitOrderDepositDestination(txBase64, { walletAddress, in
       if (from === null) throw fail('native transfer source is unresolvable (malformed transaction).');
       if (from !== walletAddress) continue; // not our funds
       requireTrustedDestination(accountAt(ix, 1), 'native transfer');
+      sawValidDepositTransfer = true;
       continue;
     }
 
@@ -2017,6 +2019,7 @@ export function assertLimitOrderDepositDestination(txBase64, { walletAddress, in
       // wallet. Use TransferChecked (below) for instruction-level mint binding.
       if (!walletAuthorizes(ix, 2)) continue;
       requireTrustedDestination(accountAt(ix, 1), 'token transfer');
+      sawValidDepositTransfer = true;
     } else if (discriminator === SPL_TRANSFER_CHECKED) {
       if (!walletAuthorizes(ix, 3)) continue;
       const mint = accountAt(ix, 1);
@@ -2024,8 +2027,12 @@ export function assertLimitOrderDepositDestination(txBase64, { walletAddress, in
         throw fail(`wallet-authorized TransferChecked uses mint ${mint || 'an address only resolvable via an address lookup table'} instead of deposit mint ${expectedMint}.`);
       }
       requireTrustedDestination(accountAt(ix, 2), 'TransferChecked');
+      sawValidDepositTransfer = true;
     }
   }
 
+  if (!sawValidDepositTransfer) {
+    throw fail('no wallet-authorized deposit transfer into a vault-seeded account was detected.');
+  }
   return { verified: true };
 }

--- a/src/trade-validation.js
+++ b/src/trade-validation.js
@@ -28,6 +28,9 @@ const SPL_SET_AUTHORITY = 6;
 const SPL_CLOSE_ACCOUNT = 9;
 const SPL_TRANSFER_CHECKED = 12;
 const SPL_APPROVE_CHECKED = 13;
+const SPL_INITIALIZE_ACCOUNT = 1;
+const SPL_INITIALIZE_ACCOUNT2 = 16;
+const SPL_INITIALIZE_ACCOUNT3 = 18;
 
 const SYSTEM_PROGRAM = '11111111111111111111111111111111';
 const SYSTEM_INSTR_TRANSFER = 2;
@@ -1904,44 +1907,89 @@ export function assertLimitOrderDepositDestination(txBase64, { walletAddress, in
     return false;
   };
 
+  const expectedMint = SOLANA_NATIVE_SOL_ALIASES.has(inputMint) ? WSOL_MINT : inputMint;
+
   // Pass 1: collect the token accounts this transaction creates via
-  // System::CreateAccountWithSeed seeded off the trusted vault owner. These are
-  // the only destinations a legitimate deposit may target.
+  // System::CreateAccountWithSeed seeded off the trusted vault owner, plus the
+  // matching SPL InitializeAccount* owner/mint assignment. A seeded address
+  // alone is not enough: the token-account authority must also be the trusted
+  // vault owner, otherwise the deposit can be withdrawn by whoever controls the
+  // initialized account.
   const vaultSeededAccounts = new Set();
+  const initializedAccounts = new Map();
   for (const ix of parsed.instructions) {
-    if (resolveStaticAccount(parsed, ix.programIdIndex) !== SYSTEM_PROGRAM) continue;
-    if (ix.data.length < 4 || ix.data.readUInt32LE(0) !== SYSTEM_INSTR_CREATE_ACCOUNT_WITH_SEED) continue;
-    // Layout: u32 index | 32 base | u64 seedLen | seed | u64 lamports | u64 space | 32 owner
-    let off = 4;
-    const need = (n) => { if (off + n > ix.data.length) throw fail('malformed CreateAccountWithSeed instruction.'); };
-    need(32); const base = ix.data.subarray(off, off + 32); off += 32;
-    need(8); const seedLen = Number(ix.data.readBigUInt64LE(off)); off += 8;
-    need(seedLen); const seed = ix.data.subarray(off, off + seedLen); off += seedLen;
-    need(16); off += 16; // skip lamports (u64) + space (u64)
-    need(32); const owner = ix.data.subarray(off, off + 32);
-    if (base58Encode(base) !== vaultOwner) continue; // not seeded off our vault
-    if (!SPL_TOKEN_PROGRAMS.has(base58Encode(owner))) continue; // not a token account
-    // create_with_seed(base, seed, owner) = base58(sha256(base || seed || owner)).
-    const derived = base58Encode(crypto.createHash('sha256').update(Buffer.concat([base, seed, owner])).digest());
-    // The account the instruction creates (index 1) must equal the recomputed
-    // address; a mismatch means a malformed/crafted instruction — fail closed.
-    const created = accountAt(ix, 1);
-    if (created !== null && created !== derived) {
-      throw fail('CreateAccountWithSeed target does not match its base/seed/owner derivation.');
+    const programId = resolveStaticAccount(parsed, ix.programIdIndex);
+    if (programId === SYSTEM_PROGRAM) {
+      if (ix.data.length < 4 || ix.data.readUInt32LE(0) !== SYSTEM_INSTR_CREATE_ACCOUNT_WITH_SEED) continue;
+      // Layout: u32 index | 32 base | u64 seedLen | seed | u64 lamports | u64 space | 32 owner
+      let off = 4;
+      const need = (n) => { if (off + n > ix.data.length) throw fail('malformed CreateAccountWithSeed instruction.'); };
+      need(32); const base = ix.data.subarray(off, off + 32); off += 32;
+      need(8); const seedLen = Number(ix.data.readBigUInt64LE(off)); off += 8;
+      need(seedLen); const seed = ix.data.subarray(off, off + seedLen); off += seedLen;
+      need(16); off += 16; // skip lamports (u64) + space (u64)
+      need(32); const owner = ix.data.subarray(off, off + 32);
+      if (base58Encode(base) !== vaultOwner) continue; // not seeded off our vault
+      if (!SPL_TOKEN_PROGRAMS.has(base58Encode(owner))) continue; // not a token account
+      // create_with_seed(base, seed, owner) = base58(sha256(base || seed || owner)).
+      const derived = base58Encode(crypto.createHash('sha256').update(Buffer.concat([base, seed, owner])).digest());
+      // The account the instruction creates (index 1) must equal the recomputed
+      // address; a mismatch means a malformed/crafted instruction — fail closed.
+      const created = accountAt(ix, 1);
+      if (created !== null && created !== derived) {
+        throw fail('CreateAccountWithSeed target does not match its base/seed/owner derivation.');
+      }
+      vaultSeededAccounts.add(derived);
+      continue;
     }
-    vaultSeededAccounts.add(derived);
+
+    if (!SPL_TOKEN_PROGRAMS.has(programId) || ix.data.length === 0) continue;
+    const discriminator = ix.data[0];
+    let account;
+    let mint;
+    let owner;
+
+    if (discriminator === SPL_INITIALIZE_ACCOUNT) {
+      // InitializeAccount: accounts [account, mint, owner, rent].
+      account = accountAt(ix, 0);
+      mint = accountAt(ix, 1);
+      owner = accountAt(ix, 2);
+    } else if (discriminator === SPL_INITIALIZE_ACCOUNT2 || discriminator === SPL_INITIALIZE_ACCOUNT3) {
+      // InitializeAccount2/3: accounts [account, mint, ...], data [disc, owner pubkey].
+      if (ix.data.length < 33) throw fail('malformed InitializeAccount owner field.');
+      account = accountAt(ix, 0);
+      mint = accountAt(ix, 1);
+      owner = base58Encode(ix.data.subarray(1, 33));
+    } else {
+      continue;
+    }
+
+    if (account === null || mint === null || owner === null) {
+      throw fail('token account initializer uses an address only resolvable via an address lookup table.');
+    }
+    initializedAccounts.set(account, { mint, owner });
   }
 
-  const expectedMint = SOLANA_NATIVE_SOL_ALIASES.has(inputMint) ? WSOL_MINT : inputMint;
-  const requireSeeded = (destination, label) => {
+  // Pass 2: every wallet-sourced transfer of value must land in a vault-seeded
+  // account that is also initialized in this transaction with the vault as its
+  // token-account authority. Covers both deposit shapes — SPL token transfers
+  // and the native-SOL System::Transfer that funds a wrapped-SOL order account.
+  const requireTrustedDestination = (destination, label) => {
     if (!vaultSeededAccounts.has(destination)) {
       throw fail(`wallet-authorized ${label} sends funds to ${destination || 'an address only resolvable via an address lookup table'} instead of a vault-seeded deposit account.`);
     }
+    const initialized = initializedAccounts.get(destination);
+    if (!initialized) {
+      throw fail(`wallet-authorized ${label} sends funds to ${destination} before verifying it is initialized with the trusted vault authority.`);
+    }
+    if (!tokensEqual(initialized.mint, expectedMint, 'solana')) {
+      throw fail(`vault-seeded token account is initialized for mint ${initialized.mint} instead of deposit mint ${expectedMint}.`);
+    }
+    if (initialized.owner !== vaultOwner) {
+      throw fail(`vault-seeded token account authority is ${initialized.owner} instead of expected vault owner ${vaultOwner}.`);
+    }
   };
 
-  // Pass 2: every wallet-sourced transfer of value must land in a vault-seeded
-  // account. Covers both deposit shapes — SPL token transfers and the native-SOL
-  // System::Transfer that funds a wrapped-SOL order account.
   for (const ix of parsed.instructions) {
     const programId = resolveStaticAccount(parsed, ix.programIdIndex);
     if (!programId) {
@@ -1949,13 +1997,14 @@ export function assertLimitOrderDepositDestination(txBase64, { walletAddress, in
     }
 
     if (programId === SYSTEM_PROGRAM) {
-      if (ix.data.length < 4 || ix.data.readUInt32LE(0) !== SYSTEM_INSTR_TRANSFER) continue;
+      if (ix.data.length < 4) continue;
+      if (ix.data.readUInt32LE(0) !== SYSTEM_INSTR_TRANSFER) continue;
       // System::Transfer accounts: [from (signer), to]. `from` must be a signer,
       // so it can never be ALT-resolved; null means a malformed tx — fail closed.
       const from = accountAt(ix, 0);
       if (from === null) throw fail('native transfer source is unresolvable (malformed transaction).');
       if (from !== walletAddress) continue; // not our funds
-      requireSeeded(accountAt(ix, 1), 'native transfer');
+      requireTrustedDestination(accountAt(ix, 1), 'native transfer');
       continue;
     }
 
@@ -1967,14 +2016,14 @@ export function assertLimitOrderDepositDestination(txBase64, { walletAddress, in
       // the balance-delta gate still bounds which token and how much leave the
       // wallet. Use TransferChecked (below) for instruction-level mint binding.
       if (!walletAuthorizes(ix, 2)) continue;
-      requireSeeded(accountAt(ix, 1), 'token transfer');
+      requireTrustedDestination(accountAt(ix, 1), 'token transfer');
     } else if (discriminator === SPL_TRANSFER_CHECKED) {
       if (!walletAuthorizes(ix, 3)) continue;
       const mint = accountAt(ix, 1);
       if (!tokensEqual(mint, expectedMint, 'solana')) {
         throw fail(`wallet-authorized TransferChecked uses mint ${mint || 'an address only resolvable via an address lookup table'} instead of deposit mint ${expectedMint}.`);
       }
-      requireSeeded(accountAt(ix, 2), 'TransferChecked');
+      requireTrustedDestination(accountAt(ix, 2), 'TransferChecked');
     }
   }
 


### PR DESCRIPTION
## Summary
- Bind each limit-order deposit to the per-order token account the transaction creates in-tx via `System::CreateAccountWithSeed(base = vault owner, seed, owner = Token program)` — the real Jupiter Trigger V2 deposit shape — rather than the canonical ATA.
- Recompute `create_with_seed(base, seed, owner)` from the transaction's own instruction and require `base == the trusted vault owner`, so the destination is provably seeded off the vault the backend named.
- Cover both deposit paths: SPL `Transfer`/`TransferChecked` for token inputs and the native `System::Transfer` for SOL inputs.
- Reworked unit and command-path regression coverage against the real on-chain deposit shape.

## Why not the canonical ATA
A live create round-trip showed the deposit does **not** land in `deriveATA(vault, mint)`: Trigger V2 uses a fresh per-order `CreateAccountWithSeed` account (different every order), and native-SOL inputs arrive via `System::Transfer`, not an SPL transfer. An ATA-equality check therefore fail-blocked every SPL deposit and was a no-op for native SOL. Binding to the recomputed seeded account fixes both and is a strictly stronger check.

## Tests
- `npm test`
- `npm run lint`
- **Live funded create/cancel round-trip on Solana mainnet, both legs** — USDC→SOL (SPL input) and SOL→USDC (native input). Each `create` cleared the destination gate and the deposit-outcome simulation and landed on-chain; each `cancel` cleared and recovered funds; no open orders remained and funds were fully recovered (network fees only). Confirms the gate passes legitimate deposits on both paths and rejects a deposit not seeded off the vault.
