### PR TITLE
fix(telemetry): report from_cache from the API instance so it survives result rebuilds

### DIFF
--- a/.changeset/from-cache-telemetry-api-instance.md
+++ b/.changeset/from-cache-telemetry-api-instance.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Report `from_cache` telemetry from the API instance so it survives command handlers that rebuild their result, and pass it on the `alerts list --table` path, which previously never reported the field at all

--- a/src/__tests__/telemetry-from-cache.test.js
+++ b/src/__tests__/telemetry-from-cache.test.js
@@ -1,0 +1,156 @@
+/**
+ * End-to-end cover for the `from_cache` telemetry field, driven through the
+ * real NansenAPI with a mocked fetch and a temp HOME.
+ *
+ * Two separate ways this metric has been wrong:
+ *
+ *  1. The tracking sites read a bare `result.fromCache`, which nothing sets —
+ *     getCachedResponse() records the hit one level down, on `_meta`.
+ *  2. `_meta` on its own isn't enough either. A handler is free to rebuild its
+ *     result and `alerts list` does (it filters the array into a fresh one), so
+ *     the marker is gone before tracking runs — and that path didn't pass the
+ *     field at all.
+ *
+ * These run the same `--cache` command twice and assert on the tracked event,
+ * so a real cache hit is what's being measured rather than a stubbed flag.
+ * `fetch` call counts prove the second run never touched the network.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const trackSucceeded = vi.fn();
+const trackFailed = vi.fn();
+
+vi.mock('../telemetry.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  trackCommandSucceeded: trackSucceeded,
+  trackCommandFailed: trackFailed,
+  trackPerpOrderCompleted: vi.fn(),
+  getAnonymousId: () => 'test-anon-id',
+  getSessionId: () => 'test-session-id',
+}));
+
+let tempHome;
+const saved = {};
+
+beforeEach(() => {
+  tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nansen-from-cache-'));
+  for (const name of ['HOME', 'USERPROFILE', 'NANSEN_API_KEY']) saved[name] = process.env[name];
+  // CONFIG_DIR (and so the response cache) is resolved from HOME at api.js load
+  // time, hence the resetModules + dynamic import in loadCli below.
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+  process.env.NANSEN_API_KEY = 'test-key';
+  trackSucceeded.mockClear();
+  trackFailed.mockClear();
+});
+
+afterEach(() => {
+  for (const [name, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[name]; else process.env[name] = value;
+  }
+  fs.rmSync(tempHome, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+/** Load cli.js and the real NansenAPI against a mocked network. */
+async function loadCli(payload) {
+  vi.resetModules();
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    // Fresh clone per call so a handler mutating the body can't leak across runs.
+    json: async () => JSON.parse(JSON.stringify(payload)),
+  })));
+  const { runCLI } = await import('../cli.js');
+  const { NansenAPI } = await import('../api.js');
+  return {
+    runCLI,
+    deps: { output: () => {}, errorOutput: () => {}, exit: () => {}, NansenAPIClass: NansenAPI },
+  };
+}
+
+/** The two `from_cache` values tracked across a miss-then-hit pair. */
+function trackedFromCache() {
+  expect(trackSucceeded).toHaveBeenCalledTimes(2);
+  return trackSucceeded.mock.calls.map(c => c[0].from_cache);
+}
+
+describe('from_cache telemetry', () => {
+  it('reports the cache hit on the second identical --cache call', async () => {
+    const { runCLI, deps } = await loadCli({ data: [{ symbol: 'ETH' }] });
+    const argv = ['research', 'token', 'screener', '--cache'];
+
+    await runCLI(argv, deps);
+    await runCLI(argv, deps);
+
+    expect(trackedFromCache()).toEqual([false, true]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the cache hit when --fields has stripped _meta off the payload', async () => {
+    const { runCLI, deps } = await loadCli({ data: [{ symbol: 'ETH' }] });
+    const argv = ['research', 'token', 'screener', '--cache', '--fields', 'symbol'];
+
+    await runCLI(argv, deps);
+    await runCLI(argv, deps);
+
+    expect(trackedFromCache()).toEqual([false, true]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the cache hit on the --stream output path', async () => {
+    const { runCLI, deps } = await loadCli({ data: [{ symbol: 'ETH' }] });
+    const argv = ['research', 'token', 'screener', '--cache', '--stream'];
+
+    await runCLI(argv, deps);
+    await runCLI(argv, deps);
+
+    expect(trackedFromCache()).toEqual([false, true]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // `alerts list` with any filter runs the array through .filter(), producing a
+  // fresh array that no longer carries the `_meta` marker — the case the
+  // instance flag exists for. Unfiltered, the cached array itself comes back
+  // with `_meta` still on it, so the filter flag is what makes these bite.
+  it('reports the cache hit when the handler has rebuilt the result', async () => {
+    const { runCLI, deps } = await loadCli([{ id: 'a1', name: 'whale moves', isEnabled: true }]);
+    const argv = ['alerts', 'list', '--cache', '--enabled'];
+
+    await runCLI(argv, deps);
+    await runCLI(argv, deps);
+
+    expect(trackedFromCache()).toEqual([false, true]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the cache hit on the alerts list --table path', async () => {
+    const { runCLI, deps } = await loadCli([{ id: 'a1', name: 'whale moves', isEnabled: true }]);
+    const argv = ['alerts', 'list', '--table', '--cache', '--enabled'];
+
+    await runCLI(argv, deps);
+    await runCLI(argv, deps);
+
+    // This path previously never passed the field at all, so it read undefined.
+    expect(trackedFromCache()).toEqual([false, true]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a live response as a miss', async () => {
+    const { runCLI, deps } = await loadCli({ data: [{ symbol: 'ETH' }] });
+    const argv = ['research', 'token', 'screener'];
+
+    await runCLI(argv, deps);
+    await runCLI(argv, deps);
+
+    // No --cache, so both calls go to the network and neither is a hit.
+    expect(trackedFromCache()).toEqual([false, false]);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/api.js
+++ b/src/api.js
@@ -543,6 +543,17 @@ export class NansenAPI {
     this.lastResponseMeta = null;
     /** API path of the most recent request(), for pairing lastResponseMeta with a cost estimate. */
     this.lastEndpoint = null;
+    /**
+     * Whether the most recent request() was answered from the local response
+     * cache instead of the network.
+     *
+     * Lives on the instance for the same reason lastResponseMeta does: a cache
+     * hit returns early, and a handler that rebuilds its result (alerts list,
+     * for one) drops the `_meta.fromCache` marker carried on the body, so the
+     * payload alone can't be trusted to still say so by the time telemetry
+     * reads it. Last write wins when a handler makes several calls.
+     */
+    this.servedFromCache = false;
   }
 
   static cleanBody(body) {
@@ -672,9 +683,11 @@ export class NansenAPI {
     if (useCache) {
       const cached = getCachedResponse(endpoint, body, cacheTtl);
       if (cached) {
+        this.servedFromCache = true;
         return cached;
       }
     }
+    this.servedFromCache = false;
 
     let lastError;
     

--- a/src/cli.js
+++ b/src/cli.js
@@ -2105,7 +2105,14 @@ export async function runCLI(rawArgs, deps = {}) {
     // never as a top-level `fromCache`. Capture it here, before `--fields`
     // filtering below drops `_meta` along with every other unrequested key —
     // read any later and a cache hit with `--fields` reports as a live call.
-    const fromCache = !!result?._meta?.fromCache;
+    //
+    // `_meta` alone isn't enough either: handlers are free to rebuild their
+    // result and some do (`alerts list` filters the array into a fresh one),
+    // which drops the marker before we get here. `api.servedFromCache` is set
+    // on the instance next to the cache-hit early return in request(), so it
+    // survives that reshaping. Compared against `true` so a stubbed API whose
+    // every property is a mock function doesn't read as a hit.
+    const fromCache = !!result?._meta?.fromCache || api.servedFromCache === true;
 
     // Credit balance warning, from the headers on the call just made. Goes to
     // stderr so it never contaminates the JSON on stdout that agents parse.
@@ -2147,7 +2154,7 @@ export async function runCLI(rawArgs, deps = {}) {
     // Alerts list with --table uses custom table format
     if (command === 'alerts' && subcommand === 'list' && table) {
       output(formatAlertsTable(result));
-      await trackSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, flags: usedFlags, chain });
+      await trackSucceeded({ command: fullCommand, duration_ms: Date.now() - startTime, from_cache: fromCache, flags: usedFlags, chain });
       return { type: 'success', data: result };
     }
 


### PR DESCRIPTION
## Problem

Follow-up hardening on the `from_cache` telemetry fix already on `main`.

That fix reads the cache marker off the payload's `_meta`, captured right after the command returns so `--fields` filtering can't strip it first:

```js
const fromCache = !!result?._meta?.fromCache;
```

Correct as far as it goes. It does not survive a handler that **rebuilds** its result, and some do. `alerts list` pulls the array out of the response and filters it into a fresh one (`src/commands/alerts.js`), so by the time the tracking site runs there is no `_meta` on the object at all:

```js
let alerts = Array.isArray(results) ? results : results?.alerts ?? results?.data ?? [];
if (options.type)  alerts = alerts.filter(a => a.type === options.type);
if (flags.enabled) alerts = alerts.filter(a => a.isEnabled === true);
```

A second, separate hole in the same metric: the `alerts list --table` branch never passed `from_cache` at all, so it reported `undefined` on every call regardless of the cache.

## Fix

- **`src/api.js`** — `this.servedFromCache` is set `true` beside the cache-hit early return in `request()`, and `false` on the path that goes to the network. Declared in the constructor next to `lastResponseMeta`, whose comment already explains why this kind of state belongs on the instance: it "survives any reshaping a command handler does to the response body". Same last-write-wins semantics when a handler makes several calls.
- **`src/cli.js`** — the tracking sites now read `!!result?._meta?.fromCache || api.servedFromCache === true`. The `_meta` read stays as the payload-level signal, so nothing about the merged behavior is reverted and neither signal depends on the other. The strict `=== true` comparison matters: the existing suite's stub API is a `Proxy` that answers every property with a mock function, which a truthy check would read as a permanent cache hit.
- **`src/cli.js`** — `alerts list --table` now passes `from_cache` like the other success paths.

The two sites that cannot involve the cache are left alone: the `result === undefined` branch (the command wrote its own output) and `schema` (served locally).

## Tests

New `src/__tests__/telemetry-from-cache.test.js` drives `runCLI` end to end with the real `NansenAPI`, a mocked `fetch` and a temp `HOME`, running the same `--cache` command twice and asserting on the tracked event. Each case also asserts the `fetch` call count, so it is a genuine cache hit being measured rather than a second network call.

Six cases: the default output path, `--fields` (which strips `_meta`), `--stream`, a rebuilt result via `alerts list --enabled`, `alerts list --table --enabled`, and a no-`--cache` control that must report a miss.

The filter flag on the two `alerts list` cases is what makes them bite — unfiltered, the cached array itself still carries `_meta`, so the handler has to actually rebuild the array for the reshaping hole to open.

Both regression modes were checked by reverting parts of the change:

```
# _meta read only, alerts site still passing the field:
× reports the cache hit when the handler has rebuilt the result
× reports the cache hit on the alerts list --table path
AssertionError: expected [ false, false ] to deeply equal [ false, true ]

# main exactly as merged:
× reports the cache hit when the handler has rebuilt the result
× reports the cache hit on the alerts list --table path
AssertionError: expected [ false, false ] to deeply equal [ false, true ]
AssertionError: expected [ undefined, undefined ] to deeply equal [ false, true ]
```

## Validation

| Check | Result |
| --- | --- |
| `npx vitest run src/__tests__/telemetry-from-cache.test.js` | 1 file passed, **6/6 tests passed** |
| `npm test` | **71 files passed, 2855 passed / 9 skipped (2864)**, 0 failed |
| `npm run lint` | clean, exit 0 |
| `node --check` on all three touched `.js` files | ok (no build/typecheck step — ESM, no TypeScript) |
| CLI smoke: `--version`, `--help`, `schema`, `alerts list --help` | all ok; `schema` parses, 118 commands |
| `npm pack --dry-run` | ok, 85 files, 1.4 MB |

## Checklist

- [x] `npm test` passes (no existing test changes status; +6 new)
- [x] `npm run lint` passes
- [x] New code path has tests
- [x] No `console.log` in core, no hardcoded secrets
- [x] Changeset added (`patch`, user-facing fix)
- [ ] `src/schema.json` — not applicable, no commands or options changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
