### PR TITLE
Fix non-JSON execute 4xx classification

### DIFF
--- a/.changeset/fix-execute-non-json-4xx.md
+++ b/.changeset/fix-execute-non-json-4xx.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Keep non-JSON 4xx responses from trade execute reusable instead of treating them as ambiguous broadcast failures.

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -3552,6 +3552,26 @@ describe('API error handling', () => {
     global.fetch = origFetch;
   });
 
+  it('treats non-JSON sub-500 execute responses as nonfatal execute errors', async () => {
+    const origFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => '<!DOCTYPE html><html><body>rate limited</body></html>',
+    });
+
+    const { executeTransaction } = await import('../trading.js');
+    await expect(executeTransaction({
+      signedTransaction: 'test',
+      chain: 'solana',
+    }, { retries: 0 })).rejects.toMatchObject({
+      code: 'EXECUTE_ERROR',
+      status: 429,
+    });
+
+    global.fetch = origFetch;
+  });
+
   it('should surface NO_QUOTES_AVAILABLE errors', async () => {
     const origFetch = global.fetch;
     const errorBody = JSON.stringify({

--- a/src/trading.js
+++ b/src/trading.js
@@ -288,10 +288,11 @@ export async function executeTransaction(params, { retries = 2, retryDelayMs = 1
 
     if (!parsed) {
       // Non-JSON on a sub-500 status (a Cloudflare challenge or HTML error
-      // page). Still uninterpretable after the POST went out, so fail closed.
+      // page). A clean sub-500 HTTP response is a definitive edge/backend
+      // rejection, so it stays nonfatal and leaves the quote reusable.
       lastError = Object.assign(
         new Error(`Execute API returned non-JSON response (status ${res.status}). This may be a Cloudflare challenge or server error.`),
-        { code: 'BROADCAST_FAILED', status: res.status, details: text.slice(0, 200) }
+        { code: 'EXECUTE_ERROR', status: res.status, details: text.slice(0, 200) }
       );
       throw lastError;
     }


### PR DESCRIPTION
Summary:
- Treat non-JSON sub-500 trade execute responses as regular execute errors instead of ambiguous broadcast failures.
- Keep non-JSON 5xx responses on the existing ambiguous broadcast failure path.
- Add regression coverage for a non-JSON 429 execute response.

Validation:
- npm test -- src/__tests__/trading.test.js
- npm test
- npm run lint