### PR TITLE
Fix from_cache telemetry reading the wrong field

### DIFF
--- a/.changeset/telemetry-from-cache-flag.md
+++ b/.changeset/telemetry-from-cache-flag.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix `from_cache` telemetry always reporting `false` on cache hits

--- a/src/__tests__/telemetry-tracking.test.js
+++ b/src/__tests__/telemetry-tracking.test.js
@@ -264,6 +264,55 @@ describe('telemetry tracking for all first-level commands', () => {
     expect(trackFailed.mock.calls[0][0].status).toBe(401);
   });
 
+  // ── from_cache reporting ──
+  //
+  // A cache hit is marked on the payload's `_meta` by getCachedResponse();
+  // there is no top-level `fromCache` field, and `--fields` filtering strips
+  // `_meta`, so the flag has to be read off `_meta` before that filtering.
+
+  /** API stub whose every method resolves to `payload`. */
+  function apiReturning(payload) {
+    return function StubAPI() {
+      return new Proxy({}, {
+        get: (_target, prop) => {
+          if (typeof prop === 'string' && prop !== 'then') {
+            return vi.fn().mockResolvedValue(payload);
+          }
+        },
+      });
+    };
+  }
+
+  const cachedPayload = { data: [{ symbol: 'ETH' }], _meta: { fromCache: true, cacheAge: 12 } };
+
+  it('reports from_cache: true for a cache hit', async () => {
+    const deps = baseDeps({ NansenAPIClass: apiReturning(cachedPayload) });
+    await runCLI(['research', 'smart-money', 'netflow'], deps);
+    expect(trackSucceeded).toHaveBeenCalledOnce();
+    expect(trackSucceeded.mock.calls[0][0].from_cache).toBe(true);
+  });
+
+  it('reports from_cache: true for a cache hit with --fields', async () => {
+    const deps = baseDeps({ NansenAPIClass: apiReturning(cachedPayload) });
+    await runCLI(['research', 'smart-money', 'netflow', '--fields', 'symbol'], deps);
+    expect(trackSucceeded).toHaveBeenCalledOnce();
+    expect(trackSucceeded.mock.calls[0][0].from_cache).toBe(true);
+  });
+
+  it('reports from_cache: true for a cache hit with --stream', async () => {
+    const deps = baseDeps({ NansenAPIClass: apiReturning(cachedPayload) });
+    await runCLI(['research', 'smart-money', 'netflow', '--stream'], deps);
+    expect(trackSucceeded).toHaveBeenCalledOnce();
+    expect(trackSucceeded.mock.calls[0][0].from_cache).toBe(true);
+  });
+
+  it('reports from_cache: false for a live response', async () => {
+    const deps = baseDeps({ NansenAPIClass: apiReturning({ data: [{ symbol: 'ETH' }] }) });
+    await runCLI(['research', 'smart-money', 'netflow'], deps);
+    expect(trackSucceeded).toHaveBeenCalledOnce();
+    expect(trackSucceeded.mock.calls[0][0].from_cache).toBe(false);
+  });
+
   // ── Meta commands should NOT trigger telemetry ──
 
   it('--help does not trigger telemetry', async () => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -2101,6 +2101,12 @@ export async function runCLI(rawArgs, deps = {}) {
 
     let result = await commands[command](subArgs, api, flags, options);
 
+    // The cache marker is hung off the payload's `_meta` by getCachedResponse(),
+    // never as a top-level `fromCache`. Capture it here, before `--fields`
+    // filtering below drops `_meta` along with every other unrequested key —
+    // read any later and a cache hit with `--fields` reports as a live call.
+    const fromCache = !!result?._meta?.fromCache;
+
     // Credit balance warning, from the headers on the call just made. Goes to
     // stderr so it never contaminates the JSON on stdout that agents parse.
     // Placed before every return path below so it fires for operational
@@ -2152,14 +2158,14 @@ export async function runCLI(rawArgs, deps = {}) {
       if (streamOutput) {
         output(streamOutput);
       }
-      await trackSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, from_cache: !!result?.fromCache, flags: usedFlags, chain });
+      await trackSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, from_cache: fromCache, flags: usedFlags, chain });
       return { type: 'stream', data: result };
     }
 
     const successData = { success: true, data: result };
     const formatted = formatOutput(successData, { pretty, table, csv });
     output(formatted.text);
-    await trackSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, from_cache: !!result?.fromCache, flags: usedFlags, chain });
+    await trackSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, from_cache: fromCache, flags: usedFlags, chain });
     return { type: csv ? 'csv' : 'success', data: result };
   } catch (error) {
     // Unified error envelope across all command families (perp/bridge/trade):


### PR DESCRIPTION
## Problem

The success-path telemetry in `runCLI()` reported `from_cache: !!result?.fromCache`. Cache hits are marked by `getCachedResponse()` on the payload's `_meta` (`_meta.fromCache`) — there is no top-level `fromCache` field — so `from_cache` was always `false`, for every command, cached or not.

## Fix

Read the flag from `_meta`, and capture it immediately after the command returns rather than at the tracking call:

- `--fields` filtering (`filterFields`) drops `_meta` along with every other unrequested key, so reading it at the tracking site would still misreport a cache hit as a live call whenever `--fields` was used.
- Both success-path tracking calls (default output and `--stream`) now share the single captured value.

Two-line behavioural change; no output, command, or option changes.

## Tests

Added four focused cases to `src/__tests__/telemetry-tracking.test.js`, asserting the tracked `from_cache` value for: a cache hit, a cache hit with `--fields`, a cache hit with `--stream`, and a live response. The first three fail on `main` and pass with this change.

## Validation

| Command | Result |
| --- | --- |
| `npx vitest run src/__tests__/telemetry-tracking.test.js` (fix reverted, tests kept) | 3 failed, 36 passed — the new cache-hit assertions |
| `npx vitest run src/__tests__/telemetry-tracking.test.js` | 39 passed |
| `npm test` | 70 files, 2849 passed, 9 skipped |
| `npm run lint` | clean |
| `node src/index.js --version` / `node src/index.js schema` | both OK |

No build or typecheck step exists — the package is ESM-only with no transpilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)