### PR TITLE
fix(agent): flush leftover SSE buffer after stream ends

### DIFF
--- a/.changeset/fix-sse-trailing-frame.md
+++ b/.changeset/fix-sse-trailing-frame.md
@@ -1,0 +1,5 @@
+---
+"nansen-cli": patch
+---
+
+Fix `consumeSSEStream` silently dropping the final SSE event when the stream closes without a trailing blank line (e.g. a `finish` event carrying `conversation_id`, or a trailing `delta` chunk).

--- a/src/__tests__/agent.test.js
+++ b/src/__tests__/agent.test.js
@@ -598,4 +598,37 @@ describe('consumeSSEStream', () => {
     const result = await consumeSSEStream(response);
     expect(result.text).toBe('ok');
   });
+
+  it('flushes a trailing delta chunk with no terminating blank line', async () => {
+    // Server closes the connection right after the last event, without a
+    // final \n\n. This is a realistic SSE termination pattern (socket
+    // close signals end-of-stream) and must not silently drop data.
+    const response = mockSSEResponse(
+      'data: {"type":"delta","text":"hello"}\n'
+    );
+    const result = await consumeSSEStream(response);
+    expect(result.text).toBe('hello');
+  });
+
+  it('flushes a trailing finish event with no terminating blank line', async () => {
+    const response = mockSSEResponse([
+      'data: {"type":"delta","text":"hi"}\n\n',
+      'data: {"type":"finish","conversation_id":"abc-123"}\n',
+    ]);
+    const result = await consumeSSEStream(response);
+    expect(result.text).toBe('hi');
+    expect(result.conversationId).toBe('abc-123');
+  });
+
+  it('does not flush a leftover buffer after [DONE] has already been seen', async () => {
+    // Guard against the flush accidentally re-processing/duplicating data
+    // when the stream terminates normally via [DONE].
+    const onDelta = vi.fn();
+    const response = mockSSEResponse(
+      'data: {"type":"delta","text":"before"}\n\ndata: [DONE]\n\n'
+    );
+    const result = await consumeSSEStream(response, { onDelta });
+    expect(result.text).toBe('before');
+    expect(onDelta).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/commands/agent.js
+++ b/src/commands/agent.js
@@ -66,11 +66,49 @@ export async function consumeSSEStream(response, callbacks = {}) {
   const toolCalls = [];
   let conversationId = null;
   let errorPayload = null;
+  let done = false;
 
   const reader = response.body;
   const decoder = new TextDecoder();
   let buffer = '';
 
+  const processFrame = (frame) => {
+    for (const line of frame.split('\n')) {
+      if (!line.startsWith('data: ')) continue;
+      const payload = line.slice(6);
+      if (payload === '[DONE]') { done = true; return; }
+
+      let event;
+      try {
+        event = JSON.parse(payload);
+      } catch {
+        continue;
+      }
+
+      switch (event.type) {
+        case 'delta':
+          if (event.text) {
+            chunks.push(event.text);
+            if (onDelta) onDelta(event.text);
+          }
+          break;
+        case 'tool_call':
+          if (event.name) {
+            toolCalls.push(event.name);
+            if (onToolCall) onToolCall(event.name);
+          }
+          break;
+        case 'finish':
+          conversationId = event.conversation_id ?? null;
+          break;
+        case 'error':
+          errorPayload = event;
+          break;
+      }
+    }
+  };
+
+  outer:
   for await (const raw of reader) {
     buffer += decoder.decode(raw, { stream: true });
 
@@ -79,47 +117,19 @@ export async function consumeSSEStream(response, callbacks = {}) {
 
     // SSE: split on double-newline boundaries
     let boundary;
-    let done = false;
     while ((boundary = buffer.indexOf('\n\n')) !== -1) {
       const frame = buffer.slice(0, boundary);
       buffer = buffer.slice(boundary + 2);
-
-      for (const line of frame.split('\n')) {
-        if (!line.startsWith('data: ')) continue;
-        const payload = line.slice(6);
-        if (payload === '[DONE]') { done = true; break; }
-
-        let event;
-        try {
-          event = JSON.parse(payload);
-        } catch {
-          continue;
-        }
-
-        switch (event.type) {
-          case 'delta':
-            if (event.text) {
-              chunks.push(event.text);
-              if (onDelta) onDelta(event.text);
-            }
-            break;
-          case 'tool_call':
-            if (event.name) {
-              toolCalls.push(event.name);
-              if (onToolCall) onToolCall(event.name);
-            }
-            break;
-          case 'finish':
-            conversationId = event.conversation_id ?? null;
-            break;
-          case 'error':
-            errorPayload = event;
-            break;
-        }
-      }
-      if (done) break;
+      processFrame(frame);
+      if (done) break outer;
     }
-    if (done) break;
+  }
+
+  // Flush a trailing unterminated frame (stream closed without \n\n after
+  // the last event, e.g. 'finish' or a final 'delta').
+  if (!done && buffer.trim() !== '') {
+    buffer += decoder.decode(); // flush any pending multi-byte UTF-8 tail
+    processFrame(buffer);
   }
 
   if (errorPayload) {


### PR DESCRIPTION
Fixed a bug in consumeSSEStream where the SSE parser silently dropped the final event if the stream closed without a trailing blank line (e.g. a finish event carrying conversation_id, or a trailing delta chunk)  the CLI would then fall back to a locally generated conversation ID with no error shown. Added a flush step to process any leftover buffer after the stream ends, plus three regression tests covering the dropped-frame cases.