### PR TITLE
fix: WalletConnect EVM signing accepted a session approved for a different chain

### DIFF
--- a/.changeset/walletconnect-chain-scoped-address.md
+++ b/.changeset/walletconnect-chain-scoped-address.md
@@ -1,0 +1,9 @@
+---
+"nansen-cli": patch
+---
+
+Fix `nansen transfer`/`nansen trade execute` with `--wallet walletconnect` using any connected EVM account instead of verifying the WalletConnect session is actually approved for the chain being signed/broadcast on.
+
+`getWalletConnectAddress('evm')` matched any account whose CAIP-2 chain tag started with `eip155:`, regardless of which specific chain it was approved for. Because EVM addresses are identical across chains, a session connected only to Ethereum mainnet would be silently used to sign a transaction destined for Base (or vice versa) -- nothing downstream (including the quote/request-intent binding checks) could catch this, since they only compare addresses, not chains.
+
+`getWalletConnectAddress` now accepts an optional `chainId`, and when given, only returns an account the session has approved for that exact chain (mirroring the mainnet-only exact match already used for Solana in the same function). Every place that resolves a WalletConnect EVM address before signing or broadcasting a real transaction now passes the target chain ID and fails closed with a clear error instead of proceeding with a wrong-chain session: `nansen transfer`'s `sendTokensViaWalletConnect`, and `nansen trade execute`'s quote-building, pre-execute wallet-match check, and immediate pre-signing check for its EVM WalletConnect swap path.

--- a/src/__tests__/trading.test.js
+++ b/src/__tests__/trading.test.js
@@ -1577,6 +1577,141 @@ describe('WalletConnect execute support', () => {
     vi.restoreAllMocks();
   });
 
