### PR TITLE
fix(x402): scope WalletConnect payment signer to the payment's chain

### DIFF
--- a/.changeset/x402-walletconnect-chain-scoped-payment.md
+++ b/.changeset/x402-walletconnect-chain-scoped-payment.md
@@ -1,0 +1,9 @@
+---
+"nansen-cli": patch
+---
+
+Fix x402 auto-payment via WalletConnect signing a payment authorization from any connected EVM account instead of verifying the WalletConnect session is actually approved for the payment's chain.
+
+`handleX402Payment` resolved its signer with its own `checkWalletConnection()` helper and took `wallet.accounts[0]?.address` with no chain filtering at all -- the same defect class fixed in `getWalletConnectAddress` for `nansen transfer`/`nansen trade execute` (see the WalletConnect chain-scoped signing fix), just left unguarded here because this path never reused that helper. Because EVM addresses are identical across chains, a WalletConnect session approved only for, say, Base could be silently used to authorize an x402 payment on BNB Smart Chain or X Layer -- the other two EVM networks Nansen's x402 payments support.
+
+`handleX402Payment` now resolves its signer via `getWalletConnectAddress('evm', chainId)`, scoped to the exact chain of the selected payment requirement, and refuses to pay with a clear error when no WalletConnect session is approved for that chain. The now-unused, duplicate `checkWalletConnection` helper was removed.

--- a/src/__tests__/walletconnect-x402.test.js
+++ b/src/__tests__/walletconnect-x402.test.js
@@ -24,9 +24,13 @@ import { evaluatePaymentRequirement } from '../x402-policy.js';
 import { wcExec } from '../walletconnect-exec.js';
 import { handleX402Payment, buildEIP712TypedData } from '../walletconnect-x402.js';
 
+// Session approved for Base (eip155:8453) only -- the account entry carries
+// the CAIP-2 chain tag getWalletConnectAddress matches on, not just a bare
+// address, so a mock without a `chain` field would mask the exact-chain bug
+// this file used to have (accounts[0] taken with no chain filter at all).
 const CONNECTED_WALLET = {
   connected: true,
-  accounts: [{ address: '0xWalletAddress' }],
+  accounts: [{ chain: 'eip155:8453', address: '0xWalletAddress' }],
 };
 
 const REQUIREMENT = {
@@ -80,6 +84,70 @@ describe('handleX402Payment — policy guard', () => {
 
     const signCalls = wcExec.mock.calls.filter(c => c[1]?.[0] === 'sign-typed-data');
     expect(signCalls).toHaveLength(1);
+  });
+});
+
+describe('handleX402Payment — WalletConnect chain scoping', () => {
+  it('refuses to pay when the connected session is approved for a different EVM chain', async () => {
+    evaluatePaymentRequirement.mockReturnValue({ ok: true, usd: 0.01, symbol: 'USDC' });
+    // Session approved for Ethereum mainnet only; the payment requirement is on Base.
+    wcExec.mockImplementation((_cmd, args) => {
+      if (args[0] === 'whoami') {
+        return Promise.resolve(JSON.stringify({
+          connected: true,
+          accounts: [{ chain: 'eip155:1', address: '0xWalletAddress' }],
+        }));
+      }
+      return Promise.resolve(JSON.stringify({ signature: '0xfakesig' }));
+    });
+
+    await expect(
+      handleX402Payment(PAYMENT_REQUIREMENTS),
+    ).rejects.toThrow(/no WalletConnect session is active for chain eip155:8453/);
+
+    // A wrong-chain session must never reach signing.
+    const signCalls = wcExec.mock.calls.filter(c => c[1]?.[0] === 'sign-typed-data');
+    expect(signCalls).toHaveLength(0);
+  });
+
+  it('refuses to pay when no WalletConnect session is connected at all', async () => {
+    evaluatePaymentRequirement.mockReturnValue({ ok: true, usd: 0.01, symbol: 'USDC' });
+    wcExec.mockImplementation((_cmd, args) => {
+      if (args[0] === 'whoami') {
+        return Promise.resolve(JSON.stringify({ connected: false }));
+      }
+      return Promise.resolve(JSON.stringify({ signature: '0xfakesig' }));
+    });
+
+    await expect(
+      handleX402Payment(PAYMENT_REQUIREMENTS),
+    ).rejects.toThrow(/no WalletConnect session is active for chain eip155:8453/);
+  });
+
+  it('signs from the account matching the target chain, not accounts[0]', async () => {
+    evaluatePaymentRequirement.mockReturnValue({ ok: true, usd: 0.01, symbol: 'USDC' });
+    // Deliberately DIFFERENT addresses per chain entry (a multi-account
+    // wallet, or a proxy quirk) and the Base entry deliberately placed
+    // SECOND, not first -- so this test can only pass if the chain tag,
+    // not array position, decides which address is used. Two entries
+    // sharing one address would let a bug that still reads accounts[0]
+    // slip through unnoticed.
+    wcExec.mockImplementation((_cmd, args) => {
+      if (args[0] === 'whoami') {
+        return Promise.resolve(JSON.stringify({
+          connected: true,
+          accounts: [
+            { chain: 'eip155:1', address: '0xEthOnlyAddress' },
+            { chain: 'eip155:8453', address: '0xBaseAddress' },
+          ],
+        }));
+      }
+      return Promise.resolve(JSON.stringify({ signature: '0xfakesig' }));
+    });
+
+    const result = await handleX402Payment(PAYMENT_REQUIREMENTS);
+    const decoded = JSON.parse(Buffer.from(result, 'base64').toString('utf8'));
+    expect(decoded.payload.authorization.from).toBe('0xBaseAddress');
   });
 });
 

