### PR TITLE
fix(keychain): reject hard-linked credentials file before writing

### DIFF
--- a/.changeset/credentials-hardlink-guard.md
+++ b/.changeset/credentials-hardlink-guard.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Reject hard-linked `.credentials` files in the wallet-password fallback write, so the credential write cannot chmod, truncate, or overwrite an unrelated file

--- a/src/__tests__/keychain.test.js
+++ b/src/__tests__/keychain.test.js
@@ -110,6 +110,26 @@ describe('keychain', () => {
       expect(fs.readFileSync(targetPath, 'utf8')).toBe('leave unchanged\n');
     });
 
+    it.skipIf(process.platform === 'win32')('should refuse to overwrite a hard-linked credentials file on POSIX', () => {
+      setPlatform('linux');
+      execFileSync.mockImplementation(() => { throw new Error('secret-tool unavailable'); });
+
+      const credDir = path.join(tempDir, '.nansen', 'wallets');
+      const credPath = path.join(credDir, '.credentials');
+      const victimPath = path.join(tempDir, 'hardlink-victim');
+      fs.mkdirSync(credDir, { recursive: true });
+      fs.writeFileSync(victimPath, 'leave unchanged\n');
+      fs.chmodSync(victimPath, 0o644);
+      // O_NOFOLLOW cannot see this: the link is a second name for the same
+      // regular inode, not a symlink.
+      fs.linkSync(victimPath, credPath);
+      expect(fs.statSync(credPath).nlink).toBe(2);
+
+      expect(storePassword('replacement-password')).toEqual({ stored: false, method: 'none' });
+      expect(fs.readFileSync(victimPath, 'utf8')).toBe('leave unchanged\n');
+      expect(fs.statSync(victimPath).mode & 0o777).toBe(0o644);
+    });
+
     it('should fall back to .credentials on unsupported platform', () => {
       setPlatform('freebsd');
       fs.mkdirSync(path.join(tempDir, '.nansen', 'wallets'), { recursive: true });

--- a/src/keychain.js
+++ b/src/keychain.js
@@ -166,7 +166,12 @@ function credentialsFileWrite(password) {
         | fs.constants.O_NOFOLLOW
         | fs.constants.O_NONBLOCK;
       fd = fs.openSync(filePath, flags, 0o600);
-      if (!fs.fstatSync(fd).isFile()) throw new Error('Credentials path is not a regular file');
+      const stats = fs.fstatSync(fd);
+      if (!stats.isFile()) throw new Error('Credentials path is not a regular file');
+      // O_NOFOLLOW only rejects symlinks. A hard link at .credentials points at
+      // a victim file that is indistinguishable by path or type, so refuse any
+      // regular file with extra links before fchmod/ftruncate touch it.
+      if (stats.nlink !== 1) throw new Error('Credentials file has unexpected hard links');
 
       // Opening an existing file does not apply the requested mode. Tighten it
       // before replacing the secret, then enforce the final mode after writing.


### PR DESCRIPTION
## Summary

Follow-up hardening for the wallet-password `.credentials` fallback.

The fallback writer already rejects symlinks, but a hard link still passes the regular-file check. This change rejects credential files with more than one hard link before changing permissions, truncating, or writing the file.

## Changes

- Reject credential files whose link count is not exactly one.
- Add a POSIX regression test proving a hard-linked victim is not modified.
- Add a changeset.

## Validation

- Focused keychain tests: passed
- Full test suite: passed
- Lint: passed

This PR is intentionally limited to the hard-link follow-up.