+  it('scopes the WalletConnect address lookup to the quote chain before signing', async () => {
+    const addrSpy = vi.spyOn(wcTrading, 'getWalletConnectAddress').mockResolvedValue('0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4');
+    vi.spyOn(wcTrading, 'sendTransactionViaWalletConnect').mockResolvedValue({ txHash: '0xmocktx' });
+
+    const originalFetch = global.fetch;
+    global.fetch = vi.fn(async () => ({
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({ result: { status: '0x1', blockNumber: '0x100' } })),
+      json: () => Promise.resolve({ result: { status: '0x1', blockNumber: '0x100' } }),
+    }));
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'lifi',
+        inputMint: BASE_ETH,
+        outputMint: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+        inAmount: '1000000000000000000',
+        outAmount: '3000000000',
+        transaction: { to: LIFI_ROUTER, data: '0x12345678', value: '1000000000000000000', gas: '200000' },
+      }],
+    }, 'base', 'walletconnect', null, null, {
+      swapMode: 'exactIn',
+      request: evmIntent({
+        walletAddress: '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4',
+        fromToken: BASE_ETH,
+        toToken: BASE_USDC,
+        amount: '1000000000000000000',
+        maxInputAmount: '1000000000000000000',
+      }),
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    delete process.env.NANSEN_WALLET_PASSWORD;
+
+    await cmds.execute([], null, {}, { quote: quoteId });
+
+    // Base's chain ID (8453), not just "some EVM account" -- the call right
+    // before signing/broadcasting must be scoped to the chain being used.
+    expect(addrSpy.mock.calls.some(call => call[0] === 'evm' && call[1] === 8453)).toBe(true);
+
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('rejects execute when the WalletConnect session is connected but not to the quote chain (regression)', async () => {
+    // Before the fix: getWalletConnectAddress(chainType) ignored the chain ID
+    // entirely and returned any eip155:* account, so a session approved only
+    // for a different chain would silently sign/broadcast here. EVM
+    // addresses are identical across chains, so nothing else in this path
+    // (assertQuoteMatchesRequest included) could have caught the mismatch.
+    vi.spyOn(wcTrading, 'getWalletConnectAddress').mockImplementation(async (chainType, chainId) => {
+      if (chainType !== 'evm') return null;
+      // Session is connected -- but only approved for Ethereum mainnet (1), not Base (8453).
+      return chainId === 1 ? '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4' : null;
+    });
+    vi.spyOn(wcTrading, 'sendTransactionViaWalletConnect').mockResolvedValue({ txHash: '0xmocktx' });
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'lifi',
+        inputMint: BASE_ETH,
+        outputMint: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+        inAmount: '1000000000000000000',
+        outAmount: '3000000000',
+        transaction: { to: LIFI_ROUTER, data: '0x12345678', value: '1000000000000000000', gas: '200000' },
+      }],
+    }, 'base', 'walletconnect', null, null, {
+      swapMode: 'exactIn',
+      request: evmIntent({
+        walletAddress: '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4',
+        fromToken: BASE_ETH,
+        toToken: BASE_USDC,
+        amount: '1000000000000000000',
+        maxInputAmount: '1000000000000000000',
+      }),
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    delete process.env.NANSEN_WALLET_PASSWORD;
+
+    await expect(cmds.execute([], null, {}, { quote: quoteId })).rejects.toThrow('No WalletConnect session active for chain "base"');
+
+    vi.restoreAllMocks();
+  });
+
+  it('rejects execute when the WalletConnect session switches to a different chain between the pre-check and signing (regression)', async () => {
+    // The pre-check right after loading the quote (line ~2571) and the check
+    // immediately before signing (line ~3036) both call
+    // getWalletConnectAddress -- deliberately, to close the gap where a
+    // session could disconnect or switch chains in between (same rationale
+    // as the pre-existing "session dropped mid-execute" guard this extends).
+    // Simulate that gap: the session is on the right chain for the first
+    // check, then switches before the second one runs.
+    let calls = 0;
+    vi.spyOn(wcTrading, 'getWalletConnectAddress').mockImplementation(async (chainType, chainId) => {
+      if (chainType !== 'evm') return null;
+      calls++;
+      if (calls === 1) return chainId === 8453 ? '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4' : null;
+      // Second call onward: session has moved to a different chain.
+      return chainId === 8453 ? null : '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4';
+    });
+    vi.spyOn(wcTrading, 'sendTransactionViaWalletConnect').mockResolvedValue({ txHash: '0xmocktx' });
+
+    const quoteId = saveQuote({
+      success: true,
+      quotes: [{
+        aggregator: 'lifi',
+        inputMint: BASE_ETH,
+        outputMint: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+        inAmount: '1000000000000000000',
+        outAmount: '3000000000',
+        transaction: { to: LIFI_ROUTER, data: '0x12345678', value: '1000000000000000000', gas: '200000' },
+      }],
+    }, 'base', 'walletconnect', null, null, {
+      swapMode: 'exactIn',
+      request: evmIntent({
+        walletAddress: '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4',
+        fromToken: BASE_ETH,
+        toToken: BASE_USDC,
+        amount: '1000000000000000000',
+        maxInputAmount: '1000000000000000000',
+      }),
+    });
+
+    const cmds = buildTradingCommands({ log: () => {}, exit: () => {} });
+    delete process.env.NANSEN_WALLET_PASSWORD;
+
+    await expect(cmds.execute([], null, {}, { quote: quoteId })).rejects.toThrow('No WalletConnect session for this chain');
+    expect(calls).toBeGreaterThanOrEqual(2);
+
+    vi.restoreAllMocks();
+  });
+
   it('should allow Solana + walletconnect for execute', async () => {
     vi.spyOn(wcTrading, 'getWalletConnectAddress').mockResolvedValue('9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM');
     vi.spyOn(wcTrading, 'sendSolanaTransactionViaWalletConnect').mockResolvedValue({ signedTransaction: '5K4Ld...' });

--- a/src/__tests__/transfer.test.js
+++ b/src/__tests__/transfer.test.js
@@ -600,6 +600,47 @@ describe('sendTokens via WalletConnect', () => {
     vi.restoreAllMocks();
   });
 
+  test('scopes the WalletConnect address lookup to the target chain, not just any EVM account', async () => {
+    const addrSpy = vi.spyOn(wcTrading, 'getWalletConnectAddress').mockResolvedValue('0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4');
+    vi.spyOn(wcTrading, 'sendTransactionViaWalletConnect').mockResolvedValue({ txHash: '0xmocktx123' });
+    fetch.mockImplementation(async (url, opts) => {
+      const body = JSON.parse(opts.body);
+      const r = { 'eth_getTransactionReceipt': { status: '0x1', blockNumber: '0x100' } };
+      return { json: () => Promise.resolve({ result: r[body.method] || '0x0' }) };
+    });
+
+    await sendTokens({
+      to: '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4',
+      amount: '0.1',
+      chain: 'base',
+      walletconnect: true,
+    });
+
+    expect(addrSpy).toHaveBeenCalledWith('evm', 8453);
+    vi.restoreAllMocks();
+  });
+
+  test('rejects when the WalletConnect session is connected but not to the target chain (regression)', async () => {
+    // Before the fix: getWalletConnectAddress() took no chain argument at all
+    // and returned any eip155:* account, so a session approved only for a
+    // different chain would silently be used to sign a transfer meant for
+    // this one -- EVM addresses are identical across chains, so nothing
+    // downstream could have caught the mismatch.
+    vi.spyOn(wcTrading, 'getWalletConnectAddress').mockImplementation(async (chainType, chainId) => {
+      // Session is connected, but only approved for Ethereum mainnet (1), not Base (8453).
+      return chainId === 1 ? '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4' : null;
+    });
+
+    await expect(sendTokens({
+      to: '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4',
+      amount: '0.1',
+      chain: 'base',
+      walletconnect: true,
+    })).rejects.toThrow('No WalletConnect session active');
+
+    vi.restoreAllMocks();
+  });
+
   test('skips password verification for walletconnect', async () => {
     const exportSpy = vi.spyOn(wallet, 'exportWallet');
     vi.spyOn(wcTrading, 'getWalletConnectAddress').mockResolvedValue('0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4');

--- a/src/__tests__/walletconnect-trading.test.js
+++ b/src/__tests__/walletconnect-trading.test.js
@@ -141,6 +141,48 @@ describe('getWalletConnectAddress', () => {
     const address = await getWalletConnectAddress();
     expect(address).toBe('0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4');
   });
+
+  it('returns the matching account when chainId matches the session (regression)', async () => {
+    mockExecFile(JSON.stringify({
+      connected: true,
+      accounts: [{ chain: 'eip155:8453', address: '0xBaseAddr0000000000000000000000000000000' }],
+    }));
+
+    const address = await getWalletConnectAddress('evm', 8453);
+    expect(address).toBe('0xBaseAddr0000000000000000000000000000000');
+  });
+
+  it('rejects a session approved for a different EVM chain instead of returning any eip155:* account (regression)', async () => {
+    // Before this check existed, chainType === 'evm' matched ANY eip155:*
+    // account regardless of which specific chain it was approved for -- a
+    // session connected only to Ethereum mainnet (1) would be handed back
+    // as if it were valid for Base (8453) too, since EVM addresses are
+    // identical across chains and the code never compared the chain ID.
+    mockExecFile(JSON.stringify({
+      connected: true,
+      accounts: [{ chain: 'eip155:1', address: '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4' }],
+    }));
+
+    const address = await getWalletConnectAddress('evm', 8453);
+    expect(address).toBeNull();
+  });
+
+  it('still matches any eip155:* account when chainId is omitted (backward compat)', async () => {
+    mockExecFile(JSON.stringify({
+      connected: true,
+      accounts: [{ chain: 'eip155:1', address: '0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4' }],
+    }));
+
+    const address = await getWalletConnectAddress('evm');
+    expect(address).toBe('0x742d35Cc6bF4F3f4e0e3a8DD7e37ff4e4Be4E4B4');
+  });
+
+  it('returns null for chainId lookup when no accounts are approved for any chain', async () => {
+    mockExecFile(JSON.stringify({ connected: true, accounts: [] }));
+
+    const address = await getWalletConnectAddress('evm', 8453);
+    expect(address).toBeNull();
+  });
 });
 
 // ============= sendTransactionViaWalletConnect =============

--- a/src/chain-ids.js
+++ b/src/chain-ids.js
@@ -4,6 +4,12 @@
  * Single source of truth — import from here instead of defining inline.
  */
 
+// If you add a chain to EVM_CHAINS below, add its numeric chain ID here too.
+// transfer.js's EVM transfer paths (both local-wallet and WalletConnect) look
+// up the chain ID here and fail closed with "Unsupported chain" when it's
+// missing -- so a chain listed in EVM_CHAINS but absent here can't actually
+// be used to send a transfer yet, even though address-format validation and
+// ENS resolution already accept it.
 export const EVM_CHAIN_IDS = {
   ethereum: 1,
   base: 8453,

--- a/src/trading.js
+++ b/src/trading.js
@@ -3048,6 +3048,10 @@ EXAMPLES:
 
             } else if (isWalletConnect) {
               // EVM via WalletConnect: wallet signs and may broadcast.
+              // chainType is always 'evm' here (unguarded, unlike the two
+              // other call sites) -- the Solana WalletConnect path is fully
+              // handled above in the `if (chainConfig.type === 'solana')`
+              // branch, so this `else if` is only ever reached for EVM.
               // Scoped to this chain's ID, not just "any EVM account" -- a
               // session approved only for a different chain must not sign
               // here. EVM addresses are identical across chains, so the

--- a/src/trading.js
+++ b/src/trading.js
@@ -2216,7 +2216,11 @@ CROSS-CHAIN NOTES (when using --to-chain):
           // Scoped to this chain's ID (see getWalletConnectAddress's chainId
           // param): a session approved only for a different EVM chain must
           // not be treated as valid here just because it's "some eip155:*"
-          // account -- EVM addresses are identical across chains.
+          // account -- EVM addresses are identical across chains. chainId is
+          // only ever passed for 'evm': Solana's chainConfig.chainId (501) is
+          // not a CAIP-2 EIP-155 chain ID, and getWalletConnectAddress's own
+          // Solana branch already does its own exact match unconditionally --
+          // passing 501 through here would break it, not narrow it further.
           walletAddress = chainType === 'evm'
             ? await getWalletConnectAddress(chainType, chainConfig.chainId)
             : await getWalletConnectAddress(chainType);
@@ -2575,6 +2579,10 @@ EXAMPLES:
           // getWalletConnectAddress's chainId param) because an address
           // match alone can't tell a session on the right chain from one on
           // the wrong chain -- EVM addresses are identical across chains.
+          // chainId is only ever passed for 'evm': Solana's chainConfig.chainId
+          // (501) is not a CAIP-2 EIP-155 chain ID, and getWalletConnectAddress's
+          // own Solana branch already does its own exact match unconditionally --
+          // passing 501 through here would break it, not narrow it further.
           const wcAddress = chainType === 'evm'
             ? await getWalletConnectAddress(chainType, chainConfig.chainId)
             : await getWalletConnectAddress(chainType);

--- a/src/trading.js
+++ b/src/trading.js
@@ -2213,9 +2213,15 @@ CROSS-CHAIN NOTES (when using --to-chain):
         let walletProvider = 'local';
         let privyWalletIds = null;
         if (isWalletConnect) {
-          walletAddress = await getWalletConnectAddress(chainType);
+          // Scoped to this chain's ID (see getWalletConnectAddress's chainId
+          // param): a session approved only for a different EVM chain must
+          // not be treated as valid here just because it's "some eip155:*"
+          // account -- EVM addresses are identical across chains.
+          walletAddress = chainType === 'evm'
+            ? await getWalletConnectAddress(chainType, chainConfig.chainId)
+            : await getWalletConnectAddress(chainType);
           if (!walletAddress) {
-            throw new CommandError('No WalletConnect session active. Run: walletconnect connect', 'NO_WALLET');
+            throw new CommandError(`No WalletConnect session active for chain "${chain}". Run: walletconnect connect`, 'NO_WALLET');
           }
         } else if (walletName) {
           const wallet = showWallet(walletName);
@@ -2564,10 +2570,16 @@ EXAMPLES:
 
           exported = exportWallet(effectiveWalletName, password);
         } else {
-          // Verify WalletConnect session is still active and address matches quote
-          const wcAddress = await getWalletConnectAddress(chainType);
+          // Verify WalletConnect session is still active, approved for this
+          // chain, and its address matches the quote. Chain-scoped (see
+          // getWalletConnectAddress's chainId param) because an address
+          // match alone can't tell a session on the right chain from one on
+          // the wrong chain -- EVM addresses are identical across chains.
+          const wcAddress = chainType === 'evm'
+            ? await getWalletConnectAddress(chainType, chainConfig.chainId)
+            : await getWalletConnectAddress(chainType);
           if (!wcAddress) {
-            throw new CommandError('No WalletConnect session active. Run: walletconnect connect', 'NO_WALLET');
+            throw new CommandError(`No WalletConnect session active for chain "${chain}". Run: walletconnect connect`, 'NO_WALLET');
           }
           // Check address matches the one used during quoting
           const quoteWallet = quoteData.response?.quotes?.[0]?.transaction?.from
@@ -3027,14 +3039,20 @@ EXAMPLES:
               requestId = currentQuote.metadata?.requestId;
 
             } else if (isWalletConnect) {
-              // EVM via WalletConnect: wallet signs and may broadcast
-              const wcAddress = await getWalletConnectAddress(chainType);
-              // A session dropped mid-execute returns null here. Without this
+              // EVM via WalletConnect: wallet signs and may broadcast.
+              // Scoped to this chain's ID, not just "any EVM account" -- a
+              // session approved only for a different chain must not sign
+              // here. EVM addresses are identical across chains, so the
+              // address-based checks below (assertQuoteMatchesRequest) can't
+              // catch a session connected to the wrong chain on their own.
+              const wcAddress = await getWalletConnectAddress(chainType, chainConfig.chainId);
+              // A session dropped mid-execute, or one that's connected but not
+              // approved for this chain, returns null here. Without this
               // guard a null address would fall through to assertQuoteMatchesRequest,
               // whose `request.walletAddress && walletAddress` condition would
               // silently skip the signer-binding check. Fail closed instead.
               if (!wcAddress) {
-                throw new CommandError('WalletConnect session lost during execute. Reconnect with `walletconnect connect` and retry.', 'NO_WALLET');
+                throw new CommandError('No WalletConnect session for this chain. Reconnect with `walletconnect connect` and retry.', 'NO_WALLET');
               }
               const isNative = isNativeToken(currentQuote.inputMint);
 

--- a/src/transfer.js
+++ b/src/transfer.js
@@ -117,7 +117,7 @@ function bigIntToHex(n) {
 
 async function buildEvmTransaction({ to, amount, token, privateKey, chain, max = false }) {
   const chainId = CHAIN_IDS[chain];
-  if (!chainId) throw new Error(`Unsupported chain: ${chain}`);
+  if (!chainId) throw new Error(`Unsupported chain: ${chain} (no chain ID configured for EVM transfers)`);
   const rpcUrl = CHAIN_RPCS[chain] || CHAIN_RPCS.evm;
 
   // Derive address and buffer for signing
@@ -831,7 +831,7 @@ export async function sendTokens({ to, amount, chain, token = null, wallet = nul
  */
 async function sendTokensViaWalletConnect({ to, amount, chain, token, max, dryRun }) {
   const chainId = CHAIN_IDS[chain];
-  if (!chainId) throw new Error(`Unsupported chain: ${chain}`);
+  if (!chainId) throw new Error(`Unsupported chain: ${chain} (no chain ID configured for EVM transfers)`);
   const rpcUrl = CHAIN_RPCS[chain] || CHAIN_RPCS.evm;
 
   // Scoped to this specific chain, not just "any EVM account" — a session

--- a/src/transfer.js
+++ b/src/transfer.js
@@ -116,8 +116,9 @@ function bigIntToHex(n) {
 // ============= EVM Transaction =============
 
 async function buildEvmTransaction({ to, amount, token, privateKey, chain, max = false }) {
+  const chainId = CHAIN_IDS[chain];
+  if (!chainId) throw new Error(`Unsupported chain: ${chain}`);
   const rpcUrl = CHAIN_RPCS[chain] || CHAIN_RPCS.evm;
-  const chainId = CHAIN_IDS[chain] || 1;
 
   // Derive address and buffer for signing
   const privBuf = Buffer.from(privateKey, 'hex');
@@ -829,8 +830,9 @@ export async function sendTokens({ to, amount, chain, token = null, wallet = nul
  * Send tokens via WalletConnect (EVM only).
  */
 async function sendTokensViaWalletConnect({ to, amount, chain, token, max, dryRun }) {
+  const chainId = CHAIN_IDS[chain];
+  if (!chainId) throw new Error(`Unsupported chain: ${chain}`);
   const rpcUrl = CHAIN_RPCS[chain] || CHAIN_RPCS.evm;
-  const chainId = CHAIN_IDS[chain] || 1;
 
   // Scoped to this specific chain, not just "any EVM account" — a session
   // approved only for a different chain must not be used to sign a transfer

--- a/src/transfer.js
+++ b/src/transfer.js
@@ -832,8 +832,12 @@ async function sendTokensViaWalletConnect({ to, amount, chain, token, max, dryRu
   const rpcUrl = CHAIN_RPCS[chain] || CHAIN_RPCS.evm;
   const chainId = CHAIN_IDS[chain] || 1;
 
-  const wcAddress = await getWalletConnectAddress();
-  if (!wcAddress) throw new Error('No WalletConnect session active. Run: walletconnect connect');
+  // Scoped to this specific chain, not just "any EVM account" — a session
+  // approved only for a different chain must not be used to sign a transfer
+  // on this one (addresses are identical across EVM chains, so an address
+  // match alone can't catch this; the CAIP-2 chain tag can).
+  const wcAddress = await getWalletConnectAddress('evm', chainId);
+  if (!wcAddress) throw new Error(`No WalletConnect session active for chain "${chain}" (eip155:${chainId}). Run: walletconnect connect`);
 
   let txTo, txValue, txData;
 

--- a/src/walletconnect-trading.js
+++ b/src/walletconnect-trading.js
@@ -48,8 +48,12 @@ function parseWcJson(output) {
  *   actually approved for THAT chain (`eip155:<chainId>`) is returned — a session
  *   connected only to, say, Ethereum mainnet must not be handed back as if it were
  *   approved for Base just because both are "eip155:*". Mirrors the mainnet-only
- *   exact-match already done for Solana above; omit chainId to keep the old
- *   any-EVM-chain behavior for callers that don't yet sign/broadcast with it.
+ *   exact-match already done for Solana above. Only meaningful for
+ *   chainType === 'evm' -- the Solana branch already does its own exact
+ *   match unconditionally, so omit chainId there (a chain-config chain ID
+ *   like Solana's 501 is not a CAIP-2 EIP-155 chain ID and would not match
+ *   anything); also omit it when no specific chain needs verifying at all
+ *   (chainType itself omitted, for first-account backward compat).
  */
 export async function getWalletConnectAddress(chainType, chainId) {
   try {

--- a/src/walletconnect-trading.js
+++ b/src/walletconnect-trading.js
@@ -43,8 +43,15 @@ function parseWcJson(output) {
  *
  * @param {string} [chainType] - Optional: 'evm' or 'solana'. Filters accounts by chain prefix.
  *   No arg = first account (backward compat).
+ * @param {number} [chainId] - Optional, 'evm' only: the specific EIP-155 chain ID the
+ *   caller is about to sign/broadcast on. When given, only an account the session has
+ *   actually approved for THAT chain (`eip155:<chainId>`) is returned — a session
+ *   connected only to, say, Ethereum mainnet must not be handed back as if it were
+ *   approved for Base just because both are "eip155:*". Mirrors the mainnet-only
+ *   exact-match already done for Solana above; omit chainId to keep the old
+ *   any-EVM-chain behavior for callers that don't yet sign/broadcast with it.
  */
-export async function getWalletConnectAddress(chainType) {
+export async function getWalletConnectAddress(chainType, chainId) {
   try {
     const output = await wcExec('walletconnect', ['whoami', '--json'], 3000);
     const data = JSON.parse(output);
@@ -58,6 +65,10 @@ export async function getWalletConnectAddress(chainType) {
       return solAccount?.address || null;
     }
     if (chainType === 'evm') {
+      if (chainId != null) {
+        const evmAccount = accounts.find(a => a.chain === `eip155:${chainId}`);
+        return evmAccount?.address || null;
+      }
       const evmAccount = accounts.find(a => a.chain?.startsWith('eip155:'));
       return evmAccount?.address || null;
     }


### PR DESCRIPTION
Fixes #614.

## Problem

`getWalletConnectAddress('evm')` matched any connected account whose CAIP-2 chain tag started with `eip155:`, regardless of which specific chain it was approved for. Because EVM addresses are identical across chains, a WalletConnect session connected only to Ethereum mainnet would be silently accepted as valid for a Base (or any other EVM) transaction. Nothing downstream -- including the quote/request-intent binding checks -- could catch this, since they only compare addresses, not chains. The equivalent Solana branch in the same function already did an exact match against Solana mainnet, so this was an inconsistency within the function itself.

## Fix

`getWalletConnectAddress` now accepts an optional `chainId` and, when given, only returns an account the session has actually approved for that exact chain (`eip155:<chainId>`), mirroring the existing Solana exact-match idiom.

Every place that resolves a WalletConnect EVM address before signing or broadcasting a real transaction now passes the target chain ID and fails closed with a clear error instead of proceeding with a wrong-chain session:

- `nansen transfer`'s `sendTokensViaWalletConnect`
- `nansen trade execute`'s quote-building step
- `nansen trade execute`'s pre-execute wallet-match check
- `nansen trade execute`'s immediate pre-signing check (the last line of defense right before a transaction is signed/broadcast)

The last two are deliberately both kept (not collapsed into one check) -- a new regression test confirms this closes the gap where a session could disconnect or switch chains between the pre-execute check and the moment of signing.

## Testing

- `npx eslint .` -- clean
- Full test suite: 2860 passed, 16 skipped (no regressions)
- New regression tests added covering: exact chainId match, a session on a different chain being rejected instead of matched, backward compat when chainId is omitted, `nansen transfer` scoping its lookup to the target chain, and `nansen trade execute` rejecting both a session on the wrong chain up front and one that switches chains mid-execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141eH4NcQy4GXgusCGbG1pm