--- a/src/walletconnect-x402.js
+++ b/src/walletconnect-x402.js
@@ -8,22 +8,8 @@
 import crypto from 'crypto';
 import { NansenError, ErrorCode } from './api.js';
 import { wcExec } from './walletconnect-exec.js';
+import { getWalletConnectAddress } from './walletconnect-trading.js';
 import { evaluatePaymentRequirement, resolvePaymentAmount, resolvePayTo } from './x402-policy.js';
-
-/**
- * Check if a WalletConnect wallet session is active.
- * Returns { wallet, accounts, expires } or null.
- */
-export async function checkWalletConnection() {
-  try {
-    const output = await wcExec('walletconnect', ['whoami', '--json'], 3000);
-    const data = JSON.parse(output);
-    if (data.connected === false) return null;
-    return data;
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Select a compatible payment requirement from the accepts array.
@@ -160,28 +146,7 @@ function formatPaymentAmount(requirement) {
  * @throws {NansenError} On failure
  */
 export async function handleX402Payment(paymentRequirements) {
-  // 1. Check wallet connection
-  const wallet = await checkWalletConnection();
-  if (!wallet) {
-    throw new NansenError(
-      'x402 payment required but no wallet connected. ' +
-        'To pay automatically: create a local wallet with `nansen wallet create` (then set NANSEN_WALLET_PASSWORD), ' +
-        'or connect an external wallet via the `walletconnect` CLI (`walletconnect connect`).',
-      ErrorCode.PAYMENT_REQUIRED,
-      402
-    );
-  }
-
-  const fromAddress = wallet.accounts[0]?.address;
-  if (!fromAddress) {
-    throw new NansenError(
-      'x402 payment required but wallet has no accounts.',
-      ErrorCode.PAYMENT_REQUIRED,
-      402
-    );
-  }
-
-  // 2. Select compatible payment requirement
+  // 1. Select compatible payment requirement
   const accepts = paymentRequirements.accepts || paymentRequirements;
   const requirement = selectPaymentRequirement(Array.isArray(accepts) ? accepts : [accepts]);
   if (!requirement) {
@@ -193,10 +158,35 @@ export async function handleX402Payment(paymentRequirements) {
     );
   }
 
-  // 3. Evaluate payment policy before touching any signing material
+  // 2. Evaluate payment policy before touching any signing material
   const decision = evaluatePaymentRequirement(requirement);
   if (!decision.ok) {
     throw new Error(decision.reason);
+  }
+
+  // 3. Resolve the WalletConnect signer scoped to this exact chain. EVM
+  // addresses are identical across chains, so "some account exists in the
+  // session" can't prove the session was actually approved for THIS chain --
+  // only the CAIP-2 chain tag can (mirrors getWalletConnectAddress's chainId
+  // param, used the same way before signing/broadcasting in trading.js and
+  // transfer.js). Without this, a session connected only to, say, Base would
+  // be silently accepted to authorize a payment on BNB Chain or X Layer --
+  // the same defect class fixed in #615, just unguarded here because this
+  // path never reused getWalletConnectAddress and instead took accounts[0]
+  // with no chain filter at all.
+  const chainId = parseChainId(requirement.network);
+  if (chainId === null) {
+    throw new Error(`Refusing to auto-pay: unsupported or missing EVM network ${requirement.network}.`);
+  }
+  const fromAddress = await getWalletConnectAddress('evm', chainId);
+  if (!fromAddress) {
+    throw new NansenError(
+      `x402 payment required but no WalletConnect session is active for chain ${requirement.network}. ` +
+        'To pay automatically: create a local wallet with `nansen wallet create` (then set NANSEN_WALLET_PASSWORD), ' +
+        'or connect an external wallet approved for this chain via the `walletconnect` CLI (`walletconnect connect`).',
+      ErrorCode.PAYMENT_REQUIRED,
+      402
+    );
   }
 
   // 4. Build EIP-712 typed data


### PR DESCRIPTION
Fixes #616.

## Problem

`handleX402Payment` (`src/walletconnect-x402.js`) resolved its WalletConnect signer with its own `checkWalletConnection()` helper and took `wallet.accounts[0]?.address` with no chain filtering at all -- the same defect class fixed in #615 (WalletConnect chain-scoped signing), just in a separate x402 auto-payment code path that PR never touched.

Reachable today: `api.js`'s `NansenAPI.request()` falls back to `handleX402Payment` on a 402 response when the default wallet provider is WalletConnect. x402 payments support three EVM networks (`x402-tokens.js` `EVM_X402_TOKENS`: Base, X Layer, BNB Smart Chain), so a session connected only to Base could be silently accepted to authorize a payment on BNB Smart Chain or X Layer -- EVM addresses are identical across chains, so an address alone can't prove the session was actually approved for the chain being paid on.

## Fix

`handleX402Payment` now resolves its signer via the already-hardened `getWalletConnectAddress('evm', chainId)`, scoped to the exact chain of the selected payment requirement, and refuses to pay with a clear error when no WalletConnect session is approved for that chain. The now-unused, duplicate `checkWalletConnection` helper was removed.

## Testing

- `npx eslint` -- clean

- Full related suite: 290/290 passed (`walletconnect-x402`, `unit`, `api` test files)

- 3 new regression tests: a session approved for a different EVM chain is refused before signing; no session at all is refused; the account matching the target chain is picked over `accounts[0]` when the session holds multiple chains

- Verified by hand that the new tests actually fail against the pre-fix `accounts[0]` logic before confirming they pass against the fix

- An independent adversarial review pass before this push caught that the first draft of the multi-chain test used the same address for both chain entries (unable to prove anything) -- fixed to use distinct addresses per chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0141eH4NcQy4GXgusCGbG1pm
